### PR TITLE
[codex] Add EdgeOS skill docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the project hub for the full diagram and decisions.
 
 - `workspace/IDENTITY.md` — what an EdgeClaw agent knows about itself and the village
 - `workspace/` — the full runtime workspace bundle (prompts, soul, heartbeat, community context)
-- `skills/` — directory for backend-specific skill bundles
+- `skills/`: backend-specific skill bundles, including EdgeOS calendar/RSVP/directory docs
 - `onboarding/` — intent-capture flow for new agents (1 to 2 questions during setup)
 - `install/` — bootstrap scripts for plugging EdgeClaw into a runtime
 
@@ -155,8 +155,9 @@ The installer:
 1. Writes `mcp.servers.index` in `~/.openclaw/openclaw.json`, pointed at `https://protocol.index.network/mcp` with your API key in `x-api-key`.
 2. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 3. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds your lived notes from `BOOTSTRAP.md`); pass `--wipe-user` to overwrite it.
-4. Installs three cron jobs: daily digest (`0 8 * * *`), ambient discovery afternoon (`0 14 * * *`), ambient discovery evening (`0 20 * * *`).
-5. Restarts the gateway so all config changes take effect.
+4. Copies backend skill docs into `~/.openclaw/workspace/skills/`.
+5. Installs three cron jobs: daily digest (`0 8 * * *`), ambient discovery afternoon (`0 14 * * *`), ambient discovery evening (`0 20 * * *`).
+6. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring EdgeClaw online:
 
