### PR TITLE
fix: propagate Telegram handles to Index MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Every call with the same email returns the same user but a **fresh API key** —
 
 ### What Portal does after signup
 
-1. Runs the AgentVillage installer with the returned `apiKey`: `bun install/install.ts --index-api-key <apiKey>` (or equivalent in the hosted runtime). If Portal has also fetched an EdgeOS personal access token for the attendee, it passes that on the same line: `bun install/install.ts --index-api-key <apiKey> --edgeos-api-key <eos_live_…> --edgeos-bearer-token <jwt>`.
-2. In a follow-up step, captures the attendee's Telegram handle and binds it to their agent transport — this is entirely Portal-owned and happens outside this endpoint.
+1. Runs the AgentVillage installer with the returned `apiKey`: `bun install/install.ts --index-api-key <apiKey>` (or equivalent in the hosted runtime). If Portal knows the attendee's Telegram handle, it passes it as `--telegram-handle @handle` so every Telegram-surface Index MCP request carries `x-index-telegram-username` and self-heals the user's public Telegram social. If Portal has also fetched an EdgeOS personal access token for the attendee, it passes that on the same line: `bun install/install.ts --index-api-key <apiKey> --telegram-handle @handle --edgeos-api-key <eos_live_…> --edgeos-bearer-token <jwt>`.
+2. If Portal learns or changes the attendee's Telegram handle later, it should rerun the installer or update `mcp_servers.index.headers.x-index-telegram-username` in the host config.
 
 ### What EdgeOS does after signup (BYOA flow)
 
@@ -148,7 +148,7 @@ claude plugin install agentvillage@agentvillage-skills
 **OpenClaw:**
 ```bash
 openclaw plugins install agentvillage --marketplace Edge-City/agentvillage-skills
-openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<apiKey>"}}'
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<apiKey>","x-index-surface":"telegram","x-index-telegram-username":"@handle"}}'
 openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<jwt>'
 openclaw config set env.vars.EDGEOS_API_KEY '<eos_live_…>'
 openclaw gateway restart
@@ -161,6 +161,8 @@ hermes skills install Edge-City/agentvillage/skills/edgeos --force
 hermes skills install Edge-City/agentvillage/skills/index-network --force
 hermes config set mcp_servers.index.url 'https://protocol.index.network/mcp'
 hermes config set mcp_servers.index.headers.x-api-key '<apiKey>'
+hermes config set mcp_servers.index.headers.x-index-surface 'telegram'
+hermes config set mcp_servers.index.headers.x-index-telegram-username '@handle'
 hermes config set EDGEOS_BEARER_TOKEN '<jwt>'
 hermes config set EDGEOS_API_KEY '<eos_live_…>'
 ```
@@ -187,6 +189,12 @@ From a clone of this repo:
 
 ```bash
 bun install/install.ts --index-api-key <YOUR_API_KEY>
+```
+
+If this AgentVillage runtime is serving the user through Telegram, include their public Telegram handle. The installer stores it in the Index MCP headers so any Telegram-surface interaction can upsert the user's reachable Telegram social without waiting for onboarding:
+
+```bash
+bun install/install.ts --index-api-key <YOUR_API_KEY> --telegram-handle @handle
 ```
 
 To target the dev environment (keys generated on `dev.index.network`), pass `--dev`:

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -38,7 +38,24 @@ function readApiKey(): string {
   return key;
 }
 
