### PR TITLE
chore: align all manifest versions to 1.0.1

### DIFF
--- a/skills/.claude-plugin/marketplace.json
+++ b/skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "edgeclaw",
       "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "edgeclaw",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "skills": "./",
   "author": {
     "name": "Edge City",
     "url": "https://edgecity.live"

--- a/skills/.codex-plugin/plugin.json
+++ b/skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "edgeclaw",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
   "author": {
     "name": "Edge City",

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,26 +17,19 @@ The skills cross-reference each other. `edge-esmeralda` supplies the popup id th
 ### Claude Code
 
 ```bash
-claude plugin install edgeclaw
-```
-
-Or from GitHub directly:
-
-```bash
-claude plugin install --from github Edge-City/edgeclaw-skills
-```
-
-### Codex
-
-```bash
-codex plugin install Edge-City/edgeclaw-skills
+claude plugin marketplace add Edge-City/edgeclaw-skills
+claude plugin install edgeclaw@edgeclaw-skills
 ```
 
 ### OpenClaw
 
 ```bash
-openclaw plugins install Edge-City/edgeclaw-skills
+openclaw plugins install edgeclaw --marketplace Edge-City/edgeclaw-skills
 ```
+
+### Codex
+
+Not yet supported. Codex requires plugins in a `plugins/<name>/` subdirectory layout, which this repo doesn't use.
 
 For the batteries-included OpenClaw experience (workspace, installer, cron jobs, onboarding), use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package instead.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,7 +37,14 @@ For the batteries-included OpenClaw experience (workspace, installer, cron jobs,
 
 ### Index Network
 
-The `index-network` skill requires an Index Network MCP server connection. On Claude Code and Codex, the plugin manifest declares the MCP endpoint automatically. On OpenClaw, use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package — its installer registers `mcp.servers.index` for you. You need an API key — obtain one at [edgecity.live/agentvillage](https://edgecity.live/agentvillage) or from your community admin.
+The `index-network` skill requires an Index Network MCP server connection. On Claude Code, the plugin manifest declares the MCP endpoint automatically and prompts for the API key on install. On OpenClaw, register the MCP server manually after installing the plugin:
+
+```bash
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"YOUR_API_KEY"}}'
+openclaw gateway restart
+```
+
+Obtain your API key at [edgecity.live/agentvillage](https://edgecity.live/agentvillage) or from your community admin.
 
 ### EdgeOS
 

--- a/skills/marketplace.json
+++ b/skills/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "edgeclaw-skills",
+  "interface": {
+    "displayName": "EdgeClaw Skills"
+  },
+  "plugins": [
+    {
+      "name": "edgeclaw",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "edgeclaw-skills",
   "name": "EdgeClaw Skills",
   "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "skills": ["."],
   "configSchema": {
     "type": "object",


### PR DESCRIPTION
## Summary
- Bump `openclaw.plugin.json` and `.codex-plugin/plugin.json` versions to 1.0.1 to match Claude Code manifests