### PR TITLE
Fix AgentVillage consent turn boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/bootstrap.md
+++ b/skills/index-network/bootstrap.md
@@ -39,7 +39,9 @@ Then ask the first privacy question in plain language:
 
 > "I can use the profile details you already gave Edge Esmeralda to draft your village profile. Is that okay?"
 
-Call `record_onboarding_privacy_consent(edgeosImportGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
+**Hard stop:** after sending this question, end the turn immediately. Do not call `record_onboarding_privacy_consent`, `preview_user_profile`, or any EdgeOS/profile lookup tool in the same turn as this question. Wait for the user's next message. Do not infer consent from `/start`, `hi`, silence, prior setup, the existence of staged data, or the fact that the API key is network-scoped.
+
+Only after the user's next message explicitly answers yes/no, call `record_onboarding_privacy_consent(edgeosImportGranted=<true|false>, source="agentvillage_onboarding")` with that answer.
 
 - If granted: `preview_user_profile` may use any server-staged signup/import profile seed automatically. You may also use EdgeOS recipes only for the user's own available profile/directory data. Do not use hidden values such as literal `"*"`; omit them.
 - If denied: do not fetch or use EdgeOS profile/directory data, and do not rely on staged signup/import profile data. Ask for a short self-description instead.
@@ -48,14 +50,16 @@ Then ask the second privacy question separately:
 
 > "Do you want me to also look at public profile information, like links you provide or public professional pages, to make the draft sharper? You can say no."
 
-Call `record_onboarding_privacy_consent(publicProfileLookupGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
+**Hard stop:** after sending this second question, end the turn immediately. Do not call `record_onboarding_privacy_consent(publicProfileLookupGranted=...)`, `preview_user_profile`, `scrape_url`, or public lookup tools until the user's next message explicitly answers this second question.
+
+Only after that explicit next-message yes/no answer, call `record_onboarding_privacy_consent(publicProfileLookupGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
 
 ## Step 2 — Draft and confirm their profile
 
-Call `preview_user_profile(...)` using only allowed inputs:
+Start this step only after both privacy questions have been asked in separate turns, both user replies have been received, and both consent-recording calls have completed successfully. Call `preview_user_profile(...)` using only allowed inputs:
 
-- Include EdgeOS/event profile text, and rely on staged signup/import profile data, only if EdgeOS import consent was granted.
-- Set `allowPublicLookup=true` only if public lookup consent was granted.
+- Include EdgeOS/event profile text, and rely on staged signup/import profile data, only if EdgeOS import consent was explicitly granted by the user's reply.
+- Set `allowPublicLookup=true` only if public lookup consent was explicitly granted by the user's reply.
 - Include social/profile URLs only if the user explicitly provided them or they came from allowed EdgeOS data.
 - If both EdgeOS import and public lookup are denied, use the user's self-description.
 
@@ -119,8 +123,10 @@ Cron-schedule preferences are not asked about — the morning digest runs at a f
 ## Rules
 
 - Do not skip steps or reorder them.
-- Do not import EdgeOS data without recorded EdgeOS import consent.
-- Do not run public lookup or scraping without recorded public-profile lookup consent.
+- Consent questions are turn boundaries: ask the question, then stop. The matching `record_onboarding_privacy_consent` call belongs only in a later turn after the user's explicit answer.
+- Do not import EdgeOS data without recorded EdgeOS import consent based on an explicit user answer.
+- Do not run public lookup or scraping without recorded public-profile lookup consent based on an explicit user answer.
+- Do not call `preview_user_profile` until both privacy questions have explicit user answers and both consent calls have succeeded.
 - Do not call `discover_opportunities`, `list_opportunities`, or any other discovery tool during onboarding. Opportunities surface on the first scheduled cron tick after onboarding completes.
 - Do not mention Gmail or email import — they are not available in this flow.
 - Call `create_intent` at most once per user response.

--- a/skills/index-network/tools.md
+++ b/skills/index-network/tools.md
@@ -38,7 +38,7 @@ Call `scrape_url(url, objective)` whenever the user shares a URL and you need it
 
 Always pass an `objective` describing why you're scraping — it guides extraction. Example: `scrape_url(url="linkedin.com/in/alex", objective="Update user profile from LinkedIn page")`.
 
-During AgentVillage onboarding, do not scrape or run public profile lookup until `record_onboarding_privacy_consent(publicProfileLookupGranted=true)` has succeeded. Use `preview_user_profile` for drafts and `confirm_user_profile` only after the user has seen and approved/corrected the draft. Do not use legacy `create_user_profile` for the AgentVillage onboarding ritual.
+During AgentVillage onboarding, privacy questions are hard turn boundaries. After asking a consent question, stop and wait for the user's next message; do not record consent in the same turn as the question. Do not scrape or run public profile lookup until the user explicitly answers yes and `record_onboarding_privacy_consent(publicProfileLookupGranted=true)` has succeeded. Do not use EdgeOS/import data until the user explicitly answers yes and `record_onboarding_privacy_consent(edgeosImportGranted=true)` has succeeded. Use `preview_user_profile` for drafts only after both consent questions have explicit answers, and use `confirm_user_profile` only after the user has seen and approved/corrected the draft. Do not use legacy `create_user_profile` for the AgentVillage onboarding ritual.
 
 ## Output translation
 


### PR DESCRIPTION
## Summary

- Enforces AgentVillage consent questions as hard turn boundaries.
- Requires the agent to ask, stop, wait for the user's explicit next-message yes/no answer, then record consent.
- Prevents profile preview until both privacy questions have explicit answers.
- Bumps `@edge-city/agentvillage` to `0.3.1`.

## Verification

- Merged upstream monorepo PRs:
  - indexnetwork/index#866 into `dev`
  - indexnetwork/index#867 into `main`
- Waited for subtree sync and verified SHA-256 parity for `dev` and `main` across:
  - `indexnetwork/agentvillage`
  - `indexnetwork/agentvillage-skills`
- This branch applies the verified upstream diff on top of `Edge-City/agentvillage:main`.

## Note

Direct PRs from `indexnetwork/agentvillage` still have unrelated history with `Edge-City/agentvillage`, so this uses the fallback branch-on-Edge-City flow.
