### PR TITLE
Sync AgentVillage skills directly to Edge-City

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,5 +1,4 @@
-# Splits skills/ and pushes to indexnetwork/agentvillage-skills (dev + main)
-# and Edge-City/agentvillage-skills (main only, upstream fork sync).
+# Splits skills/ and pushes to Edge-City/agentvillage-skills (matching branch).
 #
 # The skills/ directory IS the repo root in the target repos, so plugin
 # manifests (.claude-plugin/, .codex-plugin/, openclaw.plugin.json) land
@@ -45,16 +44,7 @@ jobs:
           SPLIT_SHA=$(git subtree split --prefix=skills "$BRANCH")
           echo "Split SHA: $SPLIT_SHA"
 
-          # Always push to indexnetwork/agentvillage-skills (matching branch)
           git push --force \
-            "https://x-access-token:${GH_PAT}@github.com/indexnetwork/agentvillage-skills.git" \
+            "https://x-access-token:${GH_PAT}@github.com/Edge-City/agentvillage-skills.git" \
             "${SPLIT_SHA}:refs/heads/${BRANCH}"
-          echo "✓ pushed to indexnetwork/agentvillage-skills ($BRANCH)"
-
-          # On main, also sync upstream fork
-          if [ "$BRANCH" = "main" ]; then
-            git push --force \
-              "https://x-access-token:${GH_PAT}@github.com/Edge-City/agentvillage-skills.git" \
-              "${SPLIT_SHA}:refs/heads/main"
-            echo "✓ pushed to Edge-City/agentvillage-skills (main)"
-          fi
+          echo "✓ pushed to Edge-City/agentvillage-skills ($BRANCH)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Make `Edge-City/agentvillage` the canonical AgentVillage subtree target.
- Update the nested `sync-skills.yml` workflow so it only splits `skills/` to `Edge-City/agentvillage-skills`.
- Remove the old `indexnetwork/agentvillage-skills` push path from the Edge-City workflow.
- Bump `@edge-city/agentvillage` to `0.3.6`.

## Verification
- Confirmed `indexnetwork/index` no longer includes `packages/agentvillage` in `.github/workflows/sync-subtrees.yml`.
- Confirmed this Edge-City workflow no longer references `indexnetwork/agentvillage-skills`.

## Tests
- Not run; workflow/package metadata only.
