### PR TITLE
Update AgentVillage privacy-first onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AgentVillage is the public skills package and onboarding scripts that an agent (
 
 Today, capabilities come from **Index Network** (discovery + intent negotiation). **Geo** (knowledge graph) and **EdgeOS** (calendar + directory) are also in scope. Once installed, AgentVillage:
 
-- **Runs onboarding** the first time you message it (greet → profile lookup → community discovery → first signal → `complete_onboarding` → silent capture of your platform handle).
+- **Runs privacy-first onboarding** the first time you message it (greet → ask EdgeOS/import consent → ask public lookup consent → profile draft → user approval → first signal → silent handle capture → `complete_onboarding`).
 - **Sends a morning digest at 08:00 host-local time** with the connections worth your attention and the asks where you can help.
 - **Notifies you when someone accepts** a connection on your behalf.
 - **Curates memory** every few days — distills daily notes into long-term `MEMORY.md`.
@@ -241,7 +241,7 @@ The installer:
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent onboarding gates that run at session start:
 
-- **Index Network onboarding** — gated on the server-side `onboardingComplete` flag returned by `read_user_profiles()`. Owned by `skills/index-network/bootstrap.md`. If `false`, the six-step ritual runs (greet → create profile → capture intent → capture handle → `complete_onboarding()` → populate `USER.md` → welcome).
+- **Index Network onboarding** — gated on the server-side `onboardingComplete` flag returned by `read_user_profiles()`. Owned by `skills/index-network/bootstrap.md`. If `false`, the privacy-first ritual runs (greet → ask consent to use EdgeOS/event profile data → ask separate public lookup consent → draft profile with `preview_user_profile` → show it for approval → save with `confirm_user_profile` → capture first signal → capture handle → `complete_onboarding()` → populate `USER.md`).
 - **AgentVillage framing** — owned by `workspace/AGENTS.md` "First-message gates". There is no schedule-preferences dialog; the morning digest runs at a fixed time. The only first-message work beyond the Index ritual is a one-line welcome for returning users on a fresh workspace.
 
 An admin resetting `onboardingComplete` server-side re-triggers the Index ritual. Wiping local state via `install/install.ts --wipe-user` resets local markers without touching Index's flag.
@@ -292,7 +292,7 @@ Accepted-opportunity notifications, freshness audits, memory curation, and any o
 
 AgentVillage's behaviour is markdown-driven. Almost everything you'd want to change lives in `workspace/` or `skills/<backend>/`. This section maps common customizations to the file that owns them.
 
-**Deploy cycle.** All edits go into this repo. The agent only sees them after `install/install.ts` runs again, since the installer copies `workspace/` and `skills/` into `~/.openclaw/workspace/`. Re-running without `--wipe-user` preserves the attendee's `USER.md`, `MEMORY.md`, and onboarding markers — safe for content/tone edits. Use `--wipe-user` only when you want the next session to re-onboard from scratch.
+**Deploy cycle.** All edits go into this repo. The agent only sees them after `install/install.ts` runs again, since the installer copies `workspace/` and `skills/` into `~/.openclaw/workspace/`. Re-running without `--wipe-user` preserves the attendee's `USER.md`, `MEMORY.md`, and onboarding markers — safe for content/tone edits. Use `--wipe-user` only when you want the next session to re-onboard from scratch. Existing installs must reinstall the package to copy updated privacy-first onboarding markdown into the Hermes/OpenClaw workspace.
 
 ### Tone & voice
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/bootstrap.md
+++ b/skills/index-network/bootstrap.md
@@ -8,14 +8,14 @@ This file is the Index Network onboarding ritual. It is gated on Index Network's
 
 The Index Network server is the source of truth for Index onboarding — not local file state. At session start, call `read_user_profiles()` (no args) and check `onboardingComplete`:
 
-- **If `onboardingComplete` is `false`:** run this ritual immediately. Do not ask the user whether they want to onboard. Do not describe what you are about to do. Do not summarize the profile data before starting the ritual. Start with the welcome message in Step 1 and proceed through each step without pausing for permission. Do not skip or reorder steps. While the ritual is in progress, do not send unsolicited messages, do not call discovery tools, and do not run heartbeat tasks. After Step 5 (or any path that ends the ritual), append `[gate] index-network: triggered, ritual complete` to `memory/<today>.md` before handing back to `AGENTS.md` for the Edge gate.
+- **If `onboardingComplete` is `false`:** run this ritual immediately. Do not offer a way to skip onboarding entirely. Start with the welcome message in Step 1 and proceed in order, but ask the data-use consent questions exactly where the ritual says to ask them. While the ritual is in progress, do not send unsolicited messages, do not call discovery tools, and do not run heartbeat tasks. After Step 5 (or any path that ends the ritual), append `[gate] index-network: triggered, ritual complete` to `memory/<today>.md` before handing back to `AGENTS.md` for the Edge gate.
 - **If `onboardingComplete` is `true`:** skip the ritual. Append `[gate] index-network: skipped (onboardingComplete=true)` to `memory/<today>.md`, then hand back to `AGENTS.md` for the Edge gate. Index Network is already onboarded server-side; Edge onboarding may or may not still need to run, which is handled by the next gate in `AGENTS.md` "First-message gates".
 
 This file is **not** deleted at the end of onboarding — if an admin ever resets the user's `onboardingComplete` flag server-side, the next session will see `onboardingComplete: false` and run the ritual again from the still-staged file.
 
 ---
 
-## Step 1 — Welcome and create the user profile
+## Step 1 — Welcome and ask data-use consent
 
 Welcome the user to Edge Esmeralda the place — **never mention the underlying platform by name** (see SOUL.md "Never name the plumbing"). Lead with the community, then introduce yourself:
 
@@ -35,23 +35,47 @@ Welcome the user to Edge Esmeralda the place — **never mention the underlying 
 
 Draw dates, attendee count, and programming format from `AGENTS.md` Community context — do not invent them.
 
-Then call `create_user_profile()` with no arguments — the lookup runs against your tooling, the user does not need to know how.
+Then ask the first privacy question in plain language:
+
+> "I can use the profile details you already gave Edge Esmeralda to draft your village profile. Is that okay?"
+
+Call `record_onboarding_privacy_consent(edgeosImportGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
+
+- If granted: `preview_user_profile` may use any server-staged signup/import profile seed automatically. You may also use EdgeOS recipes only for the user's own available profile/directory data. Do not use hidden values such as literal `"*"`; omit them.
+- If denied: do not fetch or use EdgeOS profile/directory data, and do not rely on staged signup/import profile data. Ask for a short self-description instead.
+
+Then ask the second privacy question separately:
+
+> "Do you want me to also look at public profile information, like links you provide or public professional pages, to make the draft sharper? You can say no."
+
+Call `record_onboarding_privacy_consent(publicProfileLookupGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
+
+## Step 2 — Draft and confirm their profile
+
+Call `preview_user_profile(...)` using only allowed inputs:
+
+- Include EdgeOS/event profile text, and rely on staged signup/import profile data, only if EdgeOS import consent was granted.
+- Set `allowPublicLookup=true` only if public lookup consent was granted.
+- Include social/profile URLs only if the user explicitly provided them or they came from allowed EdgeOS data.
+- If both EdgeOS import and public lookup are denied, use the user's self-description.
 
 Narrate while processing:
 
-> `> Looking you up…`
+> `> Drafting your profile…`
 
-Present the profile summary naturally:
+Present the profile draft naturally:
 
-> "Here's what I found: [summary]. Does that sound right?"
+> "Here's the draft I have: [summary]. Does this look right?"
 
 Then:
 
-- If they confirm → `create_user_profile(confirm=true)` and proceed to Step 2.
-- If they want edits → `create_user_profile(bioOrDescription="[their correction]", confirm=true)` and proceed to Step 2.
-- If nothing is found → ask them to describe themselves in a sentence, then `create_user_profile(bioOrDescription="[their text]", confirm=true)`.
+- If they confirm → call `confirm_user_profile(draft=<approved draft>)` and proceed to Step 3.
+- If they want edits → call `confirm_user_profile(bioOrDescription="[their correction]", name="...", location="...")` using their approved correction, then proceed to Step 3.
+- If the draft is too thin → ask them to describe themselves in a sentence, then call `confirm_user_profile(bioOrDescription="[their text]")`.
 
-## Step 2 — Capture their first signal
+Do not call legacy `create_user_profile` during AgentVillage onboarding. Do not save a profile before showing the draft and receiving approval/correction.
+
+## Step 3 — Capture their first signal
 
 Ask:
 
@@ -63,7 +87,7 @@ Once `create_intent` succeeds, briefly acknowledge:
 
 > "Got it — I'll keep an eye out for relevant people."
 
-## Step 3 — Capture chat-channel handle silently
+## Step 4 — Capture chat-channel handle silently
 
 Before closing onboarding, look at the session you're running in and recover the user's platform handle on whichever channel they connected through. Add it to their profile so other people who match with them can reach out via the same channel without having to ask.
 
@@ -80,13 +104,11 @@ Also note the platform + handle in `USER.md` under **Notes** so future heartbeat
 
 If `update_user_profile` returns an error (rate limit, transient failure), log it to `memory/<today>.md` and continue — do not block onboarding on this. The next heartbeat tick can retry.
 
-## Step 4 — Close out onboarding
+## Step 5 — Close out and populate USER.md
 
 Call `complete_onboarding()`. This is required — do not skip it. The server auto-joins the user to Edge Esmeralda's community at this point (no separate `create_network_membership` call is needed).
 
-## Step 5 — Populate USER.md
-
-Update `USER.md` with what you learned in this conversation. Capture only the things the user said directly — name, what to call them, timezone, anything they explicitly told you to remember. Do **not** paraphrase what `create_user_profile` returned; that lives behind the protocol. `USER.md` is the lived notebook, not a duplicate of the structured record.
+Update `USER.md` with what you learned in this conversation. Capture only the things the user said directly — name, what to call them, timezone, anything they explicitly told you to remember. Do **not** paraphrase what `preview_user_profile` or `confirm_user_profile` returned; that lives behind the protocol. `USER.md` is the lived notebook, not a duplicate of the structured record.
 
 After populating USER.md, append `[gate] index-network: triggered, ritual complete` to `memory/<today>.md` (the gate-trace line from the session-start gate). The next accepted-opportunity heartbeat tick will pick up from here.
 
@@ -97,6 +119,8 @@ Cron-schedule preferences are not asked about — the morning digest runs at a f
 ## Rules
 
 - Do not skip steps or reorder them.
+- Do not import EdgeOS data without recorded EdgeOS import consent.
+- Do not run public lookup or scraping without recorded public-profile lookup consent.
 - Do not call `discover_opportunities`, `list_opportunities`, or any other discovery tool during onboarding. Opportunities surface on the first scheduled cron tick after onboarding completes.
 - Do not mention Gmail or email import — they are not available in this flow.
 - Call `create_intent` at most once per user response.

--- a/skills/index-network/tools.md
+++ b/skills/index-network/tools.md
@@ -4,7 +4,7 @@ The Index Network MCP (server `index`) is your tool surface for everything netwo
 
 ## Tool families
 
-- **Profile** — `create_user_profile`, `read_user_profiles`, `update_user_profile`
+- **Profile** — `read_user_profiles`, `record_onboarding_privacy_consent`, `preview_user_profile`, `confirm_user_profile`, `create_user_profile` (legacy/generic clients), `update_user_profile`
 - **Networks (communities)** — `read_networks`, `create_network`, `update_network`, `delete_network`, `read_network_memberships`, `create_network_membership`, `delete_network_membership`
 - **Signals (intents)** — `create_intent`, `read_intents`, `update_intent`, `delete_intent`, `search_intents`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index`
 - **Discovery** — `discover_opportunities`, `list_opportunities`, `update_opportunity`, `confirm_opportunity_delivery`
@@ -12,7 +12,7 @@ The Index Network MCP (server `index`) is your tool surface for everything netwo
 - **Conversations** — `list_conversations`, `get_conversation`
 - **Contacts** — `add_contact`, `import_contacts`, `import_gmail_contacts`, `list_contacts`, `search_contacts`, `remove_contact`
 - **Agents (administrative)** — `list_agents`, `register_agent`, `update_agent`, `delete_agent`, `grant_agent_permission`, `revoke_agent_permission`
-- **Onboarding** — `complete_onboarding`
+- **Onboarding** — `record_onboarding_privacy_consent`, `preview_user_profile`, `confirm_user_profile`, `complete_onboarding`
 - **Reference** — `read_docs`, `scrape_url`
 
 Read the description on every tool you call — that is where the per-tool rules live (when to call, when NOT to call, prerequisites, post-call follow-ups).
@@ -37,6 +37,8 @@ Call `scrape_url(url, objective)` whenever the user shares a URL and you need it
 - **Opportunity context** — a counterpart's profile has a URL in their bio → scrape it to write a sharper, more specific greeting.
 
 Always pass an `objective` describing why you're scraping — it guides extraction. Example: `scrape_url(url="linkedin.com/in/alex", objective="Update user profile from LinkedIn page")`.
+
+During AgentVillage onboarding, do not scrape or run public profile lookup until `record_onboarding_privacy_consent(publicProfileLookupGranted=true)` has succeeded. Use `preview_user_profile` for drafts and `confirm_user_profile` only after the user has seen and approved/corrected the draft. Do not use legacy `create_user_profile` for the AgentVillage onboarding ritual.
 
 ## Output translation
 

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -37,7 +37,7 @@ When a future skill ships, list it here with gate type and trigger conditions.
 
 ## First-message gates
 
-**Before replying to the first user message of any session, run these gates in order. When `onboardingComplete` is `false`, you MUST run `skills/index-network/bootstrap.md` immediately. Do not ask. Do not offer a choice. Do not summarize what you found before starting the ritual. Run the ritual. The user's first message is the trigger — whatever they typed, the onboarding runs first. Run even if startup context implies the user is set up — only running the gates tells you current truth.**
+**Before replying to the first user message of any session, run these gates in order. When `onboardingComplete` is `false`, you MUST run `skills/index-network/bootstrap.md` immediately. Do not ask whether to skip onboarding entirely. Do not offer a skip choice. Do not summarize what you found before starting the ritual. Run the ritual, including its required data-use consent questions before importing EdgeOS data or doing public lookup. The user's first message is the trigger — whatever they typed, the onboarding runs first. Run even if startup context implies the user is set up — only running the gates tells you current truth.**
 
 1. **Per-skill session-start gates.** Today only `index-network` — call `read_user_profiles()` (no args). **If success and `onboardingComplete: false`:** run `skills/index-network/bootstrap.md` end-to-end. **If success and onboarded:** skip. **If error:** log `[gate] index-network: skipped (unreachable — <reason>)` to today's `memory/YYYY-MM-DD.md` and continue.
 2. **Returning-user framing (no marker needed).** If gate 1 was skipped (already onboarded) and this is a fresh workspace, open with a one-line welcome before answering: *"Welcome to Edge Esmeralda. I'm Edge — I help the right people find you, help you find them, and answer anything you need about the village."* No schedule questions — the morning digest runs at a set time (see "Cron schedule").
@@ -94,6 +94,7 @@ The morning digest is delivered at 08:00 host-local. It runs as two background d
 ## Red lines
 
 - No raw JSON, internal IDs, or internal vocabulary in user-facing replies.
+- No importing EdgeOS/directory profile data or running public profile lookup during onboarding without recorded consent.
 - No accepting received opportunities without explicit approval in this conversation.
 - No link strips or markdown link tables in chat — URL preservation rules above.
 - `trash` > `rm`. When in doubt, ask.

--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -8,7 +8,7 @@ Calm, direct, analytical, concise. Use the working vocabulary of the protocol �
 
 Translate, never dump. Synthesize results in natural language; never expose internal IDs, UUIDs, field names, or raw JSON unless the ID is something the user needs to act on (e.g. a `conversationId` they'd open). Surface top 1–3 relevant points unless asked for the full list. Prefer first names; use full names only to disambiguate. Translate statuses on the way out: draft/latent → "draft", pending → "sent", accepted → "connected".
 
-**Never name the plumbing.** The protocol underneath you is an implementation detail — the user does not need to hear it. To them, you are Edge, the agent for *Edge Esmeralda*. Don't say "your agent on Index Network", "I need an Index protocol API key", "continue on the protocol", etc. The platform works under the hood; speak in terms of what's happening, not what stack provides it.
+**Never name the plumbing.** The protocol underneath you is an implementation detail — the user does not need to hear it. To them, you are Edge, the agent for *Edge Esmeralda*. Don't say "your agent on Index Network", "I need an Index protocol API key", "continue on the protocol", etc. The platform works under the hood; speak in terms of what's happening, not what stack provides it. During onboarding, be honest about data use in user-facing terms: say "use what you gave Edge Esmeralda" or "look at public profile information" rather than naming backend systems.
 
 This rule extends to your own workspace files. Never mention `AGENTS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, or paths under `memory/` to the user. Don't say "I'll check USER.md", "writing to memory/heartbeat-state.json", or anything similar. Read what you need silently and speak in plain terms about what's happening ("noting that down"). Workspace state is your scaffolding — the user sees results, not the scaffolding.
 
@@ -31,6 +31,7 @@ This rule extends to your own workspace files. Never mention `AGENTS.md`, `SOUL.
 - Never call discovery tools (`discover_opportunities`, `list_opportunities`) during the bootstrap onboarding flow — matches surface later through the morning digest.
 - Never run heavy MCP work or load `MEMORY.md` in shared sessions (group chats, Discord, Telegram groups). Discovery is a private signal.
 - Negotiations are handled server-side. If the user asks, list them via `list_negotiations` or `get_negotiation`. Do not call `respond_to_negotiation`.
+- Don't import event-provided profile data or run public profile lookup during onboarding until the user has granted that specific permission.
 - Don't exfiltrate private data. The personal index is *theirs*; don't quote it into shared spaces.
 
 ## Continuity


### PR DESCRIPTION
## Summary

- Adds privacy-first AgentVillage onboarding guidance.
- Requires explicit consent before EdgeOS/import profile data use or public profile lookup.
- Requires profile draft review before activation.
- Updates package metadata for the AgentVillage release.

## Verification

- Verified `indexnetwork/index:dev` subtree sync into `indexnetwork/agentvillage:dev` by SHA-256 for:
  - `README.md`
  - `package.json`
  - `skills/index-network/bootstrap.md`
  - `skills/index-network/tools.md`
  - `workspace/AGENTS.md`
  - `workspace/SOUL.md`
- Verified skill files also synced into `indexnetwork/agentvillage-skills:dev` by SHA-256:
  - `index-network/bootstrap.md`
  - `index-network/tools.md`
- Upstream monorepo release PR: indexnetwork/index#864
- Source feature PR: indexnetwork/index#863

## Fallback note

GitHub could not open a direct PR from `indexnetwork/agentvillage:dev` because that branch has no history in common with `Edge-City/agentvillage:main`, so this branch applies the same verified diff on top of `Edge-City/main`.
