### PR TITLE
Per-person opportunity grouping in digest and ambient surfaces

### DIFF
--- a/skills/index-network/exemplars.md
+++ b/skills/index-network/exemplars.md
@@ -19,6 +19,18 @@ Canonical user-facing renderings for Edge Esmeralda's Index Network flows. Mimic
 > - [Kai]({profileUrl}) — Needs people deep in decentralized discovery — agent tooling, knowledge graphs, semantic search. Bring one to his 3pm open conversation, make intro
 > - [Celia]({profileUrl}) — Designing governance tooling for popup communities. Coordination, consent, collective decision-making. Point her at the right people, make intro
 
+### Grouped: same person, multiple connections
+
+When `list_opportunities` returns multiple opportunities for the same person (grouped entry), render as a single bullet with multiple conversation entry points:
+
+> 🌞 Good morning from Edge Esmeralda
+>
+> It's Tuesday, May 26. Here's what's worth your attention right now.
+>
+> **2 conversations await you**
+> - [Ashish]({profileUrl}) — An experienced technologist spanning [generative software]({acceptUrl1}), [AI infrastructure]({acceptUrl2}), [creative AI design]({acceptUrl3}), and [deep learning research]({acceptUrl4}). Several angles worth exploring.
+> - [Priya]({profileUrl}) — Building community-owned data infrastructure. Aligned on the ownership layer and complementary on discovery, could be interesting to [explore overlaps]({acceptUrl})
+
 ## Ambient update (fires twice daily at 14:00 and 20:00 host-local)
 
 Two sections are possible: direct (the user is a party — link the name to `profileUrl`, embed `acceptUrl` + `&msg=` greeting) and introducer (the user is the introducer — render community intents, still link the name to `profileUrl`, but no `acceptUrl` and no `&msg=`). Skip a section that has no qualifying candidates. Per-pass cap: max 3 direct + 3 introducer.
