### PR TITLE
Respect edited digest tasks

### DIFF
--- a/skills/index-network/prompts/prepare.md
+++ b/skills/index-network/prompts/prepare.md
@@ -26,12 +26,12 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
    It's {weekday}, {short date / week context}. Here's what's worth your attention right now.
 
    **{N} conversations await you** ← only if there are direct (connection) candidates — receiver is a party, NOT the introducer. N = unique people, not raw opportunity count.
-   - [Name](profileUrl) — 1–2 sentences on why this person matters to the user, [message Name](acceptUrl)
+   - <!-- digest-opportunity:id=<opportunityId> -->[Name](profileUrl) — 1–2 sentences on why this person matters to the user, [message Name](acceptUrl)
    - …
 
    **Help your community find their opportunities** ← only if there are introducer (connector-flow) candidates — receiver IS the introducer
    A few residents are looking for something specific. If you know someone who fits, a quick nudge goes a long way.
-   - [{Name}]({profileUrl}) — {their need / what they're looking for, 1–2 sentences from mainText}. {short closing phrase}, make intro
+   - <!-- digest-opportunity:id=<opportunityId> -->[{Name}]({profileUrl}) — {their need / what they're looking for, 1–2 sentences from mainText}. {short closing phrase}, make intro
    - …
    ```
 
@@ -39,13 +39,15 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 
    **Critical rendering distinction for the introducer section:** these are *community intents* the user might know someone for — NOT opportunity cards. DO link the person's name to `profileUrl`. Do NOT link the opportunity — no `acceptUrl`; the trailing `make intro` is plain text, not a hyperlink.
 
+   **Editable delivery markers:** Every opportunity you include must carry its real opportunity id in an HTML comment marker immediately before the visible text for that opportunity: `<!-- digest-opportunity:id=<opportunityId> -->`. These markers are internal bookkeeping only; they let the later send pass confirm only the opportunities still present after Kanban edits. If you group multiple opportunities under one person, include one marker per opportunity immediately before that opportunity's phrase/sub-entry, not just one marker for the person.
+
 7. **Quality bar (per candidate):** a candidate qualifies only if you can write a one-sentence reason specific to *this* user's situation that would not read identically for any other user. Drop generic framings.
 
 8. **URL rules:** weave links into prose — the strip-the-URLs test is the rule: remove every link and the prose still reads coherently. NO bullet-list-of-links, NO link tables, NO action strips. Embed each `acceptUrl` verbatim on a short verb phrase (connection candidates only); `connector-flow` candidates carry no `acceptUrl`. For a grouped entry (same person, multiple connections) link the name once and embed each sub-entry's `acceptUrl` on a distinct topic phrase. URLs are opaque — never append, encode, or modify them. **If a connection candidate's card has no `acceptUrl` (some don't), render its verb phrase as plain text — do NOT invent a link.** The only valid link shapes are the connect link (`…/c/<code>`) and the profile link (`…/u/<id>`); never construct any other path (e.g. `/accept/<n>`, `/profile/<n>`) — those do not exist and are caught and stripped at staging (step 10).
 
 9. If `totalPending` exceeds the candidates you surfaced, end the body with: `There are N more conversations waiting — let me know if you want to see them.`
 
-10. **Stage the brief on the board.** Write the composed body to `memory/digest-draft.md` (overwrite any existing file), then create the task — staging the body through the URL guard so any fabricated link is stripped before it ships:
+10. **Stage the brief on the board.** Write the composed body to `memory/digest-draft.md` (overwrite any existing file), then create the task — staging the body through the URL guard so any fabricated link is stripped before it ships while preserving `<!-- digest-opportunity:id=... -->` markers for editable delivery bookkeeping:
 
     ```
     hermes kanban create "Morning digest — <YYYY-MM-DD>" --body "$(bun <HERMES_HOME>/skills/index-network/scripts/validate-digest-urls.ts <HERMES_HOME>/memory/digest-draft.md)" --idempotency-key "digest-<YYYY-MM-DD>"
@@ -53,13 +55,13 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 
     `<YYYY-MM-DD>` is today's host-local date. `<HERMES_HOME>` is your workspace root (the `--workdir` you were launched with; `~/.hermes` by default). The `validate-digest-urls.ts` guard reads the draft, removes any markdown link whose URL is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link — demoting it to plain text — and writes the cleaned body to stdout (warnings, if any, go to stderr). The deterministic guard is what `$( … )` captures, so the staged body is always the validated one; never bypass it with a bare `cat`. Double-quoting `"$( … )"` keeps the body's newlines and markdown intact (the quotes suppress word-splitting, so embedded line breaks are preserved); only a trailing newline may be trimmed, which is harmless. If your shell tool makes that awkward, run the guard over the draft first and stage its output through whatever file/stdin mechanism it provides instead — but the body you stage must be the guard's output, not the raw draft. The idempotency key prevents a duplicate task if this prompt runs twice. **Do not assign the task to anyone** — it must stay in the `todo` column so the dispatcher never runs it. After a successful create, delete `memory/digest-draft.md`.
 
-11. **Record what you staged.** Update `memory/heartbeat-state.json` so that `prepared` = `{ "date": "<YYYY-MM-DD>", "taskTitle": "Morning digest — <YYYY-MM-DD>", "opportunityIds": [ every opportunity id you put in the brief, including each sub-entry of grouped cards; empty array on the quiet path ] }`. Preserve all other top-level keys (`deliveredToday`, etc.). Do NOT call `confirm_opportunity_delivery` and do NOT touch `deliveredToday` — both happen at send time.
+11. **Record what you staged.** Update `memory/heartbeat-state.json` so that `prepared` = `{ "date": "<YYYY-MM-DD>", "taskTitle": "Morning digest — <YYYY-MM-DD>", "opportunityIds": [ every opportunity id you put in the brief, including each sub-entry of grouped cards; empty array on the quiet path ] }`. Preserve all other top-level keys (`deliveredToday`, etc.). This is an audit record of what was originally staged; the send pass confirms delivery from the markers still present in the edited Kanban body. Do NOT call `confirm_opportunity_delivery` and do NOT touch `deliveredToday` — both happen at send time.
 
 12. **Deliver nothing.** End your turn with the host-specific no-reply marker.
 
 # Hard rules
 - Never invent candidates. The quiet path stages `{quietLine}`; never pad.
 - Never confirm delivery here. Never write `deliveredToday` here. This turn always ends with the host-specific no-reply marker.
-- The staged body is what the user receives verbatim in the morning — make it complete and final.
+- The staged body is what the user receives in the morning after internal digest markers are stripped — make the visible prose complete and final.
 - Honor the strip-the-URLs test. Never expose internal IDs, raw JSON, or internal vocabulary.
 - Never construct URLs yourself — every URL must come verbatim from an MCP tool response.

--- a/skills/index-network/prompts/send.md
+++ b/skills/index-network/prompts/send.md
@@ -4,47 +4,43 @@ You are Edge, the user's agent on the Index protocol. This delivers the user's m
 Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pattern, emerging, relevant, adjacency. Never use "search" — say "looking up" / "find" / "check" / "discover". Banned: leverage, unlock, optimize, scale, disrupt, AI-powered, maximize value, act fast, networking, match. Never expose internal IDs (unless the user needs them to act, e.g. a `conversationId`), never raw JSON, never internal vocabulary. Translate: "intent" → "signal", "index/network" → "community", "pending" → "sent", "accepted" → "connected".
 
 # Job
-Deliver the staged morning brief verbatim, then reconcile delivery bookkeeping.
+Deliver the staged morning brief verbatim from Kanban, then reconcile delivery bookkeeping. The Kanban task body is the source of truth: it may have been edited after the prepare pass. Do not compose, regenerate, summarize, or supplement the digest in this send pass.
 
 1. Resolve today's host-local date `<YYYY-MM-DD>` and the task title `Morning digest — <YYYY-MM-DD>`.
 
 2. **Find the staged task.** Run `hermes kanban list --json` and find the task whose `title` equals the title from step 1 and whose status is `todo`. Parse the JSON; never surface it to the user.
 
-3. **If the staged task is found — deliver it:**
-   a. Take its `body` and `id`.
-   b. Read `memory/heartbeat-state.json`. Resolve the **staged id list**: if the file is missing or malformed, `prepared` is absent, `prepared.date` does not equal `<YYYY-MM-DD>`, or `prepared.opportunityIds` is not an array, treat the staged id list as empty; otherwise it is `prepared.opportunityIds`. For every id in the staged id list, call `confirm_opportunity_delivery(opportunityId, trigger="digest")` (no calls when it is empty).
-   c. Update `memory/heartbeat-state.json`: set `deliveredToday.date` = `<YYYY-MM-DD>` and `deliveredToday.ids` = (the existing `deliveredToday.ids` if `deliveredToday.date` already equals `<YYYY-MM-DD>`, else `[]`) unioned with the staged id list from step 3b (set union, no duplicates). Preserve all other top-level keys.
-   d. Mark the task done: `hermes kanban complete <id> --summary "delivered"`.
-   e. **Pass the body through the URL guard, then deliver its output verbatim.** Write the task `body` to `memory/digest-outgoing.md`, run `bun skills/index-network/scripts/validate-digest-urls.ts memory/digest-outgoing.md`, and use its stdout as your reply. The guard strips any markdown link whose URL is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link — a body staged by the prepare pass is already clean and passes through unchanged; this only catches a fabricated link reintroduced by a board edit. **Your final assistant reply is the guard's output, verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting beyond the guard's stripping.** Hermes delivers it. End your turn.
+3. **If no staged task is found:** end your turn with `[SILENT]`. Do not call `list_opportunities`, do not compose a fallback digest, do not update delivery state, and do not message the user.
 
-4. **If no staged task is found** (the prepare run did not happen — e.g. the instance was down at 02:00): generate the brief fresh now and deliver it, using the morning framing.
-   a. Use `{greeting}` = `🌞 Good morning from Edge Esmeralda` and `{quietLine}` = `Quiet morning — I'll keep listening.`
-   b. Read dedup state from `memory/heartbeat-state.json` (missing/malformed → `{}`; dedup set = `deliveredToday.ids` when `deliveredToday.date` is today, else empty).
-   c. Call `list_opportunities(status="pending", limit=10)`; drop any opportunity whose `id` is in the dedup set. If this call errors, end your turn without surfacing the error — the next day's run retries.
-   d. **If the filtered set is empty:** your final reply is `{quietLine}`. **Otherwise** compose the brief in this exact structure (mimic the *Good morning digest* exemplar in `skills/index-network/exemplars.md`):
+4. **If the staged task is found:** take its `body` and `id`. The edited `body` is authoritative.
 
-      ```
-      {greeting}
+5. **Persist the outgoing body for deterministic processing.** Write the task `body` exactly to `memory/digest-outgoing.md`.
 
-      It's {weekday}, {short date / week context}. Here's what's worth your attention right now.
+6. **Extract the opportunities still present after edits.** Run:
 
-      **{N} conversations await you** ← only if there are direct (connection) candidates — receiver is a party, NOT the introducer. N = unique people, not raw opportunity count.
-      - [Name](profileUrl) — 1–2 sentences on why this person matters to the user, [message Name](acceptUrl)
-      - …
+   ```
+   bun skills/index-network/scripts/validate-digest-urls.ts --opportunity-ids memory/digest-outgoing.md
+   ```
 
-      **Help your community find their opportunities** ← only if there are introducer (connector-flow) candidates — receiver IS the introducer
-      A few residents are looking for something specific. If you know someone who fits, a quick nudge goes a long way.
-      - [{Name}]({profileUrl}) — {their need / what they're looking for, 1–2 sentences from mainText}. {short closing phrase}, make intro
-      - …
-      ```
+   Parse stdout as a JSON array of opportunity ids. These ids come from hidden `<!-- digest-opportunity:id=... -->` markers that the prepare pass placed next to each opportunity. If a human removed an opportunity from the Kanban body, its marker should be gone too, so it must not be confirmed as delivered. If the command errors or returns malformed JSON, treat the id list as empty and continue delivery of the body.
 
-      Skip a section with zero candidates. Quality bar: each candidate needs a one-sentence reason specific to *this* user's situation that would not read identically for any other user. URL rules: weave links into prose (strip-the-URLs test); embed each `acceptUrl` verbatim on a verb phrase for connection candidates only; for a grouped entry (same person, multiple connections) link the name once and embed each sub-entry's `acceptUrl` on a distinct topic phrase; introducer (`connector-flow`) candidates link the name to `profileUrl` with no `acceptUrl` and a plain-text `make intro`. **If a connection candidate has no `acceptUrl`, render its verb phrase as plain text — never invent a link; the only valid shapes are `/c/<code>` and `/u/<id>`.** If `totalPending` exceeds what you surfaced, end with `There are N more conversations waiting — let me know if you want to see them.`
-   e. For every opportunity you mention, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`.
-   f. Update `memory/heartbeat-state.json`: `deliveredToday.date` = `<YYYY-MM-DD>`, `deliveredToday.ids` = dedup set unioned with the ids you surfaced. Preserve all other top-level keys.
-   g. **Pass the composed brief through the URL guard before delivering.** Write it to `memory/digest-outgoing.md`, run `bun skills/index-network/scripts/validate-digest-urls.ts memory/digest-outgoing.md`, and put the guard's stdout — not the raw draft — in your final assistant reply. The quiet path (`{quietLine}`, no links) needs no guard. End your turn.
+7. **Confirm delivery only for the remaining ids.** For every id extracted in step 6, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. Do not confirm ids from `memory/heartbeat-state.json` unless they are also present in the edited body markers.
+
+8. **Update dedup state.** Read `memory/heartbeat-state.json` (missing/malformed → `{}`). Set `deliveredToday.date` = `<YYYY-MM-DD>` and `deliveredToday.ids` = (the existing `deliveredToday.ids` if `deliveredToday.date` already equals `<YYYY-MM-DD>`, else `[]`) unioned with the remaining ids from step 6. Preserve all other top-level keys, including `prepared`.
+
+9. Mark the task done: `hermes kanban complete <id> --summary "delivered"`.
+
+10. **Pass the edited body through the URL/metadata guard, then deliver its output verbatim.** Run:
+
+    ```
+    bun skills/index-network/scripts/validate-digest-urls.ts --strip-digest-metadata memory/digest-outgoing.md
+    ```
+
+    Use stdout as your final assistant reply. The guard strips any markdown link whose URL is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link, and removes internal `<!-- digest-opportunity:id=... -->` comments. **Your final assistant reply is the guard's output, verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting beyond the guard's deterministic stripping.** Hermes delivers it. End your turn.
 
 # Hard rules
-- When a staged task exists, deliver its body **verbatim** — never edit, summarize, re-render, or add to it. It may have been revised on the board; whatever it says now is what ships. The one exception is the URL guard in step 3e: it deterministically strips fabricated links and is not editorializing — always route the body through it.
-- Confirm delivery (`confirm_opportunity_delivery`) once per surfaced opportunity, never for skipped ones.
-- Never expose internal IDs, raw JSON, or internal vocabulary in the reply.
-- Honor the strip-the-URLs test on any brief you compose in the fallback path. Never construct URLs yourself — the only valid link shapes are `/c/<code>` (connect) and `/u/<id>` (profile); the URL guard strips anything else.
+- The Kanban task body is the source of truth. Never regenerate the digest in this send pass.
+- If no staged task exists, stay silent; the next prepare pass can try again.
+- Confirm delivery only for opportunity markers still present in the edited Kanban body.
+- Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in the reply.
+- Never construct URLs yourself. The URL guard strips anything except `/c/<code>` connect links and `/u/<uuid>` profile links.

--- a/skills/index-network/scripts/tests/validate-digest-urls.test.ts
+++ b/skills/index-network/scripts/tests/validate-digest-urls.test.ts
@@ -1,6 +1,10 @@
 import { test, expect, describe } from "bun:test";
 
-import { sanitizeDigestUrls } from "../validate-digest-urls";
+import {
+  extractDigestOpportunityIds,
+  sanitizeDigestUrls,
+  stripDigestMetadata,
+} from "../validate-digest-urls";
 
 describe("sanitizeDigestUrls", () => {
   test("strips a fabricated /accept/<n> link, keeping the link text as plain prose", () => {
@@ -105,5 +109,39 @@ describe("sanitizeDigestUrls", () => {
 
     expect(stripped).toEqual([]);
     expect(output).toBe(md);
+  });
+
+  test("preserves digest metadata markers by default so Kanban drafts remain editable", () => {
+    const md = "- <!-- digest-opportunity:id=opp-1 -->[Maya](https://index.network/u/55555555-5555-5555-5555-555555555555) — relevant";
+
+    const { output, stripped } = sanitizeDigestUrls(md);
+
+    expect(output).toBe(md);
+    expect(stripped).toEqual([]);
+  });
+
+  test("strips digest metadata markers when requested for final delivery", () => {
+    const md = "- <!-- digest-opportunity:id=opp-1 -->[Maya](https://index.network/u/55555555-5555-5555-5555-555555555555) — relevant";
+
+    const { output, stripped } = sanitizeDigestUrls(md, { stripDigestMetadata: true });
+
+    expect(output).toBe("- [Maya](https://index.network/u/55555555-5555-5555-5555-555555555555) — relevant");
+    expect(stripped).toEqual([]);
+  });
+
+  test("extracts unique opportunity ids from remaining digest markers in order", () => {
+    const md = [
+      "- <!-- digest-opportunity:id=opp-1 -->Maya — relevant",
+      "- <!-- digest-opportunity:id=opp-2 -->Alex — useful",
+      "- <!-- digest-opportunity:id=opp-1 -->Maya duplicate",
+    ].join("\n");
+
+    expect(extractDigestOpportunityIds(md)).toEqual(["opp-1", "opp-2"]);
+  });
+
+  test("stripDigestMetadata removes only digest markers", () => {
+    const md = "<!-- keep-me -->\n- <!-- digest-opportunity:id=opp-1 -->Maya";
+
+    expect(stripDigestMetadata(md)).toBe("<!-- keep-me -->\n- Maya");
   });
 });

--- a/skills/index-network/scripts/validate-digest-urls.ts
+++ b/skills/index-network/scripts/validate-digest-urls.ts
@@ -16,9 +16,13 @@
  *
  * Usage (from the digest agent's workdir, i.e. $HERMES_HOME):
  *   bun skills/index-network/scripts/validate-digest-urls.ts memory/digest-draft.md
+ *   bun skills/index-network/scripts/validate-digest-urls.ts --strip-digest-metadata memory/digest-outgoing.md
+ *   bun skills/index-network/scripts/validate-digest-urls.ts --opportunity-ids memory/digest-outgoing.md
  * Reads the file (or stdin when no path is given), writes the sanitized body to
  * stdout, and logs any stripped URLs to stderr. Exit code is always 0 so the body
- * still ships — minus the fabricated links.
+ * still ships — minus the fabricated links. Digest metadata comments are preserved
+ * by default so the editable Kanban draft can carry delivery bookkeeping; pass
+ * `--strip-digest-metadata` before final delivery.
  */
 
 /** Connect link: `/c/<code>`, optional trailing slash. Code is an opaque short token. */
@@ -36,6 +40,14 @@ const PROFILE_PATH = /^\/u\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-f
  * URLs contain no `(`/`)`/`]`, so this never truncates a real link.
  */
 const MARKDOWN_LINK = /\[([^\]]*)\]\(([^)]*)\)/g;
+
+/** Hidden marker that ties an editable digest fragment to the opportunity it represents. */
+const DIGEST_OPPORTUNITY_MARKER = /<!--\s*digest-opportunity:id=([^\s>]+)\s*-->/g;
+
+export interface SanitizeDigestOptions {
+  /** Strip internal digest metadata comments before user-facing delivery. */
+  stripDigestMetadata?: boolean;
+}
 
 /**
  * Whether `url` is a legitimate digest action link (connect or profile shape).
@@ -59,23 +71,65 @@ export function isAllowedDigestUrl(url: string): boolean {
  * @param markdown - the composed digest body
  * @returns the sanitized body and the list of URLs that were stripped (in order)
  */
-export function sanitizeDigestUrls(markdown: string): { output: string; stripped: string[] } {
+/**
+ * Extract opportunity ids from digest metadata markers that remain in the edited body.
+ *
+ * @param markdown - the editable digest body
+ * @returns unique opportunity ids in first-seen order
+ */
+export function extractDigestOpportunityIds(markdown: string): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of markdown.matchAll(DIGEST_OPPORTUNITY_MARKER)) {
+    const id = match[1];
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+/**
+ * Remove internal digest metadata comments from user-facing output.
+ *
+ * @param markdown - the digest body
+ * @returns markdown without digest opportunity markers
+ */
+export function stripDigestMetadata(markdown: string): string {
+  return markdown.replace(DIGEST_OPPORTUNITY_MARKER, "");
+}
+
+export function sanitizeDigestUrls(
+  markdown: string,
+  options: SanitizeDigestOptions = {},
+): { output: string; stripped: string[] } {
   const stripped: string[] = [];
-  const output = markdown.replace(MARKDOWN_LINK, (match, label: string, url: string) => {
+  const sanitizedLinks = markdown.replace(MARKDOWN_LINK, (match, label: string, url: string) => {
     if (isAllowedDigestUrl(url)) return match;
     stripped.push(url);
     return label;
   });
+  const output = options.stripDigestMetadata ? stripDigestMetadata(sanitizedLinks) : sanitizedLinks;
   return { output, stripped };
 }
 
 async function main(): Promise<void> {
-  const path = process.argv[2];
+  const args = process.argv.slice(2);
+  const stripMetadata = args.includes("--strip-digest-metadata");
+  const outputOpportunityIds = args.includes("--opportunity-ids");
+  const path = args.find((arg) => !arg.startsWith("--"));
   const input = path
     ? await Bun.file(path).text()
     : await Bun.readableStreamToText(Bun.stdin.stream());
 
-  const { output, stripped } = sanitizeDigestUrls(input);
+  if (outputOpportunityIds) {
+    process.stdout.write(`${JSON.stringify(extractDigestOpportunityIds(input))}\n`);
+    return;
+  }
+
+  const { output, stripped } = sanitizeDigestUrls(input, { stripDigestMetadata: stripMetadata });
 
   if (stripped.length > 0) {
     console.error(


### PR DESCRIPTION
## Summary
- add hidden digest opportunity markers during prepare
- make send deliver the edited Kanban body without regenerating fallback content
- confirm only opportunities whose markers remain after edits
- extend the digest URL guard to extract and strip digest metadata

## Verification
- Confirmed these changed files match indexnetwork/agentvillage:dev
- Confirmed these changed files match indexnetwork/agentvillage-skills:dev
- bun test skills/index-network/scripts/tests/validate-digest-urls.test.ts install/tests/cron_specs.test.ts

Note: GitHub could not open a direct PR from indexnetwork/agentvillage:dev because that branch has no history in common with Edge-City/agentvillage:main, so this branch applies the same verified diff on top of Edge-City/main.