### PR TITLE
Sync from Index Network monorepo — 2026-05-23

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,31 @@ Every call with the same email returns the same user but a **fresh API key** —
 1. Runs the EdgeClaw installer with the returned `apiKey`: `bun install/install.ts --index-api-key <apiKey>` (or equivalent in the hosted runtime). If InstaClaw has also fetched an EdgeOS personal access token for the attendee, it passes that on the same line: `bun install/install.ts --index-api-key <apiKey> --edgeos-api-key <eos_live_…> --edgeos-bearer-token <jwt>`.
 2. In a follow-up step, captures the attendee's Telegram handle and binds it to their agent transport — this is entirely InstaClaw-owned and happens outside this endpoint.
 
-### What EdgeOS does after signup
+### What EdgeOS does after signup (BYOA flow)
 
-Displays the returned `mcpServer` object to the attendee as a copyable config snippet. The attendee pastes it into their agent's MCP servers config (or runs `bun install/install.ts --index-api-key <apiKey>` from a clone of this repo).
+Displays per-host install commands with the attendee's credentials pre-filled. The attendee copies and runs them in their terminal. EdgeOS also completes the email-OTP flow to obtain `EDGEOS_BEARER_TOKEN` and `EDGEOS_API_KEY`, which are included in the install commands.
+
+**Claude Code:**
+```bash
+export INDEX_API_KEY=<apiKey>
+export EDGEOS_BEARER_TOKEN=<jwt>
+export EDGEOS_API_KEY=<eos_live_…>
+claude plugin marketplace add Edge-City/edgeclaw-skills
+claude plugin install edgeclaw@edgeclaw-skills
+```
+
+**OpenClaw:**
+```bash
+openclaw plugins install edgeclaw --marketplace Edge-City/edgeclaw-skills
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<apiKey>"}}'
+openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<jwt>'
+openclaw config set env.vars.EDGEOS_API_KEY '<eos_live_…>'
+openclaw gateway restart
+```
+
+**Claude Desktop / other MCP clients:** displays the `mcpServer` JSON with the API key baked in.
+
+See `skills/README.md` for the full per-host reference.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ openclaw config set env.vars.EDGEOS_API_KEY '<eos_live_…>'
 openclaw gateway restart
 ```
 
+**Hermes:**
+```bash
+hermes skills install Edge-City/edgeclaw/skills/edge-esmeralda --force
+hermes skills install Edge-City/edgeclaw/skills/edgeos --force
+hermes skills install Edge-City/edgeclaw/skills/index-network --force
+hermes config set mcp_servers.index.url 'https://protocol.index.network/mcp'
+hermes config set mcp_servers.index.headers.x-api-key '<apiKey>'
+hermes config set EDGEOS_BEARER_TOKEN '<jwt>'
+hermes config set EDGEOS_API_KEY '<eos_live_…>'
+```
+
 **Claude Desktop / other MCP clients:** displays the `mcpServer` JSON with the API key baked in.
 
 See `skills/README.md` for the full per-host reference.

--- a/skills/.claude-plugin/marketplace.json
+++ b/skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "edgeclaw",
       "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,26 +1,18 @@
 {
   "name": "edgeclaw",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "skills": "./",
   "author": {
     "name": "Edge City",
     "url": "https://edgecity.live"
-  },
-  "userConfig": {
-    "apiKey": {
-      "type": "string",
-      "title": "Index Network API Key",
-      "description": "API key for Index Network. Obtain one at edgecity.live/agentvillage or from your community admin.",
-      "sensitive": true
-    }
   },
   "mcpServers": {
     "index": {
       "type": "http",
       "url": "https://protocol.index.network/mcp",
       "headers": {
-        "x-api-key": "${user_config.apiKey}"
+        "x-api-key": "${INDEX_API_KEY}"
       }
     }
   }

--- a/skills/.codex-plugin/plugin.json
+++ b/skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "edgeclaw",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
   "author": {
     "name": "Edge City",

--- a/skills/README.md
+++ b/skills/README.md
@@ -14,46 +14,83 @@ The skills cross-reference each other. `edge-esmeralda` supplies the popup id th
 
 ## Install
 
+### Environment variables
+
+All hosts read credentials from environment variables. Set these before installing or add them to your shell profile (`~/.zshrc`, `~/.bashrc`) to persist across sessions:
+
+| Variable | Source | Required |
+|---|---|---|
+| `INDEX_API_KEY` | Index Network signup (BYOA page or [edgecity.live/agentvillage](https://edgecity.live/agentvillage)) | Yes |
+| `EDGEOS_BEARER_TOKEN` | EdgeOS email-OTP onboarding flow | Optional |
+| `EDGEOS_API_KEY` | EdgeOS email-OTP onboarding flow (`eos_live_...` key) | Optional |
+
+`INDEX_API_KEY` is required for the Index Network MCP server. The EdgeOS tokens are optional — without them the agent still loads; EdgeOS recipes will prompt for the missing token on first use.
+
+### BYOA flow
+
+If you authenticated through the EdgeOS portal (edgecity.live/agentvillage), the page provides your credentials and per-host install commands with the keys pre-filled. Copy and run them in your terminal.
+
 ### Claude Code
 
 ```bash
