### PR TITLE
Fix installer skipping cron creation when hermes is on PATH

### DIFF
--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -167,12 +167,27 @@ export function resolveCronSchedule(
   return override;
 }
 
+/**
+ * Probe whether the Hermes CLI can actually run. `hermesBin()` falls back to the
+ * bare name `"hermes"` when it finds no fixed-path binary, but that name still
+ * resolves on PATH (the augmented env adds ~/.local/bin etc.). So test by
+ * executing `hermes --version` rather than string-comparing the resolved name.
+ */
+function hermesAvailable(bin: string): boolean {
+  try {
+    execFileSync(bin, ["--version"], { stdio: "ignore", env: hermesExecEnv() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function installCronJobs(env: NodeJS.ProcessEnv): void {
   const home = hermesHome();
   const promptsDir = join(home, "skills/index-network/prompts");
 
   const bin = hermesBin();
-  if (bin === "hermes") {
+  if (!hermesAvailable(bin)) {
     console.warn("  warning: hermes CLI not found — skipping digest crons");
     return;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Follow-up fix to the digest prepare/send change (0.2.0).

## Bug
`installCronJobs` guarded on `bin === "hermes"` to decide the CLI was missing. But `hermesBin()` returns the bare name `"hermes"` as its fallback whenever it finds no binary at a fixed candidate path (`/opt/hermes/.venv/bin`, `/usr/local/bin`) and `HERMES_BIN` is unset — even though `hermes` is perfectly reachable on `PATH`. On a standard PATH install (e.g. `~/.local/bin/hermes`) the guard wrongly concluded "hermes CLI not found" and **skipped installing the digest crons entirely**. Confirmed on a real local install.

## Fix
Replace the string compare with an actual executability probe: run `hermes --version` through the augmented exec env (which already adds `~/.local/bin` etc.). Only skip cron creation if that genuinely fails.

## Files
- `install/install_index.ts` — add `hermesAvailable(bin)`; guard on it instead of `bin === "hermes"`.
- `package.json` — 0.2.0 → 0.2.1.

Validated by re-running the installer on a PATH-based Hermes: crons now install (`Edge — digest prepare` `0 2 * * *`, `Edge — daily digest` `0 8 * * *`).