### PR TITLE
Add geo esmeralda skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See the project hub for the full diagram and decisions.
   - `skills/index-network/` — Index Network MCP procedural knowledge (onboarding ritual, voice exemplars, cron prompts, heartbeat tasks)
   - `skills/edgeos/` — backend-generic EdgeOS API recipes (events, RSVPs, venues, attendee directory, own profile). Reads `EDGEOS_BEARER_TOKEN` and `EDGEOS_API_KEY` from env; popup id is supplied by the active operator skill.
   - `skills/edge-esmeralda/` — Edge Esmeralda 2026 popup knowledge: popup constants (popup id, week dates, themes), attendee field semantics, the curated wiki/website/newsletter references (vendored from `Edge-City/agentvillage-skills`; refreshed by upstream CI every 15 min), and the onboarding pointer for obtaining EdgeOS tokens.
+  - `skills/geo-esmeralda/` — Geo knowledge graph recipes and write guidance for attendee-authored content, relations, ontology, and media.
 - `install/` — bootstrap scripts for plugging AgentVillage into a runtime
 
 ## Getting an agent connected
@@ -205,17 +206,18 @@ bun install/install.ts \
   --edgeos-bearer-token eyJ…
 ```
 
-The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openclaw.json`; on the next gateway start they become process-env on the gateway and inherit into the agent's shell tool, so `curl -H "Authorization: Bearer $EDGEOS_API_KEY"` recipes work without further plumbing.
+The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openclaw.json`; on the next gateway start they become process-env on the gateway and inherit into the agent's shell tool, so `curl -H "Authorization: Bearer $EDGEOS_API_KEY"` recipes and `geo-edge-esmeralda` commands work without further plumbing.
 
 The installer:
 
 1. Writes `mcp.servers.index` in `~/.openclaw/openclaw.json`, pointed at `https://protocol.index.network/mcp` with your API key in `x-api-key`.
 2. If `--edgeos-api-key` and/or `--edgeos-bearer-token` are passed, writes each to `env.vars.<NAME>` so the gateway exposes them to the agent's subprocesses on its next start.
-3. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
-4. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
-5. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
-6. Installs one cron job by default: the daily digest (`0 8 * * *`). The afternoon (`0 14 * * *`) and evening (`0 20 * * *`) ambient passes are opt-in — the user enables them through the schedule sub-dialog at session start or any time later.
-7. Restarts the gateway so all config changes take effect.
+3. Installs a `geo-edge-esmeralda` wrapper into `$HOME/.local/bin` that runs the public Geo CLI package through Bun.
+4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
+5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
+6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
+7. Installs one cron job by default: the daily digest (`0 8 * * *`). The afternoon (`0 14 * * *`) and evening (`0 20 * * *`) ambient passes are opt-in — the user enables them through the schedule sub-dialog at session start or any time later.
+8. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent onboarding gates that run at session start:
 
@@ -265,6 +267,7 @@ Accepted-opportunity notifications, freshness audits, memory curation, and any o
 | `HEARTBEAT.md` | Generic heartbeat tick rules + the cross-backend `memory-curation` task. Backend-specific tasks live in each active skill's `heartbeat.md`. |
 | `skills/index-network/SKILL.md` | Index Network skill bundle entry point. Registered with OpenClaw on install; gates on `mcp.servers.index`. Body points at the bundle's sibling reference files. |
 | `skills/edgeos/SKILL.md` | EdgeOS-API skill: events + attendee directory + curated wiki/website/newsletter references. Currently scoped to Edge Esmeralda 2026. Loaded by OpenClaw alongside index-network. Vendored from `Edge-City/agentvillage-skills`. |
+| `skills/geo-esmeralda/SKILL.md` | Geo knowledge graph skill: community content, relations, ontology, and attendee-authored writes through the `geo-edge-esmeralda` CLI. |
 
 ## Configuration guide
 
@@ -316,8 +319,8 @@ AgentVillage's behaviour is markdown-driven. Almost everything you'd want to cha
 
 | You want to… | Edit | Notes |
 |---|---|---|
-| Wire a brand-new backend (e.g. Geo today, others later) | new `install/install_<name>.ts` (modeled on `install_index.ts` for MCP+cron wiring or `install_edgeos.ts` for env-token wiring) + new `skills/<name>/` bundle with `SKILL.md` + register in `workspace/AGENTS.md` "Active skills" | The orchestrator (`install/install.ts`) already calls `installIndex()`, `installEdgeos()`, `installGeo()` in sequence — add your `install_<name>()` call alongside. |
-| Extend an existing backend (Index, EdgeOS, Geo when wired) | The matching `install/install_<name>.ts` and `skills/<name>/` bundle | Runtime config (env vars, MCP entries, cron jobs) lives in `install_<name>.ts`; agent-facing instructions live in the skill bundle's `SKILL.md` and siblings. |
+| Wire a brand-new backend | new `install/install_<name>.ts` (modeled on `install_index.ts` for MCP+cron wiring, `install_edgeos.ts` for env-token wiring, or `install_geo.ts` for CLI-wrapper wiring) + new `skills/<name>/` bundle with `SKILL.md` + register in `workspace/AGENTS.md` "Active skills" | Add the installer call to `install/install.ts` and include the skill in `EDGE_SKILL_NAMES` so it is copied into the runtime workspace. |
+| Extend an existing backend (Index, EdgeOS, Geo) | The matching `install/install_<name>.ts` and `skills/<name>/` bundle | Runtime config (env vars, MCP entries, cron jobs, CLI wrappers) lives in `install_<name>.ts`; agent-facing instructions live in the skill bundle's `SKILL.md` and siblings. |
 | Wire optional env vars an existing backend needs | `install/install_<name>.ts` + the Prerequisites section of this README | The installer writes `env.vars.<NAME>`; the gateway exposes those to the agent's shell tools on next start. `install_edgeos.ts` is the worked example. |
 | Change which skills the agent loads | `workspace/AGENTS.md` "Active skills" section | Mark a skill as eager (gates fire at session start) or reactive (only consulted when needed). |
 | Update the vendored `edgeos` reference data (events, attendee directory, wiki snapshots) | Don't — it's auto-refreshed from upstream | Upstream CI in `Edge-City/agentvillage-skills` regenerates `skills/edgeos/references/` every 15 minutes; the change propagates through the nested subtree chain. See the monorepo's `CLAUDE.md` for the sync flow. The recipes in `SKILL.md` are hand-edited — see the "Content" section above. |
