### PR TITLE
Route village-chat questions to geo-esmeralda

### DIFF
--- a/skills/edge-esmeralda/SKILL.md
+++ b/skills/edge-esmeralda/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: edge-esmeralda-2026
-description: Edge Esmeralda 2026 — a month-long popup village (May 30 – Jun 27, Healdsburg, CA). Carries popup constants (popup id, week dates, themes), attendee directory field semantics, and the curated wiki / website / newsletter knowledge base. Pair with the `edgeos` skill for live API access and the `index-network` skill for discovery.
+description: Edge Esmeralda 2026 — a month-long popup village (May 30 – Jun 27, Healdsburg, CA). Carries popup constants (popup id, week dates, themes), attendee directory field semantics, and the curated wiki / website / newsletter knowledge base. Pair with the `edgeos` skill for live API access, the `index-network` skill for discovery, and the `geo-esmeralda` skill for community-authored content and main-chat history.
 version: 3.1.0
 author: Edge City
 tags: [edge-city, edge-esmeralda, popup-village, community]
@@ -105,7 +105,8 @@ If the `references/` directory is missing (the upstream CI workflow that generat
 - Check-in, wristbands → **wiki**
 - Health, gym, sauna, cold plunge → **wiki**
 - Kids, families, kids camp → **wiki**
-- Telegram groups, community chat → **wiki**
+- Telegram groups: which ones exist, how to join → **wiki**
+- What people are saying in the main village chat, chat summaries → **`geo-esmeralda` skill** (raw, time-windowed history of the main Telegram group; not covered by the wiki)
 - Transport, bikes, rideshare → **wiki**
 - Local discounts, merch → **wiki**
 - Outdoor adventures, Russian River, hikes → **wiki**
@@ -125,7 +126,8 @@ When a user asks about Edge Esmeralda, route the work like this:
 
 - **Calendar / RSVP / venue / directory API call** → `edgeos` skill. Pass `popup_id` from §1.
 - **Discovery, intent-based matching, "who should I meet?"** → `index-network` skill.
-- **Community knowledge** (logistics, organization, announcements, "what is Edge City?") → this skill, §5.
+- **Village chat ("what's the village discussing," "what's happening in the chat," "summarize the chat")** → `geo-esmeralda` skill (`telegram-messages` recipe) — raw, time-windowed history of the main Edge Esmeralda 2026 Telegram group. Synthesize a short bulleted summary; never dump raw messages or quote personal details beyond what the answer needs. If the local geo skill copy does not document `telegram-messages` yet, run `npx -y @geoprotocol/geo-edge-esmeralda-cli telegram-messages --help` for usage.
+- **Community knowledge** (logistics, organization, announcements, "what is Edge City?") → this skill, §4.
 - **Spatial / map / "what's near venue X"** → `geo-esmeralda` skill. Query `Venue` nodes via native graph queries for coordinates, or use the `edgeos` venue endpoint's `geo_lat` / `geo_lng` fields with haversine math for proximity ranking. Use the wiki (§4) for Healdsburg-area context.
 
 ---

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -4,7 +4,7 @@ You are **Edge**, a personal agent for one attendee of **Edge Esmeralda 2026**. 
 
 You are paired with one human. You know what they care about (from onboarding), and you have access to the village's shared knowledge layer (calendar, directory, governance via skills).
 
-**You do:** navigate schedule, wiki, and directory; suggest sessions and people; answer village questions; RSVP with confirmation; surface community decisions; coordinate intros via Index.
+**You do:** navigate schedule, wiki, and directory; suggest sessions and people; answer village questions; answer questions about what the main village chat is discussing; RSVP with confirmation; surface community decisions; coordinate intros via Index.
 
 **You do not:** send messages without confirmation; spend beyond their token limit; share private info without opt-in; pretend to be the human (always identify as their agent).
 
@@ -51,9 +51,9 @@ The more you tell me, the sharper I get.
 The `skills/` directory holds per-backend procedural knowledge. Today's active skills:
 
 - `**index-network`** (`skills/index-network/`) — Index Network protocol: profiles, signals, opportunities.  read when the user expresses interest in connecting, meeting people, finding others, or any social/matching intent.
-- `**edgeos`** (`skills/edgeos/SKILL.md`) — EdgeOS API: events, attendee directory, wiki, newsletters. 
+- `**edgeos`** (`skills/edgeos/SKILL.md`) — EdgeOS API: live events, RSVPs, venues, attendee directory, and the user's own profile. (No wiki or newsletter content — that lives in `edge-esmeralda`.) 
 - `**edge-esmeralda`** (`skills/edge-esmeralda/SKILL.md`) — Popup constants, directory semantics, curated wiki/website/newsletter.  Supplies community-knowledge answers.
-- `**geo-esmeralda`** (`skills/geo-esmeralda/SKILL.md`) — Geo knowledge graph: community created content, relations, ontology, and attendee-authored writes.
+- `**geo-esmeralda`** (`skills/geo-esmeralda/SKILL.md`) — Geo knowledge graph: community-created content, relations, ontology, attendee-authored writes, and raw time-windowed history of the main Edge Esmeralda Telegram chat.  read when the user asks what the village is discussing, what's happening in the chat, what they missed, "catch me up," what people are talking about, or wants a chat summary.
 
 When a future skill ships, list it here with its trigger conditions.
 


### PR DESCRIPTION
## Problem

Live repro this morning: asking an agent "What is the village discussing right now?" routed to EdgeOS instead of Geo. The agent's own debug pointed at the routing docs, and three layers confirm it:

1. `workspace/AGENTS.md` advertised **"wiki, newsletters"on the `edgeos` line** — EdgeOS has neither (its own §11 "What's NOT available" deflects discussion questions to external channels). Chat/news questions were picking edgeos from the first router.
2. `edge-esmeralda` §4 routed **"Telegram groups, community chat" → wiki**, which only covers which groups exist and how to join.
3. The §5 cross-skill table had **no village-chat row**, and `geo-esmeralda`'s AGENTS.md entry had **no trigger conditions** (unlike index-network), so nothing ever pointed a chat question at Geo. PR #40 adds the `telegram-messages` docs inside the geo skill, but agents only read that file *after* choosing geo — the routing layer is what decides.

## Changes (2 files)

**workspace/AGENTS.md**
- `edgeos` line now describes what EdgeOS actually serves (events, RSVPs, venues, directory, own profile) and notes wiki/newsletter live in `edge-esmeralda`.
- `geo-esmeralda` line gains the Telegram-history capability plus trigger conditions, mirroring the index-network pattern: *what's the village discussing, what's happening in the chat, what did I miss, catch me up, what are people talking about, chat summary*.
- "You do" list: + *answer questions about what the main village chat is discussing*.

**skills/edge-esmeralda/SKILL.md**
- Frontmatter description now names `geo-esmeralda` as a sibling.
- §4 table split: *which Telegram groups exist / how to join* → wiki; *what people are saying / chat summaries* → geo-esmeralda.
- §5 routing table: new **Village chat** row → geo-esmeralda `telegram-messages`, with synthesis guardrails (short bulleted summary, never dump raw messages or quote personal details beyond need) and a `--help` fallback for agents whose local geo skill copy predates #40.
- Fixed the community-knowledge row's self-reference (§5 → §4).

## Merge order

Pairs with #40 (telegram-messages docs in the geo skill): merge #40 first or together. The `--help` fallback keeps routing functional for agents with stale local skill copies either way.

## Out of scope, noted for later

- edgeos §11's two deflection lines ("check the popup's Telegram group for recaps" / "discussion happens in external channels") could also point at geo-esmeralda — left untouched to keep this small.
- Folding a "From the village chat" line into the digest prepare prompt once digest sends are unpaused.
- Geo-side cached digest (compute the summary once, agents personalize) per the eng-chat discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)