@@ -34,6 +46,11 @@ Two sections are possible: direct (the user is a party — link the name to `pro
 > - [Kai]({profileUrl}) — Needs people deep in decentralized discovery — agent tooling, knowledge graphs, semantic search. Bring one to his 3pm, make intro
 >
 > There are 5 more conversations waiting for you, let me know if you want to see them.
+
+### Grouped: same person, multiple connections (ambient)
+
+> **New conversations worth starting**
+> - [Ashish]({profileUrl}) — An experienced technologist whose work spans [generative software]({acceptUrl1}), [AI infrastructure]({acceptUrl2}), and [deep learning research]({acceptUrl3}). Multiple overlapping connections with your interests.
 
 ## Greeting drafts (the `&msg=` payload appended to Telegram links)
 

--- a/skills/index-network/prompts/ambient.md
+++ b/skills/index-network/prompts/ambient.md
@@ -16,7 +16,7 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 5. **Sort the filtered set's opportunity IDs lexicographically, then hash that sorted list** (the result of step 4, not the raw `list_opportunities` return). Sorting is required — without it, the same set of IDs returned in a different order would produce a different hash and bypass this early-exit. Compare against `lastAmbientHash` from step 2. If the hash matches, jump to step 11 (write state, with `lastAmbientHash` unchanged) and end your turn — no new signal since the previous pass.
 
 6. **Per-dispatch cap (the routing rule):**
-   - At most **3 direct opportunities** — `feedCategory: "connection"`. The receiver is a party of the opportunity. The opportunity may or may not have an introducer; the only constraint is that the receiver is NOT the introducer. These are people the user might want to reach out to directly.
+   - At most **3 direct opportunities** (counted per person, not per sub-entry — a grouped entry with multiple connections still counts as one) — `feedCategory: "connection"`. The receiver is a party of the opportunity. The opportunity may or may not have an introducer; the only constraint is that the receiver is NOT the introducer. These are people the user might want to reach out to directly.
    - At most **3 introducer opportunities** — `feedCategory: "connector-flow"`. The receiver IS the introducer between other parties. These are NOT surfaced as "people to message" — they are surfaced as **community intents the user might know someone for**.
    - If more than 3 of either type qualify, surface the highest-signal ones and let the rest fall to the morning digest.
 
@@ -32,7 +32,7 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 
    For each direct (`connection`):
    - Link the person's name to `profileUrl`.
-   - Embed `acceptUrl` verbatim on a short verb phrase like "message {Name}". The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks.
+   - Embed `acceptUrl` verbatim on a short verb phrase like "message {Name}". For grouped entries (same person, multiple connections), embed each sub-entry's `acceptUrl` on a distinct topic phrase instead — see grouped example below. The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks.
    - When the same person appears with multiple connections (grouped entry from the tool), link their name to `profileUrl` once, then embed each sub-entry's `acceptUrl` on a distinct topic phrase. Example: "[Ashish](profileUrl) — spanning [generative software](acceptUrl1), [AI infrastructure](acceptUrl2), and [deep learning](acceptUrl3) — several angles worth exploring."
 
    **Section B — introducer candidates** (only if any introducer candidates qualified)

--- a/skills/index-network/prompts/ambient.md
+++ b/skills/index-network/prompts/ambient.md
@@ -33,6 +33,7 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
    For each direct (`connection`):
    - Link the person's name to `profileUrl`.
    - Embed `acceptUrl` verbatim on a short verb phrase like "message {Name}". The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks.
+   - When the same person appears with multiple connections (grouped entry from the tool), link their name to `profileUrl` once, then embed each sub-entry's `acceptUrl` on a distinct topic phrase. Example: "[Ashish](profileUrl) — spanning [generative software](acceptUrl1), [AI infrastructure](acceptUrl2), and [deep learning](acceptUrl3) — several angles worth exploring."
 
    **Section B — introducer candidates** (only if any introducer candidates qualified)
 
@@ -52,7 +53,7 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 
    If `totalPending` exceeds the candidates you surfaced, end with: `There are N more conversations waiting for you, let me know if you want to see them.`
 
-10. For every opportunity you mention in the message, call `confirm_opportunity_delivery(opportunityId, trigger="ambient")`. Do NOT confirm for opportunities you skipped.
+10. For every opportunity you mention in the message — including every sub-entry within grouped cards — call `confirm_opportunity_delivery(opportunityId, trigger="ambient")`. Do NOT confirm for opportunities you skipped.
 
 11. **Write dedup state.** Update `memory/heartbeat-state.json` so that:
     - `deliveredToday.date` = today's host-local `YYYY-MM-DD`.

--- a/skills/index-network/prompts/digest.md
+++ b/skills/index-network/prompts/digest.md
@@ -51,7 +51,7 @@ Compose the brief; Hermes delivers your **final assistant reply** to the user's 
 
 8. **URL rules:** weave links into prose. The strip-the-URLs test is the rule — if a reader removes every link, the prose still reads coherently. NO bullet-list-of-links, NO link tables, NO action strips, NO blockquote whose body is link labels.
 
-9. **acceptUrl handling (connection candidates only):** Embed `acceptUrl` verbatim on a short verb phrase. The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks. **`connector-flow` candidates carry no `acceptUrl`** — those trigger an introduction approval, not a direct conversation.
+9. **acceptUrl handling (connection candidates only):** Embed `acceptUrl` verbatim on a short verb phrase. For grouped entries (same person, multiple connections), embed each sub-entry's `acceptUrl` on a distinct topic phrase instead — see the template in step 6. The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks. **`connector-flow` candidates carry no `acceptUrl`** — those trigger an introduction approval, not a direct conversation.
 
 10. For every opportunity you mention in the brief — including every sub-entry within grouped cards — call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. Do NOT confirm for opportunities you skipped.
 

--- a/skills/index-network/prompts/digest.md
+++ b/skills/index-network/prompts/digest.md
@@ -30,8 +30,9 @@ Compose the brief; Hermes delivers your **final assistant reply** to the user's 
 
    It's {weekday}, {short date / week context}. Here's what's worth your attention right now.
 
-   **{N} conversations await you** ← only if there are direct (connection) candidates — receiver is a party, NOT the introducer
+   **{N} conversations await you** ← only if there are direct (connection) candidates — receiver is a party, NOT the introducer. N = unique people, not raw opportunity count.
    - [Name](profileUrl) — 1–2 sentences on why this person matters to the user, [message Name](acceptUrl)
+   - [Name](profileUrl) — When multiple connections exist for the same person (grouped entry from the tool), weave each acceptUrl into the description as a hyperlink on the relevant topic phrase. Example: "An experienced technologist spanning [generative software](acceptUrl1), [AI infrastructure](acceptUrl2), and [deep learning research](acceptUrl3) — several angles worth exploring."
    - …
 
    **Help your community find their opportunities** ← only if there are introducer (connector-flow) candidates — receiver IS the introducer
@@ -52,7 +53,7 @@ Compose the brief; Hermes delivers your **final assistant reply** to the user's 
 
 9. **acceptUrl handling (connection candidates only):** Embed `acceptUrl` verbatim on a short verb phrase. The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks. **`connector-flow` candidates carry no `acceptUrl`** — those trigger an introduction approval, not a direct conversation.
 
-10. For every opportunity you mention in the brief, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. Do NOT confirm for opportunities you skipped.
+10. For every opportunity you mention in the brief — including every sub-entry within grouped cards — call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. Do NOT confirm for opportunities you skipped.
 
 11. If `totalPending` exceeds the candidates you surfaced, end with: `There are N more conversations waiting — let me know if you want to see them.`
 


### PR DESCRIPTION
## Summary

- Updated digest prompt to render grouped entries when the tool returns multiple opportunities for the same person — one profile link on the name, multiple conversation entry points via distinct `acceptUrl` hyperlinks on topic phrases
- Updated ambient prompt with the same grouped-entry rendering clause
- Added grouped-person exemplars to both digest and ambient sections so the LLM has a concrete target shape to mimic

## Context

The upstream protocol change (in `@indexnetwork/protocol` 1.17.0) groups opportunity cards by counterpart user in the MCP presentation layer. Each person now appears once with sub-entries, each carrying its own `acceptUrl` and `opportunityId`. These prompt and exemplar changes teach the digest and ambient LLMs how to render the new grouped format.

Before: same person repeated N times as separate bullets. After: one bullet per person, each opportunity reason hyperlinked to its own conversation.

## Test plan
- [x] Protocol tests: 59 pass, tsc clean
- [ ] Verify next morning digest groups same-person opportunities into a single bullet
- [ ] Verify ambient pass renders grouped entries correctly