### PR TITLE
welcome: suggest 'what's on for the rest of today?'

### DIFF
--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -40,7 +40,7 @@ Here's what I can do:
 
 **Find your people.** Tell me what you're building, looking for, or curious about, and I'll put it out into the village and quietly find the residents who match. The strongest ones land in your morning brief, so the right people find you while you go live your day.
 
-Want to try me? Ask 'what's on the calendar next week?' Or just tell me what you're looking for, and I'll start finding your people.
+Want to try me? Ask 'what's on for the rest of today?' Or just tell me what you're looking for, and I'll start finding your people.
 
 The more you tell me, the sharper I get.
 


### PR DESCRIPTION
Copy-only, one line in `workspace/AGENTS.md` (the First message welcome block).

**Why:** a same-day calendar question gives a new user an instant, concrete payoff on their first try, instead of next week's schedule. The agent already handles same-day queries well (relative-date grounding from May 30), and in the evening it falls back to tomorrow naturally.

Nothing parses this string; it only reaches new agents/resets via the normal sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)