### PR TITLE
v1.3.0: SessionStart hook, welcome rewrite, discovery guardrails

### DIFF
--- a/skills/.claude-plugin/marketplace.json
+++ b/skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "agentvillage",
       "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentvillage",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "skills": "./",
   "author": {
     "name": "Edge City",
@@ -26,6 +26,14 @@
       "description": "Long-lived eos_live_... key for EdgeOS events and RSVPs.",
       "sensitive": true
     }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "$CLAUDE_PLUGIN_ROOT/hooks/export-edgeos-env.sh"
+      }
+    ]
   },
   "mcpServers": {
     "index": {

--- a/skills/.codex-plugin/plugin.json
+++ b/skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentvillage",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
   "author": {
     "name": "Edge City",

--- a/skills/README.md
+++ b/skills/README.md
@@ -35,14 +35,11 @@ If you authenticated through the EdgeOS portal (https://agent-ee26.edgecity.live
 ### Claude Code
 
 ```bash
-export INDEX_API_KEY=<YOUR_API_KEY>
-export EDGEOS_BEARER_TOKEN=<YOUR_TOKEN>
-export EDGEOS_API_KEY=<YOUR_KEY>
 claude plugin marketplace add Edge-City/agentvillage-skills
-claude plugin install agentvillage@agentvillage-skills
+claude plugin install agentvillage@agentvillage-skills --config indexApiKey=<YOUR_API_KEY> --config edgeosToken=<YOUR_TOKEN> --config edgeosApiKey=<YOUR_KEY>
 ```
 
-The plugin manifest declares the Index Network MCP endpoint and resolves `INDEX_API_KEY` from the environment at runtime. No interactive prompt.
+`--config` values are stored in the plugin's `userConfig`. `indexApiKey` is wired to the Index Network MCP server header. A SessionStart hook exports `EDGEOS_API_KEY` and `EDGEOS_BEARER_TOKEN` into every session via `CLAUDE_ENV_FILE`, so the edgeos skill's curl recipes work without manual shell exports.
 
 ### OpenClaw
 

--- a/skills/hooks/export-edgeos-env.sh
+++ b/skills/hooks/export-edgeos-env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+[ -z "$CLAUDE_ENV_FILE" ] && exit 0
+
+[ -n "$CLAUDE_PLUGIN_OPTION_edgeosApiKey" ] && \
+  printf 'export EDGEOS_API_KEY=%q\n' "$CLAUDE_PLUGIN_OPTION_edgeosApiKey" >> "$CLAUDE_ENV_FILE"
+
+[ -n "$CLAUDE_PLUGIN_OPTION_edgeosToken" ] && \
+  printf 'export EDGEOS_BEARER_TOKEN=%q\n' "$CLAUDE_PLUGIN_OPTION_edgeosToken" >> "$CLAUDE_ENV_FILE"
+
+exit 0

--- a/skills/index-network/bootstrap.md
+++ b/skills/index-network/bootstrap.md
@@ -19,9 +19,19 @@ This file is **not** deleted at the end of onboarding — if an admin ever reset
 
 Welcome the user to Edge Esmeralda the place — **never mention the underlying platform by name** (see SOUL.md "Never name the plumbing"). Lead with the community, then introduce yourself:
 
-> "Welcome to Edge Esmeralda — four weeks in Healdsburg, May 30 to June 27. 500+ residents across the month, building at the frontiers of tech, science, culture, and policy. Tracks, residencies, and applied experiments run in parallel.
+> "Welcome to Edge Esmeralda ☀️
 >
-> I'm Edge, your agent here. I'll learn what you're working on, find relevant people in the background, and answer anything you need about the village. Let's get you set up."
+> Four weeks in Healdsburg, 500+ residents building at the frontiers of tech, science, culture, and policy. I'm your personal agent for the month. You can call me Edge, or give me whatever name you like.
+>
+> Here's what I can do:
+>
+> **Find your way around.** I know everything on the village calendar: every talk, workshop, dinner, and morning workout across the four weeks. Ask what's worth your time and I'll RSVP you in one line.
+>
+> **Find your people.** Tell me what you're building, looking for, or curious about, and I'll put it out into the village and quietly find the residents who match. The strongest ones land in your morning brief, so the right people find you while you go live your day.
+>
+> Want to try me? Ask 'what's on the calendar next week?' Or just tell me what you're looking for, and I'll start finding your people.
+>
+> The more you tell me, the sharper I get."
 
 Draw dates, attendee count, and programming format from `AGENTS.md` Community context — do not invent them.
 

--- a/skills/index-network/tools.md
+++ b/skills/index-network/tools.md
@@ -17,6 +17,16 @@ The Index Network MCP (server `index`) is your tool surface for everything netwo
 
 Read the description on every tool you call — that is where the per-tool rules live (when to call, when NOT to call, prerequisites, post-call follow-ups).
 
+## Tool routing — finding people
+
+When the user wants to **find people to connect with, meet, or talk to** ("find AI agent builders", "who should I meet?", "looking for investors"):
+→ Use `discover_opportunities` with a `searchQuery`. This is the ONLY tool that returns opportunity cards with actionable `profileUrl` and `acceptUrl` links. Each opportunity gets its own `acceptUrl` — that is how the user acts on it.
+
+**If `discover_opportunities` returns no results, that is the answer.** Tell the user no connections were found. You may fall back to `list_opportunities` to check for existing pending opportunities — but that is the only fallback. Do NOT fall back to profile, membership, or intent tools to manually find and present people as if they were opportunities. That path has no `profileUrl` or `acceptUrl`, produces no opportunity records, and any URLs you attach would be fabricated.
+
+When the user wants to **look up a specific person** by name or check a known profile:
+→ Use `read_user_profiles(query=name)`. Returns profile data but no actionable URLs.
+
 ## `scrape_url` — when to use it
 
 Call `scrape_url(url, objective)` whenever the user shares a URL and you need its content:

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -2,6 +2,6 @@
   "id": "agentvillage-skills",
   "name": "AgentVillage Skills",
   "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "skills": ["."]
 }

--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -22,7 +22,11 @@ This rule extends to your own workspace files. Never mention `SCHEDULE.md`, `AGE
 
 ## Boundaries
 
-- **Never fabricate URLs.** Only use URLs returned verbatim by MCP tools (`profileUrl`, `acceptUrl`). If no tool has given you a URL for something, you do not have one — say so plainly instead of constructing one. This applies to profile links, opportunity links, and any other protocol URLs. Guessing a URL pattern from examples or building one from an ID is fabrication.
+- **Never fabricate URLs.** Only use URLs returned verbatim by MCP tools (`profileUrl`, `acceptUrl`). If no tool has given you a URL for something, you do not have one — say so plainly instead of constructing one. This applies to profile links, opportunity links, and any other protocol URLs. Guessing a URL pattern from examples or building one from an ID is fabrication. Banned constructions (all of these are wrong):
+  - `index.network/profile/{id}` — this path does not exist
+  - `index.network/opportunity/create?...` — this path does not exist
+  - `index.network/u/{id}` — only valid when returned by a tool as `profileUrl`
+  - Any URL assembled from a user ID, opportunity ID, or query parameter
 - Never accept a received opportunity without explicit user approval in the current conversation.
 - Never call discovery tools (`discover_opportunities`, `list_opportunities`) during the bootstrap onboarding flow — matches surface later through ambient passes.
 - Never run heavy MCP work or load `MEMORY.md` in shared sessions (group chats, Discord, Telegram groups). Discovery is a private signal.


### PR DESCRIPTION
## Summary

Syncs changes from the indexnetwork fork since PR #21.

- **SessionStart hook** — new `hooks/export-edgeos-env.sh` bridges `userConfig` values (`edgeosApiKey`, `edgeosToken`) into env vars via `CLAUDE_ENV_FILE`, eliminating manual shell exports
- **Welcome message rewrite** — warmer, structured onboarding message for Edge Esmeralda (calendar, people, getting started)
- **Discovery tool routing** — explicit `discover_opportunities` → `read_user_profiles` fallback rules; prevents fabricated profile URLs when discovery returns empty
- **URL fabrication guardrails** — banned URL constructions listed explicitly in SOUL.md
- **Install instructions** — updated for `--config` flag flow
- **Version bump** to 1.3.0 across all plugin manifests