-function writeMcpServerEntry(apiKey: string): void {
+function readTelegramHandle(): string {
+  return readFlag("--telegram-handle")?.trim()
+    || process.env.INDEX_TELEGRAM_HANDLE?.trim()
+    || process.env.TELEGRAM_HANDLE?.trim()
+    || "";
+}
+
+export function buildIndexMcpHeaders(apiKey: string, telegramHandle = ""): Record<string, string> {
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    "x-index-surface": "telegram",
+  };
+  const trimmedHandle = telegramHandle.trim();
+  if (trimmedHandle) headers["x-index-telegram-username"] = trimmedHandle;
+  return headers;
+}
+
+function writeMcpServerEntry(apiKey: string, telegramHandle: string): void {
   const configPath = join(hermesHome(), "config.yaml");
   let doc: Record<string, unknown> = {};
   if (existsSync(configPath)) {
@@ -47,10 +64,7 @@ function writeMcpServerEntry(apiKey: string): void {
   const mcpServers = { ...((doc.mcp_servers as Record<string, unknown>) ?? {}) };
   mcpServers.index = {
     url: PROTOCOL_MCP_URL,
-    headers: {
-      "x-api-key": apiKey,
-      "x-index-surface": "telegram",
-    },
+    headers: buildIndexMcpHeaders(apiKey, telegramHandle),
   };
   doc.mcp_servers = mcpServers;
   writeFileSync(configPath, YAML.stringify(doc));
@@ -275,11 +289,13 @@ function installCronJobs(env: NodeJS.ProcessEnv): void {
 
 export function installIndex(): void {
   const apiKey = readApiKey();
+  const telegramHandle = readTelegramHandle();
   console.log(
     `→ index network: target=${IS_DEV ? "dev" : "production"} (${PROTOCOL_MCP_URL})`,
   );
   upsertEnvVar("INDEX_API_KEY", apiKey);
-  writeMcpServerEntry(apiKey);
+  if (telegramHandle) upsertEnvVar("INDEX_TELEGRAM_HANDLE", telegramHandle);
+  writeMcpServerEntry(apiKey, telegramHandle);
 
   if (!process.argv.includes("--skip-crons")) {
     installCronJobs(hermesExecEnv());

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 
 import {
   DIGEST_CRON_SPECS,
+  buildIndexMcpHeaders,
   cronCreateArgs,
   isValidCron,
   resolveCronSchedule,
@@ -39,6 +40,19 @@ test("prepare cron args omit --deliver; send cron args include --deliver telegra
     "cron", "create", "0 8 * * *", "SEND_BODY",
     "--name", "Edge — daily digest", "--deliver", "telegram", "--workdir", home,
   ]);
+});
+
+test("index MCP headers include telegram surface and optional handle", () => {
+  expect(buildIndexMcpHeaders("ix_test")).toEqual({
+    "x-api-key": "ix_test",
+    "x-index-surface": "telegram",
+  });
+
+  expect(buildIndexMcpHeaders("ix_test", " @alice ")).toEqual({
+    "x-api-key": "ix_test",
+    "x-index-surface": "telegram",
+    "x-index-telegram-username": "@alice",
+  });
 });
 
 test("each spec declares its install-time override flag + env var", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/README.md
+++ b/skills/README.md
@@ -93,12 +93,14 @@ mcp_servers:
     headers:
       x-api-key: <YOUR_API_KEY>
       x-index-surface: telegram
+      x-index-telegram-username: @handle  # optional; lets any Telegram-surface MCP call self-heal the public Telegram social
 ```
 
 For workspace, installer, and cron jobs:
 
 ```bash
 bun install/install.ts --index-api-key <KEY>
+# add --telegram-handle @handle when this runtime serves the user over Telegram
 # add --edgeos-bearer-token for Geo knowledge graph access/content writes
 # add --edgeos-api-key for EdgeOS event, RSVP, and venue recipes
 # re-onboard: add --wipe-user


### PR DESCRIPTION
## Changelog

### Fixed
- Propagate known Telegram handles through AgentVillage Index MCP headers so Telegram-surface interactions can keep Index reachable handles populated.

### Changed
- Add `--telegram-handle` / `INDEX_TELEGRAM_HANDLE` installer support and document the Portal/OpenClaw/Hermes configuration path.
- Bump `@edge-city/agentvillage` to 0.3.7.

## Tests
- `bun test install/tests/cron_specs.test.ts`