+export INDEX_API_KEY=<YOUR_API_KEY>
+export EDGEOS_BEARER_TOKEN=<YOUR_TOKEN>
+export EDGEOS_API_KEY=<YOUR_KEY>
 claude plugin marketplace add Edge-City/edgeclaw-skills
 claude plugin install edgeclaw@edgeclaw-skills
 ```
+
+The plugin manifest declares the Index Network MCP endpoint and resolves `INDEX_API_KEY` from the environment at runtime. No interactive prompt.
 
 ### OpenClaw
 
 ```bash
 openclaw plugins install edgeclaw --marketplace Edge-City/edgeclaw-skills
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<YOUR_API_KEY>"}}'
+openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<YOUR_TOKEN>'
+openclaw config set env.vars.EDGEOS_API_KEY '<YOUR_KEY>'
+openclaw gateway restart
 ```
+
+OpenClaw persists credentials in `~/.openclaw/openclaw.json` — no shell profile changes needed.
+
+### Claude Desktop
+
+Add the MCP server to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "index": {
+      "url": "https://protocol.index.network/mcp",
+      "headers": {
+        "x-api-key": "<YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+Claude Desktop provides MCP tools only (no skills).
 
 ### Codex
 
 Not yet supported. Codex requires plugins in a `plugins/<name>/` subdirectory layout, which this repo doesn't use.
 
-For the batteries-included OpenClaw experience (workspace, installer, cron jobs, onboarding), use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package instead.
+### Other MCP-compatible agents
 
-## API keys
+Configure an HTTP MCP server with the following settings:
 
-### Index Network
-
-The `index-network` skill requires an Index Network MCP server connection. On Claude Code, the plugin manifest declares the MCP endpoint automatically and prompts for the API key on install. On OpenClaw, register the MCP server manually after installing the plugin:
-
-```bash
-openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"YOUR_API_KEY"}}'
-openclaw gateway restart
+```json
+{
+  "url": "https://protocol.index.network/mcp",
+  "headers": { "x-api-key": "<YOUR_API_KEY>" }
+}
 ```
 
