### PR TITLE
fix: add skills field for Claude Code discovery + OpenClaw MCP docs

### DIFF
--- a/skills/.claude-plugin/marketplace.json
+++ b/skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "edgeclaw",
       "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "edgeclaw",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "skills": "./",
   "author": {
     "name": "Edge City",
     "url": "https://edgecity.live"

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,26 +17,19 @@ The skills cross-reference each other. `edge-esmeralda` supplies the popup id th
 ### Claude Code
 
 ```bash
-claude plugin install edgeclaw
-```
-
-Or from GitHub directly:
-
-```bash
-claude plugin install --from github Edge-City/edgeclaw-skills
-```
-
-### Codex
-
-```bash
-codex plugin install Edge-City/edgeclaw-skills
+claude plugin marketplace add Edge-City/edgeclaw-skills
+claude plugin install edgeclaw@edgeclaw-skills
 ```
 
 ### OpenClaw
 
 ```bash
-openclaw plugins install Edge-City/edgeclaw-skills
+openclaw plugins install edgeclaw --marketplace Edge-City/edgeclaw-skills
 ```
+
+### Codex
+
+Not yet supported. Codex requires plugins in a `plugins/<name>/` subdirectory layout, which this repo doesn't use.
 
 For the batteries-included OpenClaw experience (workspace, installer, cron jobs, onboarding), use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package instead.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,7 +37,14 @@ For the batteries-included OpenClaw experience (workspace, installer, cron jobs,
 
 ### Index Network
 
-The `index-network` skill requires an Index Network MCP server connection. On Claude Code and Codex, the plugin manifest declares the MCP endpoint automatically. On OpenClaw, use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package — its installer registers `mcp.servers.index` for you. You need an API key — obtain one at [edgecity.live/agentvillage](https://edgecity.live/agentvillage) or from your community admin.
+The `index-network` skill requires an Index Network MCP server connection. On Claude Code, the plugin manifest declares the MCP endpoint automatically and prompts for the API key on install. On OpenClaw, register the MCP server manually after installing the plugin:
+
+```bash
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"YOUR_API_KEY"}}'
+openclaw gateway restart
+```
+
+Obtain your API key at [edgecity.live/agentvillage](https://edgecity.live/agentvillage) or from your community admin.
 
 ### EdgeOS
 


### PR DESCRIPTION
## Summary
- Add `"skills": "./"` to `.claude-plugin/plugin.json` so Claude Code discovers the three SKILL.md files (previously showed "no skills or agents")
- Add manual MCP server setup instructions for OpenClaw users in README
- Bump plugin version to 1.0.1

## Test plan
- [ ] `claude plugin install edgeclaw@edgeclaw-skills` → verify skills appear in plugin details
- [ ] `openclaw plugins install edgeclaw --marketplace Edge-City/edgeclaw-skills` → verify skills load
- [ ] `openclaw plugins inspect edgeclaw` → confirm skills capability listed