### PR TITLE
Scope geo telegram docs to the village chat + output guardrail

### DIFF
--- a/skills/geo-esmeralda/SKILL.md
+++ b/skills/geo-esmeralda/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: geo-esmeralda
-description: Add attendee-authored content, query Geo community knowledge, retrieve raw Telegram history, and inspect relations/ontology through the Geo CLI package.
+description: Add attendee-authored content, query Geo community knowledge, retrieve raw history of the main Edge Esmeralda 2026 Telegram group, and inspect relations/ontology through the Geo CLI package.
 version: 1.0.0
 author: Edge City
 tags: [edge-city, edge-esmeralda, geo, graph, community]
@@ -22,8 +22,9 @@ history. It is especially for creating notes, transcripts, essays, project
 pitches, comments, and photos; linking those contributions to events, venues,
 tracks, or other community context; reading back knowledge graph-backed claims,
 content, source material, wiki-style knowledge, idea links, and ontology details;
-and summarizing or answering questions about what happened in Telegram during a
-specific time window.
+and summarizing or answering questions about what happened in the main Edge
+Esmeralda 2026 Telegram group (the village-wide chat) during a specific time
+window.
 
 Other sibling skills cover live EdgeOS schedule/directory operations and Index
 Network participant matching. Use this skill for the Geo knowledge graph and for all
@@ -43,6 +44,9 @@ You need one token, read by the CLI from environment/config:
 
 - Never place bearer tokens in prompts, query text, native query parameters,
   answers, examples, transcripts, or shared notes.
+- When presenting Telegram messages or history to the user, synthesize a short
+  bulleted summary in your own words; never dump raw messages or quote personal
+  details beyond what the answer needs.
 - Prefer fixed commands before native graph queries.
 - Fetch live ontology before writing a native query unless the current session
   already fetched it.
@@ -85,11 +89,14 @@ npx -y @geoprotocol/geo-edge-esmeralda-cli fixed --tool list_idea_links --input 
 npx -y @geoprotocol/geo-edge-esmeralda-cli native --query 'MATCH (c:ContentItem) WHERE c.popupId = $popupId RETURN c.id AS id, c.title AS title, c.kind AS kind LIMIT 20'
 ```
 
-Use `telegram-messages` for bounded raw Telegram context, including messages
-that may not have become graph claims. Always prefer a `--from`/`--to` day window
+Use `telegram-messages` for bounded raw Telegram context from the main Edge
+Esmeralda 2026 Telegram group (the village-wide chat), including messages that
+may not have become graph claims. Always prefer a `--from`/`--to` day window
 for summaries. Results are newest-first and include `nextCursor`; continue with
-`--cursor <nextCursor>` until `hasMore` is false. Optional `--chat-id=-100...`
-and `--thread-id <id>` filters narrow the raw history. The endpoint omits raw
+`--cursor <nextCursor>` until `hasMore` is false, but fetch only as many pages
+as the question needs; for a daily summary the first page or two usually
+suffices. The served history covers only this group, so you should not normally
+need the optional `--chat-id` and `--thread-id` filters. The endpoint omits raw
 payloads, bearer tokens, and author external ids.
 
 Load `references/setup.md` when configuring the CLI or installing the skill.

--- a/skills/geo-esmeralda/references/examples.md
+++ b/skills/geo-esmeralda/references/examples.md
@@ -25,7 +25,6 @@ Raw Telegram history:
 ```bash
 npx -y @geoprotocol/geo-edge-esmeralda-cli telegram-messages --from 2026-06-02T00:00:00Z --to 2026-06-03T00:00:00Z --limit 50
 npx -y @geoprotocol/geo-edge-esmeralda-cli telegram-messages --cursor <nextCursor>
