### PR TITLE
Restore post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,20 @@
+name: post-merge
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      SYNC_HOST: ${{ secrets.SYNC_HOST }}
+      SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+    steps:
+      - name: Refresh cache index
+        run: |
+          curl -sf -o /dev/null -X POST "https://${SYNC_HOST}/hooks/sync" \
+            -H "Authorization: Bearer ${SYNC_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{}' 2>/dev/null


### PR DESCRIPTION
## Summary
- Restore `.github/workflows/post-merge.yml`, which was removed by the `Sync AgentVillage from indexnetwork dev` PR.
- Keeps the Edge-City-specific post-merge cache refresh hook alongside the AgentVillage sync workflows.

## Verification
- Restored the file from the pre-sync parent of PR #36 (`a847cb1b942cf6a74c1da9bf27f189fa9a564deb`).
- Confirmed current `main` is missing `.github/workflows/post-merge.yml` before this PR.

## Tests
- Not run; workflow restoration only.
