### PR TITLE
fix(agentvillage): create the digest send cron paused

### DIFF
--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -6,7 +6,9 @@
  *   - Installs the digest crons: prepare (`Edge — digest prepare`, 02:00) and
  *     send (`Edge — daily digest`, 08:00) — both host-local; times overridable
  *     via --digest-prepare-cron / --digest-send-cron (or DIGEST_PREPARE_CRON /
- *     DIGEST_SEND_CRON)
+ *     DIGEST_SEND_CRON). The send cron is created **paused** (staging still runs
+ *     nightly via prepare, but nothing is auto-delivered until someone runs
+ *     `hermes cron resume <id>`).
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -90,6 +92,42 @@ function removeEdgeCronJobs(env: NodeJS.ProcessEnv): void {
   }
 }
 
+/**
+ * Pause a freshly-created cron by its human-friendly name. Resolves the job id
+ * from `$HERMES_HOME/cron/jobs.json` (the same store `removeEdgeCronJobs` reads)
+ * and runs `hermes cron pause <id>`. Best-effort: a missing store, unreadable
+ * JSON, or missing job only warns — the cron is left scheduled rather than
+ * failing the install.
+ */
+function pauseCronByName(name: string, env: NodeJS.ProcessEnv): void {
+  const jobsPath = join(hermesHome(), "cron", "jobs.json");
+  if (!existsSync(jobsPath)) {
+    console.warn(`  warning: cron jobs store missing — could not pause "${name}"`);
+    return;
+  }
+
+  let parsed: { jobs?: Array<{ id: string; name: string }> };
+  try {
+    parsed = JSON.parse(readFileSync(jobsPath, "utf8"));
+  } catch {
+    console.warn(`  warning: could not read cron jobs store — could not pause "${name}"`);
+    return;
+  }
+
+  const job = (parsed.jobs ?? []).find((entry) => entry.name === name);
+  if (!job) {
+    console.warn(`  warning: could not find cron "${name}" to pause`);
+    return;
+  }
+
+  try {
+    execFileSync(hermesBin(), ["cron", "pause", job.id], { stdio: "ignore", env });
+    console.log(`→ paused cron "${name}"`);
+  } catch {
+    console.warn(`  warning: could not pause cron "${name}"`);
+  }
+}
+
 export interface DigestCronSpec {
   /** Default cron schedule (overridable at install time). */
   schedule: string;
@@ -103,6 +141,12 @@ export interface DigestCronSpec {
   overrideFlag: string;
   /** Env var that overrides `schedule` at install time (flag wins). */
   overrideEnv: string;
+  /**
+   * When true, the cron is created and then immediately paused via
+   * `hermes cron pause <id>`, so it stays installed but is never scheduled
+   * until someone runs `hermes cron resume <id>`.
+   */
+  paused: boolean;
 }
 
 /**
@@ -118,6 +162,7 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     deliver: false,
     overrideFlag: "--digest-prepare-cron",
     overrideEnv: "DIGEST_PREPARE_CRON",
+    paused: false,
   },
   {
     schedule: "0 8 * * *",
@@ -126,6 +171,7 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     deliver: true,
     overrideFlag: "--digest-send-cron",
     overrideEnv: "DIGEST_SEND_CRON",
+    paused: true,
   },
 ];
 
@@ -211,7 +257,8 @@ function installCronJobs(env: NodeJS.ProcessEnv): void {
     const schedule = resolveCronSchedule(spec);
     const resolved = { ...spec, schedule };
     const suffix = schedule === spec.schedule ? "" : " [overridden]";
-    console.log(`→ installing cron "${spec.name}" (${schedule})${suffix}`);
+    const pausedNote = spec.paused ? " [paused]" : "";
+    console.log(`→ installing cron "${spec.name}" (${schedule})${suffix}${pausedNote}`);
     try {
       execFileSync(bin, cronCreateArgs(resolved, promptBody, home), {
         stdio: ["ignore", "ignore", "inherit"],
@@ -219,7 +266,10 @@ function installCronJobs(env: NodeJS.ProcessEnv): void {
       });
     } catch {
       console.warn(`  warning: could not install cron "${spec.name}" — gateway may still run`);
+      continue;
     }
+
+    if (spec.paused) pauseCronByName(spec.name, hermesExecEnv());
   }
 }
 

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -20,6 +20,12 @@ test("two digest cron specs: prepare (02:00, no deliver) then send (08:00, deliv
   expect(send.deliver).toBe(true);
 });
 
+test("prepare runs scheduled; send is created paused", () => {
+  const [prepare, send] = DIGEST_CRON_SPECS;
+  expect(prepare.paused).toBe(false);
+  expect(send.paused).toBe(true);
+});
+
 test("prepare cron args omit --deliver; send cron args include --deliver telegram", () => {
   const home = "/home/x/.hermes";
   const [prepare, send] = DIGEST_CRON_SPECS;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Sync from `indexnetwork/agentvillage` (monorepo `indexnetwork/index` dev/main).

## Bug Fixes
- The morning-digest **send** cron (`Edge — daily digest`, 08:00, `--deliver telegram`) is now created **paused**. The prepare pass still stages the brief on the Kanban board nightly, but nothing is auto-delivered until someone runs `hermes cron resume <id>`.
- `hermes cron create` has no `--paused` flag, so the installer resolves the freshly-created job id from `$HERMES_HOME/cron/jobs.json` (the same store `removeEdgeCronJobs` reads) and runs `hermes cron pause <id>`. Best-effort: a missing store / unreadable JSON / missing job only warns, leaving the cron scheduled rather than failing the install.

## Tests
- Added a spec asserting `prepare.paused === false` and `send.paused === true`.

## Chore
- Bump `@edge-city/agentvillage` `0.3.1` → `0.3.2`.

Touches `install/` only — no `skills/` changes, so no companion `agentvillage-skills` PR is needed (that repo is already at parity).