-Obtain your API key at [edgecity.live/agentvillage](https://edgecity.live/agentvillage) or from your community admin.
+Set `EDGEOS_BEARER_TOKEN` and `EDGEOS_API_KEY` in your agent's environment if it supports EdgeOS recipes.
 
-### EdgeOS
-
-The `edgeos` skill requires two environment variables:
-
-- `EDGEOS_BEARER_TOKEN` — human session JWT, obtained via the EdgeOS email-OTP onboarding flow.
-- `EDGEOS_API_KEY` — long-lived `eos_live_...` automation key, obtained via the same flow.
-
-Both are optional. Without them the agent still loads; EdgeOS recipes will prompt for the missing token on first use. See the `edge-esmeralda` skill's section 2 for the full onboarding flow.
+For the batteries-included OpenClaw experience (workspace, installer, cron jobs, onboarding), use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package instead.
 
 ## Contributing
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # EdgeClaw Skills
 
-Agent skills for **Edge Esmeralda 2026** (May 30 – Jun 27, Healdsburg, CA). Installable as a standalone plugin on Claude Code, Codex, and OpenClaw.
+Agent skills for **Edge Esmeralda 2026** (May 30 – Jun 27, Healdsburg, CA). Installable as a standalone plugin on Claude Code, Hermes, OpenClaw, and other MCP-compatible agents.
 
 ## What you get
 
@@ -53,6 +53,20 @@ openclaw gateway restart
 ```
 
 OpenClaw persists credentials in `~/.openclaw/openclaw.json` — no shell profile changes needed.
+
+### Hermes
+
+```bash
+hermes skills install Edge-City/edgeclaw/skills/edge-esmeralda --force
+hermes skills install Edge-City/edgeclaw/skills/edgeos --force
+hermes skills install Edge-City/edgeclaw/skills/index-network --force
+hermes config set mcp_servers.index.url 'https://protocol.index.network/mcp'
+hermes config set mcp_servers.index.headers.x-api-key '<YOUR_API_KEY>'
+hermes config set EDGEOS_BEARER_TOKEN '<YOUR_TOKEN>'
+hermes config set EDGEOS_API_KEY '<YOUR_KEY>'
+```
+
+`hermes config set` routes UPPERCASE keys to `~/.hermes/.env` and dot-notation keys to `~/.hermes/config.yaml`. The `--force` flag is required because the security scanner flags community-sourced skills.
 
 ### Claude Desktop
 

--- a/skills/edgeos/SKILL.md
+++ b/skills/edgeos/SKILL.md
@@ -4,6 +4,15 @@ description: Talk to the EdgeOS popup-village platform — read the event schedu
 version: 1.1.0
 author: Edge City
 tags: [edgeos, events, directory, popup-village]
+required_environment_variables:
+  - name: EDGEOS_BEARER_TOKEN
+    prompt: EdgeOS bearer token (JWT from email-OTP flow)
+    help: Obtain from the EdgeOS onboarding flow at edgecity.live/agentvillage
+    required_for: directory, own profile, OpenAPI spec
+  - name: EDGEOS_API_KEY
+    prompt: EdgeOS API key (eos_live_...)
+    help: Obtain from the EdgeOS onboarding flow at edgecity.live/agentvillage
+    required_for: events, RSVPs, venues
 metadata:
   openclaw:
     requires:

--- a/skills/marketplace.json
+++ b/skills/marketplace.json
@@ -12,7 +12,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
+        "authentication": "ENVIRONMENT"
       },
       "category": "Productivity"
     }

--- a/skills/mcp.json
+++ b/skills/mcp.json
@@ -1,6 +1,9 @@
 {
   "index": {
     "type": "http",
-    "url": "https://protocol.index.network/mcp"
+    "url": "https://protocol.index.network/mcp",
+    "headers": {
+      "x-api-key": "${INDEX_API_KEY}"
+    }
   }
 }

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -2,17 +2,6 @@
   "id": "edgeclaw-skills",
   "name": "EdgeClaw Skills",
   "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-  "version": "1.0.2",
-  "skills": ["."],
-  "configSchema": {
-    "type": "object",
-    "properties": {
-      "apiKey": {
-        "type": "string",
-        "description": "Index Network API key for MCP authentication."
-      }
-    },
-    "required": [],
-    "additionalProperties": false
-  }
+  "version": "1.1.0",
+  "skills": ["."]
 }


### PR DESCRIPTION
## Changelog

### New Features
- **Hermes agent BYOA**: add Hermes agent support to the bring-your-own-agent install flow
- **Plugin auth**: switch from interactive `userConfig` prompt to `INDEX_API_KEY` environment variable for simpler setup

### Install instructions

```bash
export INDEX_API_KEY=ix_...
export EDGEOS_BEARER_TOKEN=eyJ...
export EDGEOS_API_KEY=eos_live_...
claude plugin marketplace add Edge-City/edgeclaw-skills
claude plugin install edgeclaw@edgeclaw-skills
```