### PR TITLE
Restore Edge guidance and async discovery polling

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,20 @@
+name: post-merge
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      SYNC_HOST: ${{ secrets.SYNC_HOST }}
+      SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+    steps:
+      - name: Refresh cache index
+        run: |
+          curl -sf -o /dev/null -X POST "https://${SYNC_HOST}/hooks/sync" \
+            -H "Authorization: Bearer ${SYNC_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{}' 2>/dev/null

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -281,5 +281,7 @@ export function installIndex(): void {
   upsertEnvVar("INDEX_API_KEY", apiKey);
   writeMcpServerEntry(apiKey);
 
-  installCronJobs(hermesExecEnv());
+  if (!process.argv.includes("--skip-crons")) {
+    installCronJobs(hermesExecEnv());
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/edge-esmeralda/SKILL.md
+++ b/skills/edge-esmeralda/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: edge-esmeralda-2026
 description: Edge Esmeralda 2026 — a month-long popup village (May 30 – Jun 27, Healdsburg, CA). Carries popup constants (popup id, week dates, themes), attendee directory field semantics, and the curated wiki / website / newsletter knowledge base. Pair with the `edgeos` skill for live API access and the `index-network` skill for discovery.
-version: 3.0.0
+version: 3.1.0
 author: Edge City
 tags: [edge-city, edge-esmeralda, popup-village, community]
 ---
@@ -26,21 +26,25 @@ This skill is a **knowledge layer** about the popup itself. For live calendar, R
 ## 1. Popup constants (use these with the `edgeos` skill)
 
 - **`popup_id`**: `43746fd0-bce2-472b-93e4-a438177b2dff`
-  Pass this as the `popup_id` parameter to `edgeos` skill calls that need it — `GET /applications/my/directory/{popup_id}`, `GET /event-venues/portal/venues?popup_id=...`, and `POST /event-venues/portal/venues` (body field).
+  Pass this as the `popup_id` parameter to `edgeos` skill calls that need it — `GET /events/portal/events?popup_id=...` (required for correct date filtering), `GET /applications/my/directory/{popup_id}`, `GET /event-venues/portal/venues?popup_id=...`, and `POST /event-venues/portal/venues` (body field).
 - **`popup_slug`**: `edge-esmeralda-2026` (informational; not used by EdgeOS API calls).
 - **`event_base_url`**: `https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/`
   Use this as the prefix for event links by appending the `event_id` returned by the EdgeOS API.
 
-### Week dates
+### Week dates and themes
 
-| Week | Range |
-|---|---|
-| 1 | May 30 – June 6, 2026 |
-| 2 | June 6 – June 13, 2026 |
-| 3 | June 13 – June 20, 2026 |
-| 4 | June 20 – June 27, 2026 |
+Standardized weeks for Edge Esmeralda 2026. Week 1 is extended back to May 30 to cover opening weekend; weeks 2-4 match the published programming preview.
 
-When the user says "week 2", convert to `start_after=2026-06-06T00:00:00Z&start_before=2026-06-13T23:59:59Z`.
+| Week | Range | Published theme | Emphasis |
+|---|---|---|---|
+| 1 | May 30 – June 7, 2026 | Protocols for Flourishing | Health & Longevity, Consciousness, Wellbeing, Bio |
+| 2 | June 8 – June 14, 2026 | Intelligence and Autonomy | AI, Neurotech, Governance & Coordination, Hard Tech, Privacy |
+| 3 | June 15 – June 21, 2026 | Emergent Futures & World Building | Art & Culture, Decentralized Tech, Creative AI & Technologies, Spatial Computing |
+| 4 | June 22 – June 27, 2026 | Environments of Tomorrow | New Urbanism, Education, Energy & Climate, Food Systems |
+
+Themes are the published programming emphasis for each week, sourced from the Edge Esmeralda programming preview. They are directional: themes overlap and some programs span multiple weeks. A theme describes the week's focus, not a given day's schedule. For the actual events on any day, query the live `edgeos` calendar; do not infer "today's events" or "today's track" from this table, and do not present a theme as the day's schedule. Some EdgeOS tracks run across the whole month and do not map one-to-one to these theme weeks.
+
+When the user says "week 2", convert to `start_after=2026-06-08T07:00:00Z&start_before=2026-06-15T07:00:00Z` (PDT midnight = 07:00 UTC; `start_before` is the start of the day *after* the last day). Week 1 is `start_after=2026-05-30T07:00:00Z&start_before=2026-06-08T07:00:00Z`.
 
 ---
 
@@ -129,7 +133,7 @@ When a user asks about Edge Esmeralda, route the work like this:
 ## 6. Tips for answering well
 
 - **Default date range** for broad calendar queries: 2026-05-30 to 2026-06-27.
-- **Convert relative dates** ("tomorrow", "this Thursday") to ISO-8601 timestamps with the `America/Los_Angeles` timezone before passing them to the `edgeos` skill's event recipes.
+- **Convert relative dates** ("today", "tomorrow", "this Thursday") to ISO-8601 timestamps in `America/Los_Angeles`. Use the local date and UTC offset from your system timestamp — never derive the date from UTC alone.
 - **Combine sources** when needed. "What experiments are running this week?" pulls from both the wiki (experiment descriptions) and the `edgeos` calendar (live schedule).
 - **For venue questions**, first fetch the wiki for venue names / descriptions, then call the `edgeos` venues endpoint with `popup_id` from §1.
 - **For attendee matching**, prefer the `index-network` skill (semantic signal search). The `edgeos` directory is the registration-side fallback when you need a specific person by name / org / role.

--- a/skills/edgeos/SKILL.md
+++ b/skills/edgeos/SKILL.md
@@ -63,35 +63,37 @@ In every curl example below, `<EDGEOS_API_KEY>` and `<EDGEOS_BEARER_TOKEN>` are 
 
 All event-read recipes use `Authorization: Bearer <EDGEOS_API_KEY>`.
 
+**REQUIRED parameters for all event list queries:** `popup_id={popup_id}` and `event_status=published`. Without `popup_id`, the API filters by `created_at` instead of `start_time`, returning wrong results. `{popup_id}` is the popup UUID from the active popup skill (e.g. `edge-esmeralda` §1).
+
 **List upcoming events (next 30 days):**
 ```bash
 curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
-  "https://api.edgeos.world/api/v1/events/portal/events?start_after={current_iso_timestamp}&limit=50"
+  "https://api.edgeos.world/api/v1/events/portal/events?popup_id={popup_id}&event_status=published&start_after={current_iso_timestamp}&limit=50"
 ```
 `{current_iso_timestamp}` must be a literal ISO-8601 UTC string (e.g. `2026-05-26T21:00:00Z`) — compute it in code or via the agent's date tools, not via shell substitution.
 
 **List events in a date range:**
 ```bash
 curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
-  "https://api.edgeos.world/api/v1/events/portal/events?start_after={start_iso}&start_before={end_iso}&limit=100"
+  "https://api.edgeos.world/api/v1/events/portal/events?popup_id={popup_id}&event_status=published&start_after={start_iso}&start_before={end_iso}&limit=100"
 ```
 
 **Search events by title:**
 ```bash
 curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
-  "https://api.edgeos.world/api/v1/events/portal/events?search=KEYWORD&start_after={start_iso}&limit=50"
+  "https://api.edgeos.world/api/v1/events/portal/events?popup_id={popup_id}&event_status=published&search=KEYWORD&start_after={start_iso}&limit=50"
 ```
 
 **Filter by tag, kind, venue, or track:**
 ```bash
 curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
-  "https://api.edgeos.world/api/v1/events/portal/events?tags=AI&tags=Privacy&limit=50"
+  "https://api.edgeos.world/api/v1/events/portal/events?popup_id={popup_id}&event_status=published&tags=AI&tags=Privacy&limit=50"
 ```
 
 **Only events you've RSVPed to:**
 ```bash
 curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
-  "https://api.edgeos.world/api/v1/events/portal/events?rsvped_only=true&limit=50"
+  "https://api.edgeos.world/api/v1/events/portal/events?popup_id={popup_id}&event_status=published&rsvped_only=true&limit=50"
 ```
 
 **Fetch a single event (includes caller's RSVP status):**
@@ -183,7 +185,7 @@ curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
 **List active venues for a popup (`popup_id` is required, must be a UUID — the active popup skill supplies it):**
 ```bash
 curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
-  "https://api.edgeos.world/api/v1/event-venues/portal/venues?popup_id={popup_uuid}&limit=100"
+  "https://api.edgeos.world/api/v1/event-venues/portal/venues?popup_id={popup_id}&limit=100"
 ```
 
 **Create a venue (`venues:write`; may land in `PENDING` if the popup requires approval, and may be disabled by the popup's `humans_can_create_venues` setting):**
@@ -191,7 +193,7 @@ curl -s -H "Authorization: Bearer <EDGEOS_API_KEY>" \
 curl -s -X POST -H "Authorization: Bearer <EDGEOS_API_KEY>" \
   -H "Content-Type: application/json" \
   "https://api.edgeos.world/api/v1/event-venues/portal/venues" \
-  -d '{"popup_id":"{popup_uuid}","title":"Workshop Room","description":"...","location":"...","formatted_address":"...","capacity":30,"booking_mode":"free"}'
+  -d '{"popup_id":"{popup_id}","title":"Workshop Room","description":"...","location":"...","formatted_address":"...","capacity":30,"booking_mode":"free"}'
 ```
 
 `booking_mode` is one of `free` | `approval_required` | `unbookable`.

--- a/skills/index-network/bootstrap.md
+++ b/skills/index-network/bootstrap.md
@@ -6,10 +6,13 @@ This file is the Index Network onboarding ritual. It is gated on Index Network's
 
 ## Session-start gate
 
-The Index Network server is the source of truth for Index onboarding — not local file state. At session start, call `read_user_profiles()` (no args) and check `onboardingComplete`:
+At session start, run these two checks in parallel: call `read_user_profiles()` (no args) and read `memory/<today>.md`. The Index Network server is the source of truth for whether onboarding is complete; the memory note only controls same-day suppression.
 
-- **If `onboardingComplete` is `false`:** run this ritual immediately. Do not offer a way to skip onboarding entirely. Start with the welcome message in Step 1 and proceed in order, but ask the data-use consent question exactly where the ritual says to ask it. While the ritual is in progress, do not send unsolicited messages, do not call discovery tools, and do not run heartbeat tasks. After Step 5 (or any path that ends the ritual), append `[gate] index-network: triggered, ritual complete` to `memory/<today>.md` before handing back to `AGENTS.md` for the Edge gate.
+Evaluate in this order:
+
+- **If `memory/<today>.md` contains `[gate] index-network: suppressed by user`:** the user already dismissed onboarding earlier today. Skip the ritual for the rest of the day — do not re-greet, do not ask the consent question again. Answer the user's message directly. No new gate-trace line is needed.
 - **If `onboardingComplete` is `true`:** skip the ritual. Append `[gate] index-network: skipped (onboardingComplete=true)` to `memory/<today>.md`, then hand back to `AGENTS.md` for the Edge gate. Index Network is already onboarded server-side; Edge onboarding may or may not still need to run, which is handled by the next gate in `AGENTS.md` "First-message gates".
+- **If `onboardingComplete` is `false` and no suppression in memory:** start the ritual with Step 1. **Exception — suppress path:** if the user's first message clearly signals they want to skip setup and do something else (e.g. "skip", "later", "just tell me about events", or any direct question about the village unrelated to onboarding), acknowledge briefly ("Sure — we can finish setup anytime, just say 'set me up'"), append `[gate] index-network: suppressed by user` to `memory/<today>.md`, and answer their question. Do not force the ritual after a suppress signal. If the ritual is running (user is mid-step), complete the current step, then offer to pause: "Want to finish setup now, or pick it up later?" — do not redirect indefinitely. If they choose to defer, append `[gate] index-network: suppressed by user` to `memory/<today>.md`. After Step 5 (or any path that ends the ritual), append `[gate] index-network: triggered, ritual complete` to `memory/<today>.md` before handing back to `AGENTS.md` for the Edge gate.
 
 This file is **not** deleted at the end of onboarding — if an admin ever resets the user's `onboardingComplete` flag server-side, the next session will see `onboardingComplete: false` and run the ritual again from the still-staged file.
 
@@ -126,6 +129,6 @@ Cron-schedule preferences are not asked about — the morning digest runs at a f
 - Do not call `discover_opportunities`, `list_opportunities`, or any other discovery tool during onboarding. Opportunities surface on the first scheduled cron tick after onboarding completes.
 - Do not mention Gmail or email import — they are not available in this flow.
 - Call `create_intent` at most once per user response.
-- If the user tries to do something else mid-onboarding, gently redirect: "Let's finish setting you up first, then we can dive into that."
+- If the user tries to do something else mid-onboarding, complete the current step and offer to pause: "Want to finish setup now, or pick it up later?" — do not block indefinitely. If they choose to defer, append `[gate] index-network: suppressed by user` to `memory/<today>.md` and answer their question. This suppression persists for the rest of the calendar day.
 - Keep your tone calm, direct, concise — no "Great question!", no "I'd be happy to help!", no filler.
 - Edge is Edge Esmeralda's agent. Do not invite users to other communities, do not list networks — Edge Esmeralda is the only frame.

--- a/skills/index-network/tools.md
+++ b/skills/index-network/tools.md
@@ -7,7 +7,7 @@ The Index Network MCP (server `index`) is your tool surface for everything netwo
 - **Profile** — `read_user_profiles`, `record_onboarding_privacy_consent`, `preview_user_profile`, `confirm_user_profile`, `create_user_profile` (legacy/generic clients), `update_user_profile`
 - **Networks (communities)** — `read_networks`, `create_network`, `update_network`, `delete_network`, `read_network_memberships`, `create_network_membership`, `delete_network_membership`
 - **Signals (intents)** — `create_intent`, `read_intents`, `update_intent`, `delete_intent`, `search_intents`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index`
-- **Discovery** — `discover_opportunities`, `list_opportunities`, `update_opportunity`, `confirm_opportunity_delivery`
+- **Discovery** — `discover_opportunities`, `get_discovery_run`, `cancel_discovery_run`, `list_opportunities`, `update_opportunity`, `confirm_opportunity_delivery`
 - **Negotiations** — `list_negotiations`, `get_negotiation` (read-only — negotiations are handled server-side; do not call `respond_to_negotiation`)
 - **Conversations** — `list_conversations`, `get_conversation`
 - **Contacts** — `add_contact`, `import_contacts`, `import_gmail_contacts`, `list_contacts`, `search_contacts`, `remove_contact`
@@ -21,6 +21,10 @@ Read the description on every tool you call — that is where the per-tool rules
 
 When the user wants to **find people to connect with, meet, or talk to** ("find AI agent builders", "who should I meet?", "looking for investors"):
 → Use `discover_opportunities` with a `searchQuery`. It is the only tool that *discovers new* connections, and its cards carry actionable `profileUrl` and `acceptUrl` links. Each opportunity gets its own `acceptUrl` — that is how the user acts on it. (`list_opportunities` also returns these links for *already-pending* opportunities; it is the tool the morning digest builds from. Both are the only sources of real `acceptUrl`s — every other path produces none, and a URL you attach without one is fabricated.)
+
+**Async discovery rule.** In MCP, `discover_opportunities` may return `status="queued"` plus a `discoveryRunId` instead of opportunity cards. When that happens, call `get_discovery_run(discoveryRunId=...)` until the run is `succeeded`, `failed`, or `cancelled`, then present the `result` if it succeeded. Do not call `list_opportunities` as a substitute for the run result. `list_opportunities` cannot prove that a queued run finished and must not be described as "the new run".
+
+**No fake follow-up.** Do not say "I'll check back", "check back in a few minutes", or "while we wait" unless you have actually scheduled or received a later dispatch. If the run is still queued/running and you cannot continue polling in this turn, save the `discoveryRunId` and original request in today's memory note, say plainly that discovery is still running, and ask the user to send a short follow-up such as "so?" so you can call `get_discovery_run` with the saved `discoveryRunId`. Never claim a run finished unless `get_discovery_run` returned `status="succeeded"`.
 
 **If `discover_opportunities` returns no results, that is the answer.** Tell the user no connections were found. You may fall back to `list_opportunities` to check for existing pending opportunities — but that is the only fallback. Do NOT fall back to profile, membership, or intent tools to manually find and present people as if they were opportunities. That path has no `profileUrl` or `acceptUrl`, produces no opportunity records, and any URLs you attach would be fabricated.
 

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -14,7 +14,7 @@ Edge Esmeralda 2026 is a month-long popup village in Healdsburg, CA — **May 30
 
 **Programming** (three formats, four weeks):
 
-- **Tracks** — week-long thematic programming (e.g. *Environments of Tomorrow*, longevity, decentralized systems).
+- **Tracks** — week-long thematic programming. **Never assume the current week's track from examples** — always fetch the live calendar via the `edgeos` skill to surface the correct track for today.
 - **Residencies** — multi-week cohorts shipping together (e.g. *Long Journey Residency*).
 - **Experiments** — applied research using the village's density.
 
@@ -22,7 +22,7 @@ Edge Esmeralda 2026 is a month-long popup village in Healdsburg, CA — **May 30
 
 **Texture:** past residents include Vitalik Buterin, Ivan Zhao, Audrey Tang, Dylan Field, and leaders from Anthropic, Google, OpenAI, Stripe, Coinbase. Use texture in greetings only when it resonates with the user's signal — never name-drop.
 
-When composing welcome or digest, draw dates, attendee count, and programming from this section — don't invent them. Keep references concrete (week 2, the longevity track) rather than abstract.
+When composing a welcome or digest, take the village dates and attendee count from this section. For the current week's theme, read the week table in the `edge-esmeralda` skill. For today's events, tracks, and who is around, query the live `edgeos` calendar and directory. State only what you have just read from a skill or a live lookup, and never invent a theme, event, track, or attendee. A week's published theme describes its emphasis; today's actual schedule always comes from the live calendar.
 
 ## Active skills
 
@@ -37,12 +37,12 @@ When a future skill ships, list it here with gate type and trigger conditions.
 
 ## First-message gates
 
-**Before replying to the first user message of any session, run these gates in order. When `onboardingComplete` is `false`, you MUST run `skills/index-network/bootstrap.md` immediately. Do not ask whether to skip onboarding entirely. Do not offer a skip choice. Do not summarize what you found before starting the ritual. Run the ritual, including its required single data-use consent question before importing EdgeOS data or doing public lookup. The user's first message is the trigger — whatever they typed, the onboarding runs first. Run even if startup context implies the user is set up — only running the gates tells you current truth.**
+**Before replying to the first user message of any session, run these gates in order. When `onboardingComplete` is `false`, start the onboarding ritual from `skills/index-network/bootstrap.md` — but respect the suppress path defined there. If the user's message is a direct village question or a clear defer signal, follow bootstrap.md's suppress path. Do not summarize what you found before starting the ritual. Run the gates — only running them tells you current truth.**
 
 1. **Per-skill session-start gates.** Today only `index-network` — call `read_user_profiles()` (no args). **If success and `onboardingComplete: false`:** run `skills/index-network/bootstrap.md` end-to-end. **If success and onboarded:** skip. **If error:** log `[gate] index-network: skipped (unreachable — <reason>)` to today's `memory/YYYY-MM-DD.md` and continue.
 2. **Returning-user framing (no marker needed).** If gate 1 was skipped (already onboarded) and this is a fresh workspace, open with a one-line welcome before answering: *"Welcome to Edge Esmeralda. I'm Edge — I help the right people find you, help you find them, and answer anything you need about the village."* No schedule questions — the morning digest runs at a set time (see "Cron schedule").
 
-While gates run: no heartbeat tasks, no unrelated content, no answering the user's first message until gates finish.
+While gates run: follow bootstrap.md's suppress path if the user's first message is a direct question or a defer signal — answer them rather than blocking indefinitely. Otherwise, no heartbeat tasks, no unrelated content, and no answering the user's first message until gates finish.
 
 After each gate, append one line to `memory/YYYY-MM-DD.md`:
 
@@ -94,6 +94,7 @@ The morning digest is delivered at 08:00 host-local. It runs as two background d
 ## Red lines
 
 - No raw JSON, internal IDs, or internal vocabulary in user-facing replies.
+- Never invent or guess events, tracks, week themes, or attendee names. State only what you just read from a skill or a live lookup; if you cannot reach the source, say so plainly.
 - No importing EdgeOS/directory profile data or running public profile lookup during onboarding without recorded consent.
 - No accepting received opportunities without explicit approval in this conversation.
 - No link strips or markdown link tables in chat — URL preservation rules above.


### PR DESCRIPTION
## Summary
- Bump `@edge-city/agentvillage` to `0.3.4`.
- Clarify Index Network async discovery handling: queued `discover_opportunities` runs must be polled via `get_discovery_run`; `list_opportunities` must not be treated as run completion.
- Restore Edge-City-specific guidance that was lost during the prior mirror sync:
  - post-merge cache refresh workflow
  - `--skip-crons` installer support
  - Edge Esmeralda week themes, PDT/UTC week windows, and anti-fabrication calendar guidance
  - EdgeOS event query requirements (`popup_id` + `event_status=published`)
  - onboarding same-day suppress/defer path

## Verification
- Ported the restored guidance back into `indexnetwork/index` so future subtree syncs preserve it.
- Pushed source changes to `indexnetwork/index:main` and `indexnetwork/index:dev`.
- Verified subtree sync hashes against `indexnetwork/agentvillage:dev` and `indexnetwork/agentvillage-skills:dev` for affected AgentVillage and skill files.
- Confirmed this PR is mergeable and preserves the existing Edge-City `sync-edge-esmeralda-references.yml` workflow.

## Tests
- Pre-commit ESLint ran for `install/install_index.ts`.
- Not otherwise run; guidance/workflow/package metadata changes only.

## Branch note
GitHub could not open a direct PR from `indexnetwork/agentvillage:dev` because that branch has no history in common with `Edge-City/agentvillage:main`, so this branch applies the same verified diff on top of `Edge-City/main`.