@@ -327,8 +330,8 @@ AgentVillage's behaviour is markdown-driven. Almost everything you'd want to cha
 Skills in this repo are public. Each backend gates access with its own per-user credential, wired in by the matching per-backend installer:
 
 - **Index Network (today's wired backend)** — per-user API key returned by `POST /api/networks/:id/signup` (see [Integration API: Authentication](#authentication) above). `install/install_index.ts` writes it into `mcp.servers.index` as the `x-api-key` header.
-- **EdgeOS** — per-user token issued via OTP through the EdgeOS portal. Lands in `install/install_edgeos.ts` once that backend is wired.
-- **Geo** — per-user credential, mechanism TBD. Lands in `install/install_geo.ts` once that backend is wired.
+- **EdgeOS** — per-user tokens issued via OTP through the EdgeOS portal. `install/install_edgeos.ts` writes `EDGEOS_API_KEY` and `EDGEOS_BEARER_TOKEN` into the runtime environment when provided.
+- **Geo** — uses the attendee's `EDGEOS_BEARER_TOKEN` and the `geo-edge-esmeralda` CLI. `install/install_geo.ts` installs the CLI wrapper into `$HOME/.local/bin`.
 
 The skill files describe HOW to call each backend's APIs; the per-backend credential is what unlocks them.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ See `skills/README.md` for the full per-host reference.
 - [OpenClaw](https://openclaw.dev) installed and configured (`openclaw onboard --mode local` or `openclaw setup`).
 - An API key for the Index protocol. Generate one on your agents page at [index.network](https://index.network) (or your community-branded node).
 - [Bun](https://bun.sh) — the installer is a Bun script (Node 20+ also works if you swap the shebang).
+- Node 20+ with npm/npx available to run the Geo CLI recipes.
 - *(Optional)* EdgeOS tokens, if you want live event/attendee recipes to work without per-query prompting:
   - `EDGEOS_API_KEY` — long-lived `eos_live_…` automation key, minted via the EdgeCity onboarding flow (see the "EdgeOS tokens" section above). Unlocks the calendar/RSVPs/venues recipes in `skills/edgeos/SKILL.md`.
   - `EDGEOS_BEARER_TOKEN` — human session JWT obtained via the same email-OTP flow. Unlocks the directory, own-profile, and OpenAPI-spec recipes.
@@ -206,13 +207,13 @@ bun install/install.ts \
   --edgeos-bearer-token eyJ…
 ```
 
-The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openclaw.json`; on the next gateway start they become process-env on the gateway and inherit into the agent's shell tool, so `curl -H "Authorization: Bearer $EDGEOS_API_KEY"` recipes and `geo-edge-esmeralda` commands work without further plumbing.
+The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openclaw.json`; on the next gateway start they become process-env on the gateway and inherit into the agent's shell tool, so `curl -H "Authorization: Bearer $EDGEOS_API_KEY"` recipes and Geo CLI commands work without further plumbing.
 
 The installer:
 
 1. Writes `mcp.servers.index` in `~/.openclaw/openclaw.json`, pointed at `https://protocol.index.network/mcp` with your API key in `x-api-key`.
 2. If `--edgeos-api-key` and/or `--edgeos-bearer-token` are passed, writes each to `env.vars.<NAME>` so the gateway exposes them to the agent's subprocesses on its next start.
-3. Installs a `geo-edge-esmeralda` wrapper into `$HOME/.local/bin` that runs the public Geo CLI package through Bun.
+3. Leaves Geo CLI execution to the skill recipes, which run the public package through `npx`.
 4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
@@ -267,7 +268,7 @@ Accepted-opportunity notifications, freshness audits, memory curation, and any o
 | `HEARTBEAT.md` | Generic heartbeat tick rules + the cross-backend `memory-curation` task. Backend-specific tasks live in each active skill's `heartbeat.md`. |
 | `skills/index-network/SKILL.md` | Index Network skill bundle entry point. Registered with OpenClaw on install; gates on `mcp.servers.index`. Body points at the bundle's sibling reference files. |
 | `skills/edgeos/SKILL.md` | EdgeOS-API skill: events + attendee directory + curated wiki/website/newsletter references. Currently scoped to Edge Esmeralda 2026. Loaded by OpenClaw alongside index-network. Vendored from `Edge-City/agentvillage-skills`. |
-| `skills/geo-esmeralda/SKILL.md` | Geo knowledge graph skill: community content, relations, ontology, and attendee-authored writes through the `geo-edge-esmeralda` CLI. |
+| `skills/geo-esmeralda/SKILL.md` | Geo knowledge graph skill: community content, relations, ontology, and attendee-authored writes through the Geo CLI package. |
 
 ## Configuration guide
 
@@ -319,8 +320,8 @@ AgentVillage's behaviour is markdown-driven. Almost everything you'd want to cha
 
 | You want to… | Edit | Notes |
 |---|---|---|
-| Wire a brand-new backend | new `install/install_<name>.ts` (modeled on `install_index.ts` for MCP+cron wiring, `install_edgeos.ts` for env-token wiring, or `install_geo.ts` for CLI-wrapper wiring) + new `skills/<name>/` bundle with `SKILL.md` + register in `workspace/AGENTS.md` "Active skills" | Add the installer call to `install/install.ts` and include the skill in `EDGE_SKILL_NAMES` so it is copied into the runtime workspace. |
-| Extend an existing backend (Index, EdgeOS, Geo) | The matching `install/install_<name>.ts` and `skills/<name>/` bundle | Runtime config (env vars, MCP entries, cron jobs, CLI wrappers) lives in `install_<name>.ts`; agent-facing instructions live in the skill bundle's `SKILL.md` and siblings. |
+| Wire a brand-new backend | new `install/install_<name>.ts` (modeled on `install_index.ts` for MCP+cron wiring, `install_edgeos.ts` for env-token wiring, or `install_geo.ts` for CLI runtime guidance) + new `skills/<name>/` bundle with `SKILL.md` + register in `workspace/AGENTS.md` "Active skills" | Add the installer call to `install/install.ts` and include the skill in `EDGE_SKILL_NAMES` so it is copied into the runtime workspace. |
+| Extend an existing backend (Index, EdgeOS, Geo) | The matching `install/install_<name>.ts` and `skills/<name>/` bundle | Runtime config (env vars, MCP entries, cron jobs, CLI commands) lives in `install_<name>.ts`; agent-facing instructions live in the skill bundle's `SKILL.md` and siblings. |
 | Wire optional env vars an existing backend needs | `install/install_<name>.ts` + the Prerequisites section of this README | The installer writes `env.vars.<NAME>`; the gateway exposes those to the agent's shell tools on next start. `install_edgeos.ts` is the worked example. |
 | Change which skills the agent loads | `workspace/AGENTS.md` "Active skills" section | Mark a skill as eager (gates fire at session start) or reactive (only consulted when needed). |
 | Update the vendored `edgeos` reference data (events, attendee directory, wiki snapshots) | Don't — it's auto-refreshed from upstream | Upstream CI in `Edge-City/agentvillage-skills` regenerates `skills/edgeos/references/` every 15 minutes; the change propagates through the nested subtree chain. See the monorepo's `CLAUDE.md` for the sync flow. The recipes in `SKILL.md` are hand-edited — see the "Content" section above. |
@@ -331,7 +332,7 @@ Skills in this repo are public. Each backend gates access with its own per-user 
 
 - **Index Network (today's wired backend)** — per-user API key returned by `POST /api/networks/:id/signup` (see [Integration API: Authentication](#authentication) above). `install/install_index.ts` writes it into `mcp.servers.index` as the `x-api-key` header.
 - **EdgeOS** — per-user tokens issued via OTP through the EdgeOS portal. `install/install_edgeos.ts` writes `EDGEOS_API_KEY` and `EDGEOS_BEARER_TOKEN` into the runtime environment when provided.
-- **Geo** — uses the attendee's `EDGEOS_BEARER_TOKEN` and the `geo-edge-esmeralda` CLI. `install/install_geo.ts` installs the CLI wrapper into `$HOME/.local/bin`.
+- **Geo** — uses the attendee's `EDGEOS_BEARER_TOKEN` and the Geo CLI package. Skill recipes run it through `npx`.
 
 The skill files describe HOW to call each backend's APIs; the per-backend credential is what unlocks them.
 

--- a/install/install.ts
+++ b/install/install.ts
@@ -6,9 +6,10 @@
  *
  *   - `SOUL.md` → `$HERMES_HOME/SOUL.md` (identity; overwrites generic Hermes soul)
  *   - `AGENTS.md`, `SCHEDULE.md`, `USER.md` → `$HERMES_HOME/`
- *   - Edge skill bundles → `$HERMES_HOME/skills/{index-network,edgeos,edge-esmeralda}/`
+ *   - Edge skill bundles → `$HERMES_HOME/skills/{index-network,edgeos,edge-esmeralda,geo-esmeralda}/`
  *   - `terminal.cwd` in config.yaml → `$HERMES_HOME`
  *   - Index MCP + morning digest cron (`install_index.ts`)
+ *   - Geo CLI wrapper (`install_geo.ts`)
  *
  * Usage (from repo root):
  *   bun install/install.ts --index-api-key <KEY>

--- a/install/install.ts
+++ b/install/install.ts
@@ -9,7 +9,7 @@
  *   - Edge skill bundles → `$HERMES_HOME/skills/{index-network,edgeos,edge-esmeralda,geo-esmeralda}/`
  *   - `terminal.cwd` in config.yaml → `$HERMES_HOME`
  *   - Index MCP + morning digest cron (`install_index.ts`)
- *   - Geo CLI wrapper (`install_geo.ts`)
+ *   - Geo CLI runtime note (`install_geo.ts`)
  *
  * Usage (from repo root):
  *   bun install/install.ts --index-api-key <KEY>

--- a/install/install_geo.ts
+++ b/install/install_geo.ts
@@ -1,5 +1,32 @@
-/** Geo backend installer — placeholder. */
+/**
+ * Geo backend installer.
+ *
+ * Installs a `geo-edge-esmeralda` command wrapper into `$HOME/.local/bin`.
+ * The wrapper executes the public CLI package through Bun so the agent can use
+ * a stable command without this installer vendoring the CLI package.
+ */
+
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function localBinDir(): string {
+  return join(process.env.HOME?.trim() || homedir(), ".local", "bin");
+}
 
 export function installGeo(): void {
-  // placeholder — no-op
+  const binDir = localBinDir();
+  if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
+
+  const target = join(binDir, "geo-edge-esmeralda");
+  const script = [
+    "#!/bin/sh",
+    "set -eu",
+    'exec bun x --bun @geoprotocol/geo-edge-esmeralda-cli "$@"',
+    "",
+  ].join("\n");
+
+  writeFileSync(target, script, { mode: 0o755 });
+  chmodSync(target, 0o755);
+  console.log(`→ geo: installed geo-edge-esmeralda wrapper at ${target}`);
 }

--- a/install/install_geo.ts
+++ b/install/install_geo.ts
@@ -1,32 +1,5 @@
-/**
- * Geo backend installer.
- *
- * Installs a `geo-edge-esmeralda` command wrapper into `$HOME/.local/bin`.
- * The wrapper executes the public CLI package through Bun so the agent can use
- * a stable command without this installer vendoring the CLI package.
- */
-
-import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
-function localBinDir(): string {
-  return join(process.env.HOME?.trim() || homedir(), ".local", "bin");
-}
+/** Geo backend installer. */
 
 export function installGeo(): void {
-  const binDir = localBinDir();
-  if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
-
-  const target = join(binDir, "geo-edge-esmeralda");
-  const script = [
-    "#!/bin/sh",
-    "set -eu",
-    'exec bun x --bun @geoprotocol/geo-edge-esmeralda-cli "$@"',
-    "",
-  ].join("\n");
-
-  writeFileSync(target, script, { mode: 0o755 });
-  chmodSync(target, 0o755);
-  console.log(`→ geo: installed geo-edge-esmeralda wrapper at ${target}`);
+  console.log("→ geo: no local install needed; recipes run the public CLI with npx");
 }

--- a/install/paths.ts
+++ b/install/paths.ts
@@ -16,6 +16,11 @@ export function skillsDir(): string {
 }
 
 /** Skill bundles shipped by this repo (installed into `$HERMES_HOME/skills/<name>/`). */
-export const EDGE_SKILL_NAMES = ["index-network", "edgeos", "edge-esmeralda"] as const;
+export const EDGE_SKILL_NAMES = [
+  "index-network",
+  "edgeos",
+  "edge-esmeralda",
+  "geo-esmeralda",
+] as const;
 
 export const CRON_NAME_PREFIX = "Edge —";

--- a/skills/.claude-plugin/marketplace.json
+++ b/skills/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agentvillage-skills",
   "metadata": {
-    "description": "Edge Esmeralda 2026 Agent Village skills — popup knowledge, EdgeOS APIs, and Index Network discovery."
+    "description": "Edge Esmeralda 2026 Agent Village skills — popup knowledge, EdgeOS APIs, Geo knowledge graph access, and Index Network discovery."
   },
   "owner": {
     "name": "Edge City",
@@ -11,8 +11,8 @@
   "plugins": [
     {
       "name": "agentvillage",
-      "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-      "version": "1.3.0",
+      "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery.",
+      "version": "1.4.0",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentvillage",
-  "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.3.0",
+  "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery skills for the Agent Village.",
+  "version": "1.4.0",
   "skills": "./",
   "author": {
     "name": "Edge City",
@@ -17,7 +17,7 @@
     "edgeosToken": {
       "type": "string",
       "title": "EdgeOS Bearer Token",
-      "description": "Human session JWT for EdgeOS directory and profile access.",
+      "description": "Human session JWT for Geo knowledge graph access, content writes, EdgeOS directory, and own profile.",
       "sensitive": true
     },
     "edgeosApiKey": {

--- a/skills/.codex-plugin/plugin.json
+++ b/skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentvillage",
-  "version": "1.3.0",
-  "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
+  "version": "1.4.0",
+  "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery.",
   "author": {
     "name": "Edge City",
     "url": "https://edgecity.live"
@@ -14,7 +14,7 @@
   "mcpServers": "./mcp.json",
   "interface": {
     "displayName": "AgentVillage Skills",
-    "shortDescription": "Edge Esmeralda popup knowledge, calendar, directory, and discovery.",
+    "shortDescription": "Edge Esmeralda popup knowledge, knowledge graph, calendar, directory, and discovery.",
     "developerName": "Edge City",
     "category": "Productivity",
     "capabilities": ["MCP", "Skills"],

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,13 +4,14 @@ Agent skills for **Edge Esmeralda 2026** (May 30 – Jun 27, Healdsburg, CA). Sh
 
 ## What you get
 
-Three skill bundles that give your agent Edge Esmeralda knowledge and live API access:
+Four skill bundles that give your agent Edge Esmeralda knowledge and live API access:
 
 - **edge-esmeralda** — popup constants (popup id, week dates, themes), attendee directory field semantics, curated wiki/website/newsletter knowledge base, and the onboarding pointer for obtaining EdgeOS tokens.
 - **edgeos** — backend-generic EdgeOS API recipes: events, RSVPs, venues, attendee directory, and your own profile lookup.
+- **geo-esmeralda** — Geo knowledge graph access through the `geo-edge-esmeralda` CLI: ontology, fixed graph tools, guarded native read-only queries, and attendee-authored content/photo creation.
 - **index-network** — Index Network discovery: onboarding ritual, opportunity surfacing, voice exemplars, cron prompts for welcome/digest/ambient flows, and heartbeat tasks.
 
-The skills cross-reference each other. `edge-esmeralda` supplies the popup id that `edgeos` recipes need. `index-network` handles discovery and intent-based matching. Install all three together.
+The skills cross-reference each other. `edge-esmeralda` supplies the popup id that `edgeos` recipes need. `geo-esmeralda` handles Geo knowledge graph-backed knowledge and attendee-authored writes, and `index-network` handles discovery and intent-based matching. Install all four together.
 
 ## Install
 
@@ -22,11 +23,11 @@ All hosts read credentials from environment variables. Set these before installi
 | Variable              | Source                                                                                               | Required |
 | --------------------- | ---------------------------------------------------------------------------------------------------- | -------- |
 | `INDEX_API_KEY`       | Index Network signup (BYOA page or [agent-ee26.edgecity.live](https://agent-ee26.edgecity.live/)) | Yes      |
-| `EDGEOS_BEARER_TOKEN` | EdgeOS email-OTP onboarding flow                                                                     | Optional |
-| `EDGEOS_API_KEY`      | EdgeOS email-OTP onboarding flow (`eos_live_...` key)                                                | Optional |
+| `EDGEOS_BEARER_TOKEN` | EdgeOS email-OTP onboarding flow                                                                     | Yes for Geo knowledge graph access and content writes; also used for EdgeOS directory/profile |
+| `EDGEOS_API_KEY`      | EdgeOS email-OTP onboarding flow (`eos_live_...` key)                                                | Optional; needed for EdgeOS events, RSVPs, venues |
 
 
-`INDEX_API_KEY` is required for the Index Network MCP server. The EdgeOS tokens are optional — without them the agent still loads; EdgeOS recipes will prompt for the missing token on first use.
+`INDEX_API_KEY` is required for the Index Network MCP server. `EDGEOS_BEARER_TOKEN` is required for `geo-esmeralda` auth, graph reads, and content writes. `EDGEOS_API_KEY` is only needed for EdgeOS event, RSVP, and venue recipes.
 
 ### BYOA flow
 
@@ -39,15 +40,15 @@ claude plugin marketplace add Edge-City/agentvillage-skills
 claude plugin install agentvillage@agentvillage-skills --config indexApiKey=<YOUR_API_KEY> --config edgeosToken=<YOUR_TOKEN> --config edgeosApiKey=<YOUR_KEY>
 ```
 
-`--config` values are stored in the plugin's `userConfig`. `indexApiKey` is wired to the Index Network MCP server header. A SessionStart hook exports `EDGEOS_API_KEY` and `EDGEOS_BEARER_TOKEN` into every session via `CLAUDE_ENV_FILE`, so the edgeos skill's curl recipes work without manual shell exports.
+`--config` values are stored in the plugin's `userConfig`. `indexApiKey` is wired to the Index Network MCP server header. A SessionStart hook exports `EDGEOS_API_KEY` and `EDGEOS_BEARER_TOKEN` into every session via `CLAUDE_ENV_FILE`, so the Geo CLI and edgeos skill's curl recipes work without manual shell exports.
 
 ### OpenClaw
 
 ```bash
 openclaw plugins install agentvillage --marketplace Edge-City/agentvillage-skills
 openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<YOUR_API_KEY>"}}'
-openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<YOUR_TOKEN>'
-openclaw config set env.vars.EDGEOS_API_KEY '<YOUR_KEY>'
+openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<YOUR_TOKEN>'  # Human session JWT for Geo knowledge graph access and content writes
+openclaw config set env.vars.EDGEOS_API_KEY '<YOUR_KEY>'         # Long-lived automation key for events, RSVPs, venues
 openclaw gateway restart
 ```
 
@@ -58,6 +59,7 @@ OpenClaw persists credentials in `~/.openclaw/openclaw.json` — no shell profil
 ```bash
 hermes skills install Edge-City/agentvillage/skills/edge-esmeralda --force
 hermes skills install Edge-City/agentvillage/skills/edgeos --force
+hermes skills install Edge-City/agentvillage/skills/geo-esmeralda --force
 hermes skills install Edge-City/agentvillage/skills/index-network --force
 ```
 
@@ -65,8 +67,8 @@ Add to `~/.hermes/.env`:
 
 ```bash
 INDEX_API_KEY=<YOUR_API_KEY>
-EDGEOS_BEARER_TOKEN=<YOUR_TOKEN>
-EDGEOS_API_KEY=<YOUR_KEY>
+EDGEOS_BEARER_TOKEN=<YOUR_TOKEN>   # Human session JWT for Geo knowledge graph access and content writes
+EDGEOS_API_KEY=<YOUR_KEY>          # Long-lived automation key for events, RSVPs, venues
 TELEGRAM_HOME_CHANNEL=<numeric_chat_id>   # optional, for cron delivery
 ```
 
@@ -85,7 +87,8 @@ For workspace, installer, and cron jobs:
 
 ```bash
 bun install/install.ts --index-api-key <KEY>
-# optional: --edgeos-api-key ... --edgeos-bearer-token ...
+# add --edgeos-bearer-token for Geo knowledge graph access/content writes
+# add --edgeos-api-key for EdgeOS event, RSVP, and venue recipes
 # re-onboard: add --wipe-user
 ```
 
@@ -125,7 +128,7 @@ Configure an HTTP MCP server with the following settings:
 }
 ```
 
-Set `EDGEOS_BEARER_TOKEN` and `EDGEOS_API_KEY` in your agent's environment if it supports EdgeOS recipes.
+Set `EDGEOS_BEARER_TOKEN` for Geo knowledge graph access and content writes. Set `EDGEOS_API_KEY` as well if the agent supports EdgeOS event, RSVP, or venue recipes.
 
 For Hermes with workspace + installer, use [agentvillage](https://github.com/Edge-City/agentvillage). For OpenClaw, use [agentvillage](https://github.com/Edge-City/agentvillage).
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,7 +8,7 @@ Four skill bundles that give your agent Edge Esmeralda knowledge and live API ac
 
 - **edge-esmeralda** — popup constants (popup id, week dates, themes), attendee directory field semantics, curated wiki/website/newsletter knowledge base, and the onboarding pointer for obtaining EdgeOS tokens.
 - **edgeos** — backend-generic EdgeOS API recipes: events, RSVPs, venues, attendee directory, and your own profile lookup.
-- **geo-esmeralda** — Geo knowledge graph access through the `geo-edge-esmeralda` CLI: ontology, fixed graph tools, guarded native read-only queries, and attendee-authored content/photo creation.
+- **geo-esmeralda** — Geo knowledge graph access through the Geo CLI package: ontology, fixed graph tools, guarded native read-only queries, and attendee-authored content/photo creation.
 - **index-network** — Index Network discovery: onboarding ritual, opportunity surfacing, voice exemplars, cron prompts for welcome/digest/ambient flows, and heartbeat tasks.
 
 The skills cross-reference each other. `edge-esmeralda` supplies the popup id that `edgeos` recipes need. `geo-esmeralda` handles Geo knowledge graph-backed knowledge and attendee-authored writes, and `index-network` handles discovery and intent-based matching. Install all four together.

--- a/skills/edge-esmeralda/README.md
+++ b/skills/edge-esmeralda/README.md
@@ -11,7 +11,7 @@ For backend-agnostic EdgeOS API recipes (events, RSVPs, venues, the directory en
 - **Claude Code**: copy both files to `~/.claude/skills/edge-esmeralda/SKILL.md` and `~/.claude/skills/edgeos/SKILL.md` respectively.
 - **OpenClaw / Hermes / NanoClaw**: add to your agent's skill directory.
 
-Set environment variables (the `edgeos` skill needs both; this skill needs none):
+Set environment variables when pairing this skill with live API skills. `edge-esmeralda` itself does not read environment variables:
 ```bash
 export EDGEOS_API_KEY="eos_live_..."      # Long-lived automation key for events, RSVPs, venues
 export EDGEOS_BEARER_TOKEN="..."          # Human session JWT for directory, own profile

--- a/skills/geo-esmeralda/SKILL.md
+++ b/skills/geo-esmeralda/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: geo-esmeralda
+description: Add attendee-authored content and query Geo community knowledge, relations, and ontology through the geo-edge-esmeralda CLI.
+version: 1.0.0
+author: Edge City
+tags: [edge-city, edge-esmeralda, geo, graph, community]
+required_environment_variables:
+  - name: EDGEOS_BEARER_TOKEN
+    required_for: auth, graph reads, content writes
+metadata:
+  openclaw:
+    requires:
+      config:
+        - env.vars.EDGEOS_BEARER_TOKEN
+---
+
+# Geo Esmeralda
+
+Use this skill when an attendee wants to add community knowledge to Geo or work
+with the Geo knowledge graph's content, relations, and ontology. It is especially
+for creating notes, transcripts, essays, project pitches, comments, and photos;
+linking those contributions to events, venues, tracks, or other community
+context; and reading back knowledge graph-backed claims, content, source material,
+wiki-style knowledge, idea links, and ontology details.
+
+Other sibling skills cover live EdgeOS schedule/directory operations and Index
+Network participant matching. Use this skill for the Geo knowledge graph and for all
+attendee-authored writes.
+
+Always use the `geo-edge-esmeralda` CLI as the execution surface. Do not call the
+HTTP API directly unless the user is debugging the service itself.
+
+## 1. Authentication
+
+You need one token, read by the CLI from environment/config:
+
+- **`$EDGEOS_BEARER_TOKEN`** — human session JWT. Required for: Geo auth, graph reads, content writes.
+
+## 2. Safety Rules
+
+- Never place bearer tokens in prompts, query text, native query parameters,
+  answers, examples, transcripts, or shared notes.
+- Prefer fixed commands before native graph queries.
+- Fetch live ontology before writing a native query unless the current session
+  already fetched it.
+- Treat denied native queries as a signal to narrow the query or switch to a
+  fixed command.
+- Only write through `geo-edge-esmeralda create`. Do not attempt imports, schema
+  changes, admin calls, direct Neo4j access, or generic mutation endpoints.
+- Before creating content, use the user's own words where possible and scope it
+  to `--event-id`, `--venue-id`, or `--track-id` when the user names one.
+- For photos, prefer `--file ./photo.jpg` over hosted image URLs when the user
+  has a local file. Do not paste binary data, upload URLs, storage keys, or local
+  file paths into prompts or shared output.
+- Use a stable `--client-request-id` for creates so retries do not duplicate
+  the attendee's content.
+
+## 3. Write Pattern
+
+Use `geo-edge-esmeralda create` whenever the attendee wants to contribute
+knowledge, commentary, media, or project context. Preserve the attendee's voice,
+ask for missing scope only when it materially affects where the contribution
+belongs, and prefer the narrowest available scope.
+
+```bash
+geo-edge-esmeralda auth
+geo-edge-esmeralda create --event-id <event-id> --kind comment --client-request-id <stable-id> --content 'Several attendees connected the session to local-first data sharing.'
+geo-edge-esmeralda create --kind project_pitch --title 'Mutual aid map' --client-request-id <stable-id> --content 'Looking for collaborators on an offline-capable resource map.'
+geo-edge-esmeralda create --event-id <event-id> --kind photo --file ./photo.jpg --client-request-id <stable-id> --content 'Whiteboard from the protocol design session.'
+```
+
+## 4. Read Pattern
+
+```bash
+geo-edge-esmeralda auth
+geo-edge-esmeralda ontology
+geo-edge-esmeralda fixed --tool community_search --input '{"query":"housing coordination","limit":10}'
+geo-edge-esmeralda fixed --tool list_content --input '{"scopeKind":"event","scopeId":"<event-id>","limit":10}'
+geo-edge-esmeralda fixed --tool list_idea_links --input '{"limit":20}'
+geo-edge-esmeralda native --query 'MATCH (c:ContentItem) WHERE c.popupId = $popupId RETURN c.id AS id, c.title AS title, c.kind AS kind LIMIT 20'
+```
+
+Load `references/setup.md` when configuring the CLI or installing the skill.
+Load `references/examples.md` when choosing a fixed command or native-query
+shape. Load `references/ontology.md` before constructing native queries.

--- a/skills/geo-esmeralda/SKILL.md
+++ b/skills/geo-esmeralda/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: geo-esmeralda
-description: Add attendee-authored content and query Geo community knowledge, relations, and ontology through the geo-edge-esmeralda CLI.
+description: Add attendee-authored content and query Geo community knowledge, relations, and ontology through the Geo CLI package.
 version: 1.0.0
 author: Edge City
 tags: [edge-city, edge-esmeralda, geo, graph, community]
@@ -27,8 +27,9 @@ Other sibling skills cover live EdgeOS schedule/directory operations and Index
 Network participant matching. Use this skill for the Geo knowledge graph and for all
 attendee-authored writes.
 
-Always use the `geo-edge-esmeralda` CLI as the execution surface. Do not call the
-HTTP API directly unless the user is debugging the service itself.
+Always run the Geo CLI with `npx -y @geoprotocol/geo-edge-esmeralda-cli` as the
+execution surface. Do not call the HTTP API directly unless the user is
+debugging the service itself.
 
 ## 1. Authentication
 
@@ -45,8 +46,9 @@ You need one token, read by the CLI from environment/config:
   already fetched it.
 - Treat denied native queries as a signal to narrow the query or switch to a
   fixed command.
-- Only write through `geo-edge-esmeralda create`. Do not attempt imports, schema
-  changes, admin calls, direct Neo4j access, or generic mutation endpoints.
+- Only write through `npx -y @geoprotocol/geo-edge-esmeralda-cli create`. Do not
+  attempt imports, schema changes, admin calls, direct Neo4j access, or generic
+  mutation endpoints.
 - Before creating content, use the user's own words where possible and scope it
   to `--event-id`, `--venue-id`, or `--track-id` when the user names one.
 - For photos, prefer `--file ./photo.jpg` over hosted image URLs when the user
@@ -57,27 +59,27 @@ You need one token, read by the CLI from environment/config:
 
 ## 3. Write Pattern
 
-Use `geo-edge-esmeralda create` whenever the attendee wants to contribute
-knowledge, commentary, media, or project context. Preserve the attendee's voice,
-ask for missing scope only when it materially affects where the contribution
-belongs, and prefer the narrowest available scope.
+Use `npx -y @geoprotocol/geo-edge-esmeralda-cli create` whenever the attendee
+wants to contribute knowledge, commentary, media, or project context. Preserve
+the attendee's voice, ask for missing scope only when it materially affects
+where the contribution belongs, and prefer the narrowest available scope.
 
 ```bash
-geo-edge-esmeralda auth
-geo-edge-esmeralda create --event-id <event-id> --kind comment --client-request-id <stable-id> --content 'Several attendees connected the session to local-first data sharing.'
-geo-edge-esmeralda create --kind project_pitch --title 'Mutual aid map' --client-request-id <stable-id> --content 'Looking for collaborators on an offline-capable resource map.'
-geo-edge-esmeralda create --event-id <event-id> --kind photo --file ./photo.jpg --client-request-id <stable-id> --content 'Whiteboard from the protocol design session.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli auth
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --event-id <event-id> --kind comment --client-request-id <stable-id> --content 'Several attendees connected the session to local-first data sharing.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --kind project_pitch --title 'Mutual aid map' --client-request-id <stable-id> --content 'Looking for collaborators on an offline-capable resource map.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --event-id <event-id> --kind photo --file ./photo.jpg --client-request-id <stable-id> --content 'Whiteboard from the protocol design session.'
 ```
 
 ## 4. Read Pattern
 
 ```bash
-geo-edge-esmeralda auth
-geo-edge-esmeralda ontology
-geo-edge-esmeralda fixed --tool community_search --input '{"query":"housing coordination","limit":10}'
-geo-edge-esmeralda fixed --tool list_content --input '{"scopeKind":"event","scopeId":"<event-id>","limit":10}'
-geo-edge-esmeralda fixed --tool list_idea_links --input '{"limit":20}'
-geo-edge-esmeralda native --query 'MATCH (c:ContentItem) WHERE c.popupId = $popupId RETURN c.id AS id, c.title AS title, c.kind AS kind LIMIT 20'
+npx -y @geoprotocol/geo-edge-esmeralda-cli auth
+npx -y @geoprotocol/geo-edge-esmeralda-cli ontology
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool community_search --input '{"query":"housing coordination","limit":10}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool list_content --input '{"scopeKind":"event","scopeId":"<event-id>","limit":10}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool list_idea_links --input '{"limit":20}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli native --query 'MATCH (c:ContentItem) WHERE c.popupId = $popupId RETURN c.id AS id, c.title AS title, c.kind AS kind LIMIT 20'
 ```
 
 Load `references/setup.md` when configuring the CLI or installing the skill.

--- a/skills/geo-esmeralda/references/examples.md
+++ b/skills/geo-esmeralda/references/examples.md
@@ -1,0 +1,33 @@
+# Examples
+
+Create village content:
+
+```bash
+geo-edge-esmeralda create --event-id <event-id> --kind comment --client-request-id <stable-id> --content 'Several attendees connected the session to local-first data sharing.'
+geo-edge-esmeralda create --venue-id <venue-id> --kind note --client-request-id <stable-id> --content 'The side conversation after lunch focused on practical onboarding for new contributors.'
+geo-edge-esmeralda create --track-id <track-id> --kind essay --title 'Coordination notes from week one' --client-request-id <stable-id> --content 'A synthesis of what participants have been learning about shared infrastructure.'
+geo-edge-esmeralda create --kind project_pitch --title 'Mutual aid map' --client-request-id <stable-id> --content 'Looking for collaborators on an offline-capable resource map.'
+geo-edge-esmeralda create --event-id <event-id> --kind photo --file ./photo.jpg --client-request-id <stable-id> --content 'Whiteboard from the protocol design session.'
+```
+
+Community knowledge and relations:
+
+```bash
+geo-edge-esmeralda fixed --tool community_search --input '{"query":"housing coordination","limit":10}'
+geo-edge-esmeralda fixed --tool recent_messages --input '{"limit":10}'
+geo-edge-esmeralda fixed --tool list_content --input '{"scopeKind":"event","scopeId":"<event-id>","limit":10}'
+geo-edge-esmeralda fixed --tool get_event_content --input '{"eventId":"<event-id>","limit":20}'
+geo-edge-esmeralda fixed --tool list_idea_links --input '{"limit":20}'
+```
+
+Ontology:
+
+```bash
+geo-edge-esmeralda ontology
+```
+
+Native read-only query:
+
+```bash
+geo-edge-esmeralda native --query 'MATCH (c:ContentItem) WHERE c.popupId = $popupId RETURN c.id AS id, c.title AS title, c.kind AS kind LIMIT 20'
+```

--- a/skills/geo-esmeralda/references/examples.md
+++ b/skills/geo-esmeralda/references/examples.md
@@ -3,31 +3,31 @@
 Create village content:
 
 ```bash
-geo-edge-esmeralda create --event-id <event-id> --kind comment --client-request-id <stable-id> --content 'Several attendees connected the session to local-first data sharing.'
-geo-edge-esmeralda create --venue-id <venue-id> --kind note --client-request-id <stable-id> --content 'The side conversation after lunch focused on practical onboarding for new contributors.'
-geo-edge-esmeralda create --track-id <track-id> --kind essay --title 'Coordination notes from week one' --client-request-id <stable-id> --content 'A synthesis of what participants have been learning about shared infrastructure.'
-geo-edge-esmeralda create --kind project_pitch --title 'Mutual aid map' --client-request-id <stable-id> --content 'Looking for collaborators on an offline-capable resource map.'
-geo-edge-esmeralda create --event-id <event-id> --kind photo --file ./photo.jpg --client-request-id <stable-id> --content 'Whiteboard from the protocol design session.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --event-id <event-id> --kind comment --client-request-id <stable-id> --content 'Several attendees connected the session to local-first data sharing.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --venue-id <venue-id> --kind note --client-request-id <stable-id> --content 'The side conversation after lunch focused on practical onboarding for new contributors.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --track-id <track-id> --kind essay --title 'Coordination notes from week one' --client-request-id <stable-id> --content 'A synthesis of what participants have been learning about shared infrastructure.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --kind project_pitch --title 'Mutual aid map' --client-request-id <stable-id> --content 'Looking for collaborators on an offline-capable resource map.'
+npx -y @geoprotocol/geo-edge-esmeralda-cli create --event-id <event-id> --kind photo --file ./photo.jpg --client-request-id <stable-id> --content 'Whiteboard from the protocol design session.'
 ```
 
 Community knowledge and relations:
 
 ```bash
-geo-edge-esmeralda fixed --tool community_search --input '{"query":"housing coordination","limit":10}'
-geo-edge-esmeralda fixed --tool recent_messages --input '{"limit":10}'
-geo-edge-esmeralda fixed --tool list_content --input '{"scopeKind":"event","scopeId":"<event-id>","limit":10}'
-geo-edge-esmeralda fixed --tool get_event_content --input '{"eventId":"<event-id>","limit":20}'
-geo-edge-esmeralda fixed --tool list_idea_links --input '{"limit":20}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool community_search --input '{"query":"housing coordination","limit":10}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool recent_messages --input '{"limit":10}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool list_content --input '{"scopeKind":"event","scopeId":"<event-id>","limit":10}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool get_event_content --input '{"eventId":"<event-id>","limit":20}'
+npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool list_idea_links --input '{"limit":20}'
 ```
 
 Ontology:
 
 ```bash
-geo-edge-esmeralda ontology
+npx -y @geoprotocol/geo-edge-esmeralda-cli ontology
 ```
 
 Native read-only query:
 
 ```bash
-geo-edge-esmeralda native --query 'MATCH (c:ContentItem) WHERE c.popupId = $popupId RETURN c.id AS id, c.title AS title, c.kind AS kind LIMIT 20'
+npx -y @geoprotocol/geo-edge-esmeralda-cli native --query 'MATCH (c:ContentItem) WHERE c.popupId = $popupId RETURN c.id AS id, c.title AS title, c.kind AS kind LIMIT 20'
 ```

--- a/skills/geo-esmeralda/references/ontology.md
+++ b/skills/geo-esmeralda/references/ontology.md
@@ -1,0 +1,24 @@
+# Ontology Guidance
+
+Prefer live ontology:
+
+```bash
+geo-edge-esmeralda ontology
+```
+
+The ontology response lists node labels, fields, relationship triples, fixed
+tools, and native-query constraints. Use it as the source of truth for native
+query construction.
+
+Important v2 native-query constraints:
+
+- Use one read-only `MATCH ... RETURN ... LIMIT ...` statement.
+- Include `$popupId`; the server controls the parameter value.
+- Filter popup-scoped labels with `n.popupId = $popupId`.
+- Filter `Popup`, `Track`, `Event`, and `Venue` rows with `hidden = false`.
+- Keep `WHERE` to top-level `AND`-joined scalar comparisons. Scope filters
+  must remain equality filters like `e.popupId = $popupId AND e.hidden = false`.
+- Return scalar fields, not whole nodes or `RETURN *`.
+- List fields keep `type=json` for compatibility and include
+  `nativeType=text[]`; they are returned as native arrays.
+- Do not use mutation, admin, import, vector procedure, or unbounded queries.

--- a/skills/geo-esmeralda/references/ontology.md
+++ b/skills/geo-esmeralda/references/ontology.md
@@ -3,7 +3,7 @@
 Prefer live ontology:
 
 ```bash
-geo-edge-esmeralda ontology
+npx -y @geoprotocol/geo-edge-esmeralda-cli ontology
 ```
 
 The ontology response lists node labels, fields, relationship triples, fixed

--- a/skills/geo-esmeralda/references/setup.md
+++ b/skills/geo-esmeralda/references/setup.md
@@ -1,0 +1,24 @@
+# Setup
+
+The CLI is shipped as the public package
+`@geoprotocol/geo-edge-esmeralda-cli`. The AgentVillage installer creates a
+`geo-edge-esmeralda` wrapper in `$HOME/.local/bin` that runs the public package
+through Bun.
+
+Required configuration:
+
+```bash
+export EDGEOS_BEARER_TOKEN="..."          # Human session JWT for Geo knowledge graph access and content writes
+```
+
+Keep bearer tokens in environment/config only. `EDGEOS_API_TOKEN` is the
+service-token env var for EdgeOS sync and must not be used by attendee agents.
+
+Copy this folder into `~/.hermes/skills/` or include it through an external
+AgentSkills directory such as `~/.agents/skills`.
+
+Run an auth check first:
+
+```bash
+geo-edge-esmeralda auth
+```

--- a/skills/geo-esmeralda/references/setup.md
+++ b/skills/geo-esmeralda/references/setup.md
@@ -1,9 +1,8 @@
 # Setup
 
 The CLI is shipped as the public package
-`@geoprotocol/geo-edge-esmeralda-cli`. The AgentVillage installer creates a
-`geo-edge-esmeralda` wrapper in `$HOME/.local/bin` that runs the public package
-through Bun.
+`@geoprotocol/geo-edge-esmeralda-cli`. Run it with `npx` from any environment
+with Node 20+ and npm available.
 
 Required configuration:
 
@@ -11,8 +10,7 @@ Required configuration:
 export EDGEOS_BEARER_TOKEN="..."          # Human session JWT for Geo knowledge graph access and content writes
 ```
 
-Keep bearer tokens in environment/config only. `EDGEOS_API_TOKEN` is the
-service-token env var for EdgeOS sync and must not be used by attendee agents.
+Keep bearer tokens in environment/config only.
 
 Copy this folder into `~/.hermes/skills/` or include it through an external
 AgentSkills directory such as `~/.agents/skills`.
@@ -20,5 +18,5 @@ AgentSkills directory such as `~/.agents/skills`.
 Run an auth check first:
 
 ```bash
-geo-edge-esmeralda auth
+npx -y @geoprotocol/geo-edge-esmeralda-cli auth
 ```

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "agentvillage-skills",
   "name": "AgentVillage Skills",
-  "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-  "version": "1.3.0",
+  "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery.",
+  "version": "1.4.0",
   "skills": ["."]
 }

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -31,6 +31,7 @@ The `skills/` directory holds per-backend procedural knowledge. Today's active s
 - **`index-network`** (`skills/index-network/`) — Index Network protocol: profiles, signals, opportunities. Tools via MCP. **Session-start gate** (`bootstrap.md`) when `onboardingComplete: false`.
 - **`edgeos`** (`skills/edgeos/SKILL.md`) — EdgeOS API: events, attendee directory, wiki, newsletters. **No session-start gate.** Needs `$EDGEOS_API_KEY` and `$EDGEOS_BEARER_TOKEN`; if missing, follow SKILL.md and ask inline.
 - **`edge-esmeralda`** (`skills/edge-esmeralda/SKILL.md`) — Popup constants, directory semantics, curated wiki/website/newsletter. **No session-start gate.** Supplies `popup_id` for `edgeos` and community-knowledge answers.
+- **`geo-esmeralda`** (`skills/geo-esmeralda/SKILL.md`) — Geo knowledge graph: community content, relations, ontology, and attendee-authored writes. **No session-start gate.** Needs `$EDGEOS_BEARER_TOKEN`; if missing, follow SKILL.md and ask inline.
 
 When a future skill ships, list it here with gate type and trigger conditions.
 


### PR DESCRIPTION
## Summary
- add the geo-esmeralda skill under skills/ so it syncs into agentvillage-skills
- document Geo knowledge graph auth, write flows, ontology, and read examples
- update skill bundle manifests, install docs, and workspace active-skill guidance
- use npx to run the public Node-native Geo CLI package directly, avoiding PATH-dependent wrappers

## Commits
- cfa494a Add geo esmeralda skill
- 3b52535 Address Geo CLI review

## Validation
- parsed skill JSON manifests successfully
- ran installer against temp HOME/HERMES_HOME with --no-restart and verified geo-esmeralda was copied, EDGEOS_BEARER_TOKEN was written, and no wrapper was created
- verified no executable recipe starts with bare geo-edge-esmeralda
- ran npx -y @geoprotocol/geo-edge-esmeralda-cli --help successfully with a temp npm cache
