### PR TITLE
EdgeClaw v1.2.0 — persistent userConfig for all API keys

### DIFF
--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,18 +1,26 @@
 {
   "name": "edgeclaw",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "skills": "./",
   "author": {
     "name": "Edge City",
     "url": "https://edgecity.live"
+  },
+  "userConfig": {
+    "apiKey": {
+      "type": "string",
+      "title": "Index Network API Key",
+      "description": "API key for Index Network. Obtain one at edgecity.live/agentvillage or from your community admin.",
+      "sensitive": true
+    }
   },
   "mcpServers": {
     "index": {
       "type": "http",
       "url": "https://protocol.index.network/mcp",
       "headers": {
-        "x-api-key": "${INDEX_API_KEY}"
+        "x-api-key": "${user_config.apiKey}"
       }
     }
   }

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -8,10 +8,22 @@
     "url": "https://edgecity.live"
   },
   "userConfig": {
-    "apiKey": {
+    "indexApiKey": {
       "type": "string",
       "title": "Index Network API Key",
       "description": "API key for Index Network. Obtain one at edgecity.live/agentvillage or from your community admin.",
+      "sensitive": true
+    },
+    "edgeosToken": {
+      "type": "string",
+      "title": "EdgeOS Bearer Token",
+      "description": "Human session JWT for EdgeOS directory and profile access.",
+      "sensitive": true
+    },
+    "edgeosApiKey": {
+      "type": "string",
+      "title": "EdgeOS API Key",
+      "description": "Long-lived eos_live_... key for EdgeOS events and RSVPs.",
       "sensitive": true
     }
   },
@@ -20,7 +32,7 @@
       "type": "http",
       "url": "https://protocol.index.network/mcp",
       "headers": {
-        "x-api-key": "${user_config.apiKey}"
+        "x-api-key": "${user_config.indexApiKey}"
       }
     }
   }

--- a/skills/.codex-plugin/plugin.json
+++ b/skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "edgeclaw",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
   "author": {
     "name": "Edge City",

--- a/skills/marketplace.json
+++ b/skills/marketplace.json
@@ -12,7 +12,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ENVIRONMENT"
+        "authentication": "USER_CONFIG"
       },
       "category": "Productivity"
     }

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -2,6 +2,6 @@
   "id": "edgeclaw-skills",
   "name": "EdgeClaw Skills",
   "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "skills": ["."]
 }


### PR DESCRIPTION
## Changelog

- **Persistent API keys**: all three keys (`indexApiKey`, `edgeosToken`, `edgeosApiKey`) are now stored via `userConfig` in the Claude Code plugin manifest. Install with `--config` flags — no ephemeral `export` needed.
- **Hermes agent BYOA**: add Hermes agent support to the bring-your-own-agent install flow.
- **Version bump**: 1.1.0 → 1.2.0 across all plugin manifests.

### Claude Code install

```
claude plugin marketplace add Edge-City/edgeclaw-skills
claude plugin install edgeclaw@edgeclaw-skills --config indexApiKey=ix_... --config edgeosToken=eyJ... --config edgeosApiKey=eos_live_...
```