### PR TITLE
fix: use userConfig in Claude Code plugin manifest

### DIFF
--- a/skills/.claude-plugin/marketplace.json
+++ b/skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "edgeclaw",
       "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,24 +1,26 @@
 {
   "name": "edgeclaw",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "skills": "./",
   "author": {
     "name": "Edge City",
     "url": "https://edgecity.live"
   },
+  "userConfig": {
+    "apiKey": {
+      "type": "string",
+      "title": "Index Network API Key",
+      "description": "API key for Index Network. Obtain one at edgecity.live/agentvillage or from your community admin.",
+      "sensitive": true
+    }
+  },
   "mcpServers": {
     "index": {
       "type": "http",
-      "url": "https://protocol.index.network/mcp"
-    }
-  },
-  "configSchema": {
-    "type": "object",
-    "properties": {
-      "apiKey": {
-        "type": "string",
-        "description": "Index Network API key. Obtain one at edgecity.live/agentvillage or from your community admin."
+      "url": "https://protocol.index.network/mcp",
+      "headers": {
+        "x-api-key": "${user_config.apiKey}"
       }
     }
   }

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "edgeclaw-skills",
   "name": "EdgeClaw Skills",
   "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "skills": ["."],
   "configSchema": {
     "type": "object",


### PR DESCRIPTION
## Summary

- Fix `configSchema` → `userConfig` in `.claude-plugin/plugin.json` — Claude Code expects `userConfig` for user-configurable options; the old field name silently prevented API key injection into MCP server headers
- Add `sensitive: true` and `title` to API key config so it's stored in the system keychain
- Add `headers` block with `${user_config.apiKey}` substitution to the MCP server entry
- Bump version 1.0.1 → 1.0.2 across `plugin.json`, `marketplace.json`, and `openclaw.plugin.json`

## Test plan

- [x] `claude plugin install edgeclaw@edgeclaw-skills --config "apiKey=..."` — API key accepted, no "userConfig not set" warning
- [x] MCP tool calls (e.g. `read_intents`) return data — confirms header injection works end-to-end
- [x] OpenClaw plugin path (`openclaw.plugin.json` with `configSchema`) still works — only the Claude Code manifest was changed