-npx -y @geoprotocol/geo-edge-esmeralda-cli telegram-messages --from 2026-06-02T00:00:00Z --to 2026-06-03T00:00:00Z --chat-id=-1001234567890
 ```
 
 Ontology:

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -50,10 +50,10 @@ The more you tell me, the sharper I get.
 
 The `skills/` directory holds per-backend procedural knowledge. Today's active skills:
 
-- `**index-network`** (`skills/index-network/`) — Index Network protocol: profiles, signals, opportunities.  read when the user expresses interest in connecting, meeting people, finding others, or any social/matching intent.
-- `**edgeos`** (`skills/edgeos/SKILL.md`) — EdgeOS API: live events, RSVPs, venues, attendee directory, and the user's own profile. (No wiki or newsletter content — that lives in `edge-esmeralda`.) 
-- `**edge-esmeralda`** (`skills/edge-esmeralda/SKILL.md`) — Popup constants, directory semantics, curated wiki/website/newsletter.  Supplies community-knowledge answers.
-- `**geo-esmeralda`** (`skills/geo-esmeralda/SKILL.md`) — Geo knowledge graph: community-created content, relations, ontology, attendee-authored writes, and raw time-windowed history of the main Edge Esmeralda Telegram chat.  read when the user asks what the village is discussing, what's happening in the chat, what they missed, "catch me up," what people are talking about, or wants a chat summary.
+- **`index-network`** (`skills/index-network/`) — Index Network protocol: profiles, signals, opportunities.  read when the user expresses interest in connecting, meeting people, finding others, or any social/matching intent.
+- **`edgeos`** (`skills/edgeos/SKILL.md`) — EdgeOS API: live events, RSVPs, venues, attendee directory, and the user's own profile. (No wiki or newsletter content — that lives in `edge-esmeralda`.) 
+- **`edge-esmeralda`** (`skills/edge-esmeralda/SKILL.md`) — Popup constants, directory semantics, curated wiki/website/newsletter.  Supplies community-knowledge answers.
+- **`geo-esmeralda`** (`skills/geo-esmeralda/SKILL.md`) — Geo knowledge graph: community-created content, relations, ontology, attendee-authored writes, and raw time-windowed history of the main Edge Esmeralda 2026 Telegram group (the village-wide chat).  read when the user asks what the village is discussing, what's happening in the chat, what they missed, "catch me up," what people are talking about, or wants a chat summary.
 
 When a future skill ships, list it here with its trigger conditions.
 


### PR DESCRIPTION
Follow-up polish on #40/#41 after reviewing the merged state. Doc-only, three files.

**Why**

- The geo skill never said *which* chat `telegram-messages` serves. An agent entering the skill directly (without passing through the edge-esmeralda routing table) had no idea it was summarizing the main Edge Esmeralda 2026 group.
- The synthesize-don't-dump privacy rule only existed in edge-esmeralda §5, so the geo-direct path missed it entirely.
- `continue until hasMore is false` is unconditional: a literal agent answering "catch me up on the week" drains a 7-day window page by page and burns credits before synthesizing.
- examples.md carried a placeholder `--chat-id=-1001234567890` that an agent could copy verbatim into a query against a nonexistent chat.

**Changes**

- `skills/geo-esmeralda/SKILL.md`: name the main Edge Esmeralda 2026 Telegram group (the village-wide chat) as the source in frontmatter, intro, and §4; add a synthesize-a-short-bulleted-summary / never-dump-raw-messages rule to §2 Safety Rules (wording matches edge-esmeralda §5, and §2 also covers the `recent_messages` read path); add pagination restraint (first page or two usually suffices for a daily summary); demote `--chat-id`/`--thread-id` since the served history covers only this group.
- `skills/geo-esmeralda/references/examples.md`: drop the placeholder `--chat-id` example.
- `workspace/AGENTS.md`: fix the malformed bold/backtick nesting on all four active-skill entries; name the chat consistently on the geo line.

Verified that nothing in install/, the sync workflows, or the plugin manifests parses or checksums these files, so the formatting fix is tooling-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)