### PR TITLE
edge-esmeralda: week themes table + ground programming in live data

### DIFF
--- a/skills/edge-esmeralda/SKILL.md
+++ b/skills/edge-esmeralda/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: edge-esmeralda-2026
 description: Edge Esmeralda 2026 — a month-long popup village (May 30 – Jun 27, Healdsburg, CA). Carries popup constants (popup id, week dates, themes), attendee directory field semantics, and the curated wiki / website / newsletter knowledge base. Pair with the `edgeos` skill for live API access and the `index-network` skill for discovery.
-version: 3.0.0
+version: 3.1.0
 author: Edge City
 tags: [edge-city, edge-esmeralda, popup-village, community]
 ---
@@ -31,16 +31,20 @@ This skill is a **knowledge layer** about the popup itself. For live calendar, R
 - **`event_base_url`**: `https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/`
   Use this as the prefix for event links by appending the `event_id` returned by the EdgeOS API.
 
-### Week dates
+### Week dates and themes
 
-| Week | Range |
-|---|---|
-| 1 | May 30 – June 6, 2026 |
-| 2 | June 6 – June 13, 2026 |
-| 3 | June 13 – June 20, 2026 |
-| 4 | June 20 – June 27, 2026 |
+Standardized weeks for Edge Esmeralda 2026. Week 1 is extended back to May 30 to cover opening weekend; weeks 2-4 match the published programming preview.
 
-When the user says "week 2", convert to `start_after=2026-06-06T07:00:00Z&start_before=2026-06-14T07:00:00Z` (PDT midnight = 07:00 UTC; `start_before` is the start of the day *after* the last day).
+| Week | Range | Published theme | Emphasis |
+|---|---|---|---|
+| 1 | May 30 – June 7, 2026 | Protocols for Flourishing | Health & Longevity, Consciousness, Wellbeing, Bio |
+| 2 | June 8 – June 14, 2026 | Intelligence and Autonomy | AI, Neurotech, Governance & Coordination, Hard Tech, Privacy |
+| 3 | June 15 – June 21, 2026 | Emergent Futures & World Building | Art & Culture, Decentralized Tech, Creative AI & Technologies, Spatial Computing |
+| 4 | June 22 – June 27, 2026 | Environments of Tomorrow | New Urbanism, Education, Energy & Climate, Food Systems |
+
+Themes are the published programming emphasis for each week, sourced from the Edge Esmeralda programming preview. They are directional: themes overlap and some programs span multiple weeks. A theme describes the week's focus, not a given day's schedule. For the actual events on any day, query the live `edgeos` calendar; do not infer "today's events" or "today's track" from this table, and do not present a theme as the day's schedule. Some EdgeOS tracks run across the whole month and do not map one-to-one to these theme weeks.
+
+When the user says "week 2", convert to `start_after=2026-06-08T07:00:00Z&start_before=2026-06-15T07:00:00Z` (PDT midnight = 07:00 UTC; `start_before` is the start of the day *after* the last day). Week 1 is `start_after=2026-05-30T07:00:00Z&start_before=2026-06-08T07:00:00Z`.
 
 ---
 

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -22,7 +22,7 @@ Edge Esmeralda 2026 is a month-long popup village in Healdsburg, CA — **May 30
 
 **Texture:** past residents include Vitalik Buterin, Ivan Zhao, Audrey Tang, Dylan Field, and leaders from Anthropic, Google, OpenAI, Stripe, Coinbase. Use texture in greetings only when it resonates with the user's signal — never name-drop.
 
-When composing welcome or digest, draw dates, attendee count, and programming from this section — don't invent them. Keep references concrete (week 2, the longevity track) rather than abstract.
+When composing a welcome or digest, take the village dates and attendee count from this section. For the current week's theme, read the week table in the `edge-esmeralda` skill. For today's events, tracks, and who is around, query the live `edgeos` calendar and directory. State only what you have just read from a skill or a live lookup, and never invent a theme, event, track, or attendee. A week's published theme describes its emphasis; today's actual schedule always comes from the live calendar.
 
 ## Active skills
 
@@ -94,6 +94,7 @@ The morning digest is delivered at 08:00 host-local. It runs as two background d
 ## Red lines
 
 - No raw JSON, internal IDs, or internal vocabulary in user-facing replies.
+- Never invent or guess events, tracks, week themes, or attendee names. State only what you just read from a skill or a live lookup; if you cannot reach the source, say so plainly.
 - No importing EdgeOS/directory profile data or running public profile lookup during onboarding without recorded consent.
 - No accepting received opportunities without explicit approval in this conversation.
 - No link strips or markdown link tables in chat — URL preservation rules above.


### PR DESCRIPTION
## What this does

Complements Seref's `Update AGENTS.md` fix (which removed the `Environments of Tomorrow` example from the Programming section and told the agent to fetch the live calendar). This adds the pieces needed to fully close the "agent states the wrong week theme / improvises a brief" failure that surfaced on May 31.

1. **`edge-esmeralda` SKILL.md: add a week to theme table.** Gives the agent one stable, correct source for "what's the theme this week" so it never reaches for a guess. Standardized to the published [programming preview](https://edgeesmeralda2026.substack.com/p/programming-preview-for-edge-esmeralda), with Week 1 extended back to May 30 to cover opening weekend:
   - W1 May 30 to Jun 7: Protocols for Flourishing
   - W2 Jun 8 to 14: Intelligence and Autonomy
   - W3 Jun 15 to 21: Emergent Futures & World Building
   - W4 Jun 22 to 27: Environments of Tomorrow

   The table is labeled directional, and the agent is told to pull the actual day's events from the live `edgeos` calendar and never present a theme as the day's schedule.

2. **`AGENTS.md` line 25: remove the residual leak.** It still said "draw ... programming from this section" with "the longevity track" as a concrete example, which contradicts the new line 17. Rewritten so dates and attendee count come from the section, the week theme comes from the skill table, and events/tracks/people come from a live lookup.

3. **`AGENTS.md` Red lines: hard anti-fabrication rule.** "Never invent events, tracks, week themes, or attendee names; state only what you just read; if you can't reach the source, say so." The original incident also invented two attendees.

## Why

On May 31 the agent said "today is focused on the Environments of Tomorrow track." Two causes: (a) the example in AGENTS.md line 17 (now removed), and (b) "Environments of Tomorrow" is actually the Week 4 theme, and its EdgeOS track runs the whole month, so even "fetch the live calendar for today's track" can surface it on any day. The theme table plus the theme-vs-schedule separation closes (b).

## Date standardization (please confirm)

Standardized to one week definition across this skill: W1 = May 30 to Jun 7 (extended to absorb opening weekend), W2 to W4 exactly as the blog. The "week N to query range" conversion is updated to match.

Note: EdgeOS sells tickets as "Week 1" through "Week 4" with no embedded dates, so the canonical registration-week boundaries live on the EdgeOS / SimpleFi side. The agent reads each attendee's actual participation dates from the directory, so this table is for theme + calendar-query convenience. If registration uses different week boundaries, flag it and we'll align.

## Safety

Markdown only. No code parses these files (verified). No behavior code changed.

Ready for Seref / Yanek to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