@@ -211,7 +212,7 @@ The remaining ambient/accepted/freshness/memory work stays on the heartbeat tick
 Skills in this repo are public. Each backend gates access with its own per-user credential, wired in by the matching per-backend installer:
 
 - **Index Network (today's wired backend)** — per-user API key returned by `POST /api/networks/:id/signup` (see [Integration API: Authentication](#authentication) above). `install/install_index.ts` writes it into `mcp.servers.index` as the `x-api-key` header.
-- **EdgeOS** — per-user token issued via OTP through the EdgeOS portal. Lands in `install/install_edgeos.ts` once that backend is wired.
+- **EdgeOS:** per-user API key or OTP-issued bearer token rooted in EdgeOS identity. The skill docs in `skills/edgeos/` describe calendar, RSVP, and directory calls. Credential provisioning lands in `install/install_edgeos.ts` once the portal / InstaClaw handoff is finalized.
 - **Geo** — per-user credential, mechanism TBD. Lands in `install/install_geo.ts` once that backend is wired.
 
 The skill files describe HOW to call each backend's APIs; the per-backend credential is what unlocks them.

--- a/install/install.ts
+++ b/install/install.ts
@@ -15,6 +15,9 @@
  *   - Copy the workspace markdown bundle (BOOTSTRAP, AGENTS, SOUL, USER,
  *     IDENTITY, TOOLS, HEARTBEAT, COMMUNITY, prompts/*) into
  *     `~/.openclaw/workspace/`.
+ *   - Copy backend skill docs from `skills/` into
+ *     `~/.openclaw/workspace/skills/` so the agent has API playbooks at
+ *     runtime.
  *   - Call each backend installer in `install_<backend>.ts`.
  *   - Bind any `EdgeClaw — *` cron jobs to the user's Telegram chat once a
  *     session exists, so digest / ambient deliveries route correctly.
@@ -56,7 +59,9 @@ import { installGeo } from "./install_geo";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const SOURCE_WORKSPACE = join(SCRIPT_DIR, "../workspace");
+const SOURCE_SKILLS = join(SCRIPT_DIR, "../skills");
 const TARGET_WORKSPACE = join(homedir(), ".openclaw", "workspace");
+const TARGET_SKILLS = join(TARGET_WORKSPACE, "skills");
 
 function ensureOpenclawAvailable(): void {
   try {
@@ -115,6 +120,33 @@ function copyWorkspaceFiles(wipeUser: boolean): void {
   console.log(`→ staged ${copied} workspace files into ${TARGET_WORKSPACE}`);
   if (preservedUserNotes) {
     console.log("  (USER.md preserved — pass --wipe-user to overwrite it)");
+  }
+}
+
+function copyMarkdownTree(sourceDir: string, targetDir: string): number {
+  if (!existsSync(sourceDir)) return 0;
+  if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
+
+  let copied = 0;
+  for (const entry of readdirSync(sourceDir)) {
+    const sourcePath = join(sourceDir, entry);
+    const targetPath = join(targetDir, entry);
+    const stat = statSync(sourcePath);
+
+    if (stat.isDirectory()) {
+      copied += copyMarkdownTree(sourcePath, targetPath);
+    } else if (entry.endsWith(".md")) {
+      copyFileSync(sourcePath, targetPath);
+      copied++;
+    }
+  }
+  return copied;
+}
+
+function copySkillFiles(): void {
+  const copied = copyMarkdownTree(SOURCE_SKILLS, TARGET_SKILLS);
+  if (copied > 0) {
+    console.log(`→ staged ${copied} skill files into ${TARGET_SKILLS}`);
   }
 }
 
@@ -211,6 +243,7 @@ function main(): void {
 
   disableTelegramTidepooling();
   copyWorkspaceFiles(wipeUser);
+  copySkillFiles();
 
   installIndex();
   installEdgeos();

--- a/install/install_edgeos.ts
+++ b/install/install_edgeos.ts
@@ -1,14 +1,21 @@
 /**
  * EdgeOS backend installer — placeholder.
  *
- * EdgeOS provides calendar + directory APIs. Integration is not yet wired up.
+ * EdgeOS provides calendar, RSVP, venue, and directory APIs. Runtime guidance
+ * lives in `../skills/edgeos/` and is staged into the OpenClaw workspace by
+ * the orchestrator. Credential provisioning is still handled externally by
+ * EdgeOS / InstaClaw, so this installer does not write secrets or API config
+ * yet.
  *
  * Invoked only by the orchestrator (`install.ts`) — not a standalone
  * entrypoint. If your EdgeOS integration needs OpenClaw configuration (MCP
  * server entries, cron jobs, gateway settings), wire it here. Runtime
- * guidance for the agent (tool usage, behavioral notes, prompt content) can
- * be added by editing the markdown files in `../workspace/` — TOOLS.md,
- * HEARTBEAT.md, AGENTS.md, etc. — or adding EdgeOS-specific files there.
+ * Expected runtime env/config, once wired:
+ *
+ *   - EDGEOS_BASE_URL (default https://api.edgeos.world)
+ *   - EDGEOS_POPUP_ID
+ *   - EDGEOS_POPUP_SLUG
+ *   - EDGEOS_API_KEY (per-user EdgeOS key, bearer credential)
  */
 
 export function installEdgeos(): void {

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,13 @@
+# EdgeClaw Skills
+
+This directory contains backend-specific skill files for EdgeClaw agents.
+
+Each backend folder should explain:
+
+- what the backend is responsible for
+- which credential the agent needs
+- which endpoints or tools to use
+- what the agent must confirm with the human before taking action
+- what data is public, private, masked, or source-of-truth
+
+Public skill files are safe to read. The credentials that unlock the backends are not stored here and must be injected by EdgeOS, InstaClaw, or the user's own runtime.

--- a/skills/edgeos/README.md
+++ b/skills/edgeos/README.md
@@ -1,0 +1,16 @@
+# EdgeOS Skill
+
+EdgeOS is the identity spine and the source of truth for attendee status, calendar, venues, RSVP state, and the attendee directory.
+
+Use these files when the user asks about the live event schedule, venue availability, RSVPs, attendee lookup, or their own Edge Esmeralda participation:
+
+- `auth.md`: how the agent is authenticated to EdgeOS
+- `calendar.md`: how to read schedule, tracks, venues, and availability
+- `rsvp.md`: how to register, cancel, check in, and inspect RSVP state
+- `directory.md`: how to search the attendee directory safely
+
+Production API base URL: `https://api.edgeos.world`
+
+Development API base URL: `https://api.dev.edgeos.world`
+
+The live API contract is published at `/openapi.json` on each base URL. Prefer the live OpenAPI contract over stale examples in chat logs or old docs.

--- a/skills/edgeos/auth.md
+++ b/skills/edgeos/auth.md
@@ -1,0 +1,104 @@
+# EdgeOS Auth
+
+EdgeOS credentials are private. Never show them in chat, paste them into logs, put them in URLs, or store them in public files.
+
+## Runtime configuration
+
+The runtime should inject:
+
+- `EDGEOS_BASE_URL`: defaults to `https://api.edgeos.world`.
+- `EDGEOS_POPUP_ID`: the Edge Esmeralda popup UUID for authenticated portal endpoints.
+- `EDGEOS_POPUP_SLUG`: the Edge Esmeralda popup slug for the public calendar endpoint.
+- `EDGEOS_API_KEY`: the per-user EdgeOS API key for this agent, usually with the smallest useful scopes. Expected to be sent as a bearer credential once Tule/SimpleFi confirm the final agent-auth contract.
+
+Optional during the transition:
+
+- `EDGEOS_USER_TOKEN`: a per-user OTP login bearer token. Prefer `EDGEOS_API_KEY` for agent runtime calls once available.
+- `EDGEOS_TENANT_ID`: tenant override for anonymous public-calendar calls made from server-side runtimes with no Origin/Referer header.
+
+## Normal agent auth
+
+For protected EdgeOS endpoints, the expected agent-auth shape is to send the user-scoped EdgeOS credential as a bearer token:
+
+```http
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+This is the intended shape for `eos_live_...` per-user API keys, but it still needs final confirmation from EdgeOS before merge. OTP-issued access tokens are confirmed bearer credentials.
+
+Use the least powerful key that can do the job:
+
+- `events:read` for calendar, venue, tracks, and participant reads.
+- `rsvp:write` for RSVP registration, cancellation, and check-in.
+- `events:write` only when the user explicitly asks the agent to create or edit an event.
+
+Directory access currently does not have a separate scope in the public schema. Use the smallest EdgeOS key that EdgeOS exposes for directory reads.
+
+Do not use the Index Network `x-api-key` pattern for EdgeOS unless EdgeOS explicitly changes the contract. Index keys and EdgeOS keys are separate credentials.
+
+## OTP flow
+
+EdgeOS also supports a human OTP flow:
+
+```http
+POST /api/v1/auth/user/login
+Content-Type: application/json
+
+{ "email": "person@example.com" }
+```
+
+This sends a 6-digit code to the user. Then:
+
+```http
+POST /api/v1/auth/user/authenticate
+Content-Type: application/json
+
+{ "email": "person@example.com", "code": "123456" }
+```
+
+The response is:
+
+```json
+{
+  "access_token": "<bearer token>",
+  "token_type": "bearer"
+}
+```
+
+Use OTP when the user is actively logging in or authorizing a runtime. Do not interrupt normal agent conversations by asking for OTP if a runtime credential is already installed.
+
+## Creating a per-user API key
+
+When the setup flow has a valid user bearer token, it can create a per-user API key:
+
+```http
+POST /api/v1/api-keys
+Authorization: Bearer ${EDGEOS_USER_TOKEN}
+Content-Type: application/json
+
+{
+  "name": "EdgeClaw agent",
+  "scopes": ["events:read", "rsvp:write"]
+}
+```
+
+The response includes the raw `key` exactly once. Store it encrypted, inject it into the agent runtime as `EDGEOS_API_KEY`, and never display it again.
+
+## Path 1 handoff status
+
+For hosted InstaClaw users, the intended flow is:
+
+1. The attendee starts from the EdgeOS portal.
+2. EdgeOS confirms the attendee identity and ticket/application context.
+3. EdgeOS sends InstaClaw a short-lived handoff code or signed token.
+4. InstaClaw verifies it server-side with EdgeOS.
+5. InstaClaw stores the user's EdgeOS credential encrypted and injects it into the agent runtime.
+6. The agent uses the confirmed EdgeOS credential shape for future EdgeOS calls, expected to be `Authorization: Bearer ${EDGEOS_API_KEY}`.
+
+Open item: the exact EdgeOS-to-InstaClaw handoff endpoint is not yet documented in the public OpenAPI. Do not invent it. Until Tule/SimpleFi finalize it, treat this as an integration contract rather than an endpoint the agent can call.
+
+## Failure handling
+
+- `401` means the token is missing, stale, revoked, or not accepted for that endpoint. Ask the runtime/portal to refresh the credential. Do not ask the attendee to paste secrets into chat.
+- `403` means the credential exists but lacks permission or the user does not have access to the popup/resource.
+- `422` means the request shape is wrong. Re-check required path/query/body fields against `/openapi.json`.

--- a/skills/edgeos/calendar.md
+++ b/skills/edgeos/calendar.md
@@ -1,0 +1,173 @@
+# EdgeOS Calendar
+
+Use EdgeOS for live schedule, tracks, venues, room availability, RSVP-aware event views, and event creation.
+
+Default base URL:
+
+```text
+https://api.edgeos.world
+```
+
+Use ISO 8601 datetimes with timezone offsets whenever possible. Edge Esmeralda is in Healdsburg, California, so local event times are Pacific time unless the API response says otherwise.
+
+## Read public calendar
+
+Use this when no user credential is available or the user only needs public schedule information:
+
+```http
+GET /api/v1/events/public/calendar?popup_slug=${EDGEOS_POPUP_SLUG}&start_after=${ISO_DATETIME}&start_before=${ISO_DATETIME}&search=${QUERY}&limit=200
+```
+
+No auth is required. The response is intentionally narrow: public, published events only. It excludes private/unlisted/draft/cancelled events and sensitive fields such as meeting URLs, owner IDs, tenant IDs, and internal content.
+
+If the call is made from a server-side runtime with no `Origin` or `Referer`, include `X-Tenant-Id: ${EDGEOS_TENANT_ID}` when EdgeOS has provided it.
+
+Important response fields:
+
+- `results[].id`
+- `results[].title`
+- `results[].start_time`
+- `results[].end_time`
+- `results[].timezone`
+- `results[].kind`
+- `results[].tags`
+- `results[].host_display_name`
+- `results[].venue_id`
+- `results[].venue_title`
+- `results[].venue_location`
+- `results[].track_id`
+- `results[].track_title`
+- `results[].occurrence_id` for recurring event instances
+- `meta.allowed_tags`
+- `meta.allowed_tracks`
+- `meta.timezone`
+- `meta.popup_id`
+
+## Read authenticated calendar
+
+Use this when the user asks for their RSVPs, private/user-specific schedule state, hidden events, meeting URLs, or details not exposed by the public calendar:
+
+```http
+GET /api/v1/events/portal/events?popup_id=${EDGEOS_POPUP_ID}&start_after=${ISO_DATETIME}&start_before=${ISO_DATETIME}&search=${QUERY}&rsvped_only=false&limit=100
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+Useful filters:
+
+- `event_status=published`
+- `kind=<kind>`
+- `venue_id=<uuid>`
+- `track_ids=<uuid>`
+- `tags=<tag>`
+- `search=<text>`
+- `rsvped_only=true`
+- `include_hidden=false`
+- `skip=<number>`
+- `limit=<1..1000>`
+
+The authenticated response can include `content`, `meeting_url`, `my_rsvp_status`, and other fields that are not available in the public calendar response.
+
+## Event details
+
+Use event detail before acting on a specific event:
+
+```http
+GET /api/v1/events/portal/events/${EVENT_ID}?occurrence_start=${ISO_DATETIME}
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+For recurring events, include `occurrence_start` when the user is referring to a specific instance.
+
+## Tracks
+
+```http
+GET /api/v1/tracks/portal/tracks?popup_id=${EDGEOS_POPUP_ID}&search=${QUERY}&limit=100
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+Use tracks to explain programming themes or filter event recommendations.
+
+## Venues
+
+```http
+GET /api/v1/event-venues/portal/venues?popup_id=${EDGEOS_POPUP_ID}&search=${QUERY}&limit=100
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+Venue fields can include `title`, `description`, `location`, `formatted_address`, `capacity`, `tags`, `booking_mode`, photos, weekly hours, and exceptions.
+
+## Venue availability
+
+Use this before suggesting a room for a workshop, meetup, or session:
+
+```http
+GET /api/v1/event-venues/portal/venues/${VENUE_ID}/availability?start=${ISO_DATETIME}&end=${ISO_DATETIME}
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+The response has:
+
+- `open_ranges[]`: venue open windows
+- `busy[]`: blocked windows, including event conflicts where available
+
+For a direct availability check against a proposed event window:
+
+```http
+POST /api/v1/events/portal/events/check-availability
+Authorization: Bearer ${EDGEOS_API_KEY}
+Content-Type: application/json
+
+{
+  "venue_id": "<uuid>",
+  "start_time": "2026-06-04T16:00:00-07:00",
+  "end_time": "2026-06-04T17:30:00-07:00"
+}
+```
+
+The response includes `available`, `conflicts`, and `reason`.
+
+## Create or edit events
+
+Creating, editing, cancelling, hiding, or otherwise changing events is a write action. Confirm with the user first in the current conversation.
+
+Create:
+
+```http
+POST /api/v1/events/portal/events
+Authorization: Bearer ${EDGEOS_API_KEY}
+Content-Type: application/json
+
+{
+  "popup_id": "${EDGEOS_POPUP_ID}",
+  "title": "Workshop title",
+  "start_time": "2026-06-04T16:00:00-07:00",
+  "end_time": "2026-06-04T17:30:00-07:00",
+  "timezone": "America/Los_Angeles",
+  "venue_id": "<uuid>",
+  "visibility": "public",
+  "status": "draft"
+}
+```
+
+Update:
+
+```http
+PATCH /api/v1/events/portal/events/${EVENT_ID}
+Authorization: Bearer ${EDGEOS_API_KEY}
+Content-Type: application/json
+```
+
+Cancel:
+
+```http
+POST /api/v1/events/portal/events/${EVENT_ID}/cancel
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+## Agent behavior
+
+- For "what's happening now / next / today", query a bounded time window instead of the whole month.
+- For "what should I attend", combine calendar data with the user's stated interests and explain why each pick fits.
+- For "where can I host X", check venues and availability before recommending.
+- If the public calendar lacks enough detail, use the authenticated portal endpoint before saying something is unavailable.
+- Never invent times, locations, hosts, URLs, or RSVP state. If the API does not return it, say that it is not showing in EdgeOS.

--- a/skills/edgeos/directory.md
+++ b/skills/edgeos/directory.md
@@ -1,0 +1,68 @@
+# EdgeOS Directory
+
+Use the EdgeOS directory for attendee lookup and privacy-aware context. Use Index for ambient matching and agent-to-agent discovery when the user is asking "who should I meet" or when the answer needs negotiation between agents.
+
+## Current user's participation
+
+Check whether the authenticated human has participation in the popup:
+
+```http
+GET /api/v1/applications/my/participation/${EDGEOS_POPUP_ID}
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+The response is one of:
+
+- `type: "applicant"`: the user has their own application for this popup.
+- `type: "companion"`: the user is an attendee on someone else's application.
+- `type: "none"`: the user has no participation in this popup.
+
+Use this before treating someone as an attendee, especially during setup or support.
+
+## Search the attendee directory
+
+```http
+GET /api/v1/applications/my/directory/${EDGEOS_POPUP_ID}?q=${QUERY}&skip=0&limit=100
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+The endpoint returns accepted applications with at least one product and respects `info_not_shared` masking.
+
+Fields can include:
+
+- `id`
+- `first_name`
+- `last_name`
+- `email`
+- `telegram`
+- `role`
+- `organization`
+- `residence`
+- `age`
+- `gender`
+- `picture_url`
+- `brings_kids`
+- `participation`
+- `associated_attendees`
+
+Treat every field as permissioned. If EdgeOS masks or omits a field, do not infer or fill it in from memory unless the user directly gave you that information.
+
+## CSV export
+
+The API also exposes a CSV export for the directory:
+
+```http
+GET /api/v1/applications/my/directory/${EDGEOS_POPUP_ID}/csv
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+Agents should avoid CSV export for normal chat. Prefer paginated JSON lookup. Use CSV only when the runtime is doing a controlled batch process with explicit authorization.
+
+## Agent behavior
+
+- For "is X coming?", search the directory and answer only with fields returned by EdgeOS.
+- For "who is working on X?", search the directory when the user wants a literal attendee lookup. Use Index when the user wants ranked matches, proactive discovery, or agent-to-agent coordination.
+- Do not expose private email addresses casually. If `telegram` or another contact field is available, ask before drafting an intro or message.
+- If multiple people match, show a short disambiguation list and ask which one they mean.
+- If the user asks for sensitive attributes, apply privacy judgment even if the field exists. Prefer "I can only use what attendees chose to share."
+- On `401`, treat the credential as stale or missing. On `403`, treat it as an access/permission problem.

--- a/skills/edgeos/rsvp.md
+++ b/skills/edgeos/rsvp.md
@@ -1,0 +1,94 @@
+# EdgeOS RSVP
+
+Use RSVP endpoints only when the user clearly asks to register, cancel, check in, or inspect attendee/RSVP state.
+
+RSVP write actions require the user's explicit confirmation in the current conversation. Do not register, cancel, or check in silently.
+
+## List the user's RSVPs
+
+```http
+GET /api/v1/events/portal/events?popup_id=${EDGEOS_POPUP_ID}&rsvped_only=true&limit=100
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+Use this for questions like:
+
+- "What am I signed up for today?"
+- "Do I have anything at 4pm?"
+- "Show my RSVPs this week."
+
+## Inspect participants for an event
+
+```http
+GET /api/v1/event-participants/portal/participants?event_id=${EVENT_ID}&occurrence_start=${ISO_DATETIME}&limit=100
+Authorization: Bearer ${EDGEOS_API_KEY}
+```
+
+For recurring events, include `occurrence_start` when the user means a specific occurrence.
+
+## Register for an event
+
+Before registering:
+
+1. Fetch the event details.
+2. If it is recurring, identify the exact occurrence.
+3. Confirm title, time, venue, and any capacity/approval caveat with the user.
+
+Then:
+
+```http
+POST /api/v1/event-participants/portal/register/${EVENT_ID}
+Authorization: Bearer ${EDGEOS_API_KEY}
+Content-Type: application/json
+
+{
+  "role": "attendee",
+  "message": "Optional note from the user",
+  "occurrence_start": "2026-06-04T16:00:00-07:00"
+}
+```
+
+Omit `occurrence_start` only for non-recurring events or when the API event detail indicates it is not needed.
+
+## Cancel an RSVP
+
+Before cancelling:
+
+1. Fetch the user's RSVP state.
+2. Confirm title, time, and occurrence with the user.
+
+Then:
+
+```http
+POST /api/v1/event-participants/portal/cancel-registration/${EVENT_ID}
+Authorization: Bearer ${EDGEOS_API_KEY}
+Content-Type: application/json
+
+{
+  "occurrence_start": "2026-06-04T16:00:00-07:00"
+}
+```
+
+The cancel body reuses the RSVP body shape. `role` and `message` are ignored on cancel.
+
+## Check in
+
+Checking in is also a write action. Confirm first.
+
+```http
+POST /api/v1/event-participants/portal/check-in/${EVENT_ID}
+Authorization: Bearer ${EDGEOS_API_KEY}
+Content-Type: application/json
+
+{
+  "occurrence_start": "2026-06-04T16:00:00-07:00"
+}
+```
+
+## Agent behavior
+
+- Never RSVP the user to an event without a fresh confirmation.
+- For recurring events, do not assume "register" means every occurrence. Ask which date/time if unclear.
+- If the API returns approval-pending, capacity, or waitlist-like state, report it plainly instead of saying the RSVP is complete.
+- If the RSVP endpoint fails with `401`, ask the runtime/portal to refresh the EdgeOS credential. Do not ask the user to paste a key into chat.
+- If it fails with `403`, explain that the user may not have access to that event or popup.

--- a/workspace/TOOLS.md
+++ b/workspace/TOOLS.md
@@ -48,6 +48,10 @@ Never expose internal IDs unless the ID is actionable (e.g. a `conversationId` t
 ## Local files
 
 - `COMMUNITY.md` — Edge Esmeralda context (dates, attendee count, programming format, design principles). Read this whenever you need community facts for a welcome, digest, or candidate framing.
+- `skills/edgeos/auth.md` — EdgeOS credential shape, OTP flow, API key creation, and hosted-agent handoff status. Read this before calling protected EdgeOS endpoints.
+- `skills/edgeos/calendar.md` — EdgeOS calendar, track, venue, room availability, and event creation playbook. Read this for schedule and venue questions.
+- `skills/edgeos/rsvp.md` — EdgeOS RSVP, participant, cancellation, and check-in playbook. Read this before RSVP write actions.
+- `skills/edgeos/directory.md` — EdgeOS attendee directory and participation-status playbook. Read this for attendee lookup questions.
 - `memory/heartbeat-state.json` — last-run timestamps for heartbeat tasks (so intervals survive restarts) and dedup hashes (e.g. `lastAmbientHash`).
 - `memory/welcome-state.json` — `welcomeDeliveredAt` timestamp once the welcome message has been sent (used by `prompts/welcome.md` for dedup).
 - `memory/YYYY-MM-DD.md` — daily memory log.


### PR DESCRIPTION
## Summary

Adds the first concrete EdgeOS skill bundle for agents, based on the live EdgeOS OpenAPI and the current Agent Village integration plan.

This PR adds:

- `skills/edgeos/auth.md` for base URLs, runtime env vars, per-user bearer credentials, OTP login, API key creation, and the current Path 1 handoff contract
- `skills/edgeos/calendar.md` for public calendar, authenticated portal calendar, tracks, venues, availability, and event write rules
- `skills/edgeos/rsvp.md` for RSVP listing, registration, cancellation, check-in, and confirmation rules
- `skills/edgeos/directory.md` for attendee directory lookup, participation status, CSV caution, and privacy behavior
- installer support to stage top-level `skills/` docs into `~/.openclaw/workspace/skills/` so the agent has the API playbooks at runtime

## Auth assumptions to review

The docs treat per-user EdgeOS API keys as the normal agent credential and send them as:

```http
Authorization: Bearer ${EDGEOS_API_KEY}
```

The docs also preserve OTP as the human/session authorization flow and explicitly mark the EdgeOS-to-InstaClaw hosted-agent handoff as not yet finalized in the public OpenAPI.

Please review these specific assumptions before merge:

- confirm that `eos_live_...` per-user API keys should be used as bearer credentials for agent calls
- confirm the minimum scopes for calendar reads, RSVP writes, event writes, and directory reads
- provide the final `EDGEOS_POPUP_ID`, `EDGEOS_POPUP_SLUG`, and optional `EDGEOS_TENANT_ID` values when ready
- finalize the Path 1 handoff endpoint or signing contract between EdgeOS and InstaClaw

## Validation

- `bun build install/install.ts --target=bun`
- `bun build install/reset.ts --target=bun`
- `git diff --check`
- `npm pack --dry-run`
- scanned for stale SimpleFi prototype endpoints, leaked token prefixes, and BotFather misinformation
