### PR TITLE
feat: add daily morning brief context builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 node_modules
+
+# Private sibling checkouts for local development only.
+# These are cloned alongside AgentVillage for context but are not part of the public skills package.
+/controlplane/
+/landing/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AgentVillage is the public skills package and onboarding scripts that an agent (
 Today, capabilities come from **Index Network** (discovery + intent negotiation). **Geo** (knowledge graph) and **EdgeOS** (calendar + directory) are also in scope. Once installed, AgentVillage:
 
 - **Runs privacy-first onboarding** the first time you message it (greet → ask one data-use consent question covering EdgeOS data and public lookup → profile draft → user approval → first signal → silent handle capture → `complete_onboarding`).
-- **Sends a morning brief at 08:00 host-local time** with admin-set village announcements, today's EdgeOS calendar highlights, the connections worth your attention, and the asks where you can help.
+- **Prepares a morning brief for 08:00 host-local time** with admin-set village announcements, today's EdgeOS calendar highlights, the connections worth your attention, and the asks where you can help. The delivery cron is installed paused until operators explicitly resume it.
 - **Notifies you when someone accepts** a connection on your behalf.
 - **Curates memory** every few days — distills daily notes into long-term `MEMORY.md`.
 
@@ -244,7 +244,7 @@ The installer:
 4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
-7. Installs the two digest cron jobs: a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The morning send is enabled by default. The end user can't change the schedule from chat, but the installer can override both times via `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the digest cron times" above.
+7. Installs the two digest cron jobs: a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The morning send is installed paused by default to prevent accidental delivery; operators must explicitly resume it after validation. The end user can't change the schedule from chat, but the installer can override both times via `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the digest cron times" above.
 8. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent onboarding gates that run at session start:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AgentVillage is the public skills package and onboarding scripts that an agent (
 Today, capabilities come from **Index Network** (discovery + intent negotiation). **Geo** (knowledge graph) and **EdgeOS** (calendar + directory) are also in scope. Once installed, AgentVillage:
 
 - **Runs privacy-first onboarding** the first time you message it (greet → ask one data-use consent question covering EdgeOS data and public lookup → profile draft → user approval → first signal → silent handle capture → `complete_onboarding`).
-- **Sends a morning digest at 08:00 host-local time** with the connections worth your attention and the asks where you can help.
+- **Sends a morning brief at 08:00 host-local time** with admin-set village announcements, today's EdgeOS calendar highlights, the connections worth your attention, and the asks where you can help.
 - **Notifies you when someone accepts** a connection on your behalf.
 - **Curates memory** every few days — distills daily notes into long-term `MEMORY.md`.
 
@@ -244,7 +244,7 @@ The installer:
 4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
-7. Installs the two digest cron jobs: a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The end user can't change the schedule from chat, but the installer can override both times via `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the digest cron times" above.
+7. Installs the two digest cron jobs: a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The morning send is enabled by default. The end user can't change the schedule from chat, but the installer can override both times via `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the digest cron times" above.
 8. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent onboarding gates that run at session start:
@@ -317,7 +317,7 @@ AgentVillage's behaviour is markdown-driven. Almost everything you'd want to cha
 | You want to… | Edit | Notes |
 |---|---|---|
 | Update community facts (dates, headcount, venue, programming format) | `workspace/COMMUNITY.md` | This is the only authoritative source the agent reads for community context. Don't duplicate the facts into prompts. |
-| Change what the morning digest says or how it's structured | `skills/index-network/prompts/prepare.md` (compose) and `skills/index-network/prompts/send.md` (deliver + fallback) | The morning greeting is fixed in both. Keep the two-section structure in sync between them. |
+| Change what the morning brief says or how it's structured | `skills/index-network/prompts/prepare.md` (compose), `skills/index-network/scripts/build-daily-brief-context.ts` (structured announcements/calendar/opportunity context), and `skills/index-network/prompts/send.md` (deliver + fallback) | The morning greeting is fixed in both. Keep the announcements/calendar/people/community-asks structure in sync with `skills/index-network/exemplars.md`. |
 | Change the welcome message | `skills/index-network/bootstrap.md` Step 1 | The same welcome runs for every user — new and returning. |
 | Change the lived-notebook (`USER.md`) template | `skills/index-network/bootstrap.md` | The bootstrap ritual writes `USER.md`. Editing the file in `workspace/` only affects the empty stub copied in by `--wipe-user`. |
 | Change how the agent calls EdgeOS APIs (events, attendees, RSVPs, venues, wiki recipes) | `skills/edgeos/SKILL.md` | This is the hand-edited recipe file. The auto-refreshed reference data under `skills/edgeos/references/` is a different surface — see "Backends & skills" below for the don't-edit-this caveat. |

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -6,9 +6,7 @@
  *   - Installs the digest crons: prepare (`Edge — digest prepare`, 02:00) and
  *     send (`Edge — daily digest`, 08:00) — both host-local; times overridable
  *     via --digest-prepare-cron / --digest-send-cron (or DIGEST_PREPARE_CRON /
- *     DIGEST_SEND_CRON). The send cron is created **paused** (staging still runs
- *     nightly via prepare, but nothing is auto-delivered until someone runs
- *     `hermes cron resume <id>`).
+ *     DIGEST_SEND_CRON). The morning send cron is enabled by default.
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -185,7 +183,7 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     deliver: true,
     overrideFlag: "--digest-send-cron",
     overrideEnv: "DIGEST_SEND_CRON",
-    paused: true,
+    paused: false,
   },
 ];
 

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -6,7 +6,7 @@
  *   - Installs the digest crons: prepare (`Edge — digest prepare`, 02:00) and
  *     send (`Edge — daily digest`, 08:00) — both host-local; times overridable
  *     via --digest-prepare-cron / --digest-send-cron (or DIGEST_PREPARE_CRON /
- *     DIGEST_SEND_CRON). The morning send cron is enabled by default.
+ *     DIGEST_SEND_CRON). The morning send cron is installed paused by default.
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -183,7 +183,7 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     deliver: true,
     overrideFlag: "--digest-send-cron",
     overrideEnv: "DIGEST_SEND_CRON",
-    paused: false,
+    paused: true,
   },
 ];
 

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -21,10 +21,10 @@ test("two digest cron specs: prepare (02:00, no deliver) then send (08:00, deliv
   expect(send.deliver).toBe(true);
 });
 
-test("prepare runs scheduled; send is created paused", () => {
+test("prepare and morning send are created enabled by default", () => {
   const [prepare, send] = DIGEST_CRON_SPECS;
   expect(prepare.paused).toBe(false);
-  expect(send.paused).toBe(true);
+  expect(send.paused).toBe(false);
 });
 
 test("prepare cron args omit --deliver; send cron args include --deliver telegram", () => {

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -21,10 +21,10 @@ test("two digest cron specs: prepare (02:00, no deliver) then send (08:00, deliv
   expect(send.deliver).toBe(true);
 });
 
-test("prepare and morning send are created enabled by default", () => {
+test("prepare is enabled and morning send is installed paused by default", () => {
   const [prepare, send] = DIGEST_CRON_SPECS;
   expect(prepare.paused).toBe(false);
-  expect(send.paused).toBe(false);
+  expect(send.paused).toBe(true);
 });
 
 test("prepare cron args omit --deliver; send cron args include --deliver telegram", () => {

--- a/skills/edgeos/SKILL.md
+++ b/skills/edgeos/SKILL.md
@@ -106,6 +106,8 @@ For a recurring event, scope the RSVP lookup to one instance with `?occurrence_s
 
 **Pagination:** use `skip` and `limit` (max `100`). Stop when `results.length < limit`.
 
+**Highlighted events:** event records include a boolean `highlighted` field. The list endpoint does not provide a `highlighted` query parameter; fetch the relevant date range and filter client-side with `event.highlighted === true`.
+
 ## 4. Writing events (requires `events:write` scope on `$EDGEOS_API_KEY`)
 
 **Update an event you own:**

--- a/skills/index-network/SKILL.md
+++ b/skills/index-network/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: index-network
-description: Edge Esmeralda's Index Network bundle. Surfaces opportunities through a morning 08:00 digest (composed ahead by a prepare pass, delivered by a send pass) and accepted-opportunity notifications on the heartbeat tick. Prunes stale signals weekly. Read when surfacing opportunities, drafting introductions, onboarding a user who has expressed social intent, composing the digest flow, or handling anything backed by the Index Network MCP (server `index`).
+description: Edge Esmeralda's Index Network bundle. Surfaces opportunities through a morning 08:00 brief (composed ahead by a prepare pass, delivered by a send pass) alongside calendar highlights, plus accepted-opportunity notifications on the heartbeat tick. Prunes stale signals weekly. Read when surfacing opportunities, drafting introductions, onboarding a user who has expressed social intent, composing the brief flow, or handling anything backed by the Index Network MCP (server `index`).
 metadata:
   openclaw:
     requires:
@@ -19,7 +19,7 @@ Edge's bundle for surfacing opportunities through Edge Esmeralda's Index Network
 - **User expresses social intent** → [bootstrap.md](bootstrap.md). Five-step Index Network onboarding ritual; gated on `onboardingComplete` and triggered by user intent, not session start.
 - **Heartbeat tick** → [heartbeat.md](heartbeat.md). Accepted-opportunity notifications and signal-freshness pruning.
 
-Cron prompts in `prompts/` (`prepare.md`, `send.md`) are loaded by the cron runner via `--message`; you do not read them yourself. The crons are fixed Edge infrastructure — their schedule is not user-configurable. The digest prompts route their body through `scripts/validate-digest-urls.ts` — a deterministic URL guard that strips any link that is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link, so a fabricated action URL can never ship.
+Cron prompts in `prompts/` (`prepare.md`, `send.md`) are loaded by the cron runner via `--message`; you do not read them yourself. The crons are fixed Edge infrastructure — their schedule is not user-configurable. The brief prompts route their body through `scripts/validate-digest-urls.ts` — a deterministic URL guard that strips any link that is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link, so a fabricated action URL can never ship.
 
 ## Handoff
 

--- a/skills/index-network/exemplars.md
+++ b/skills/index-network/exemplars.md
@@ -1,35 +1,80 @@
 # Index Network — Voice Exemplars
 
-Canonical user-facing renderings for Edge Esmeralda's Index Network flows. Mimic these exactly when composing the morning digest and greeting drafts. They are the bar for tone, structure, and information density. Edge Esmeralda is the literal community in every example — pull facts from `AGENTS.md` Community context, never invent dates, attendee counts, or programming formats.
+Canonical user-facing renderings for Edge Esmeralda's Index Network flows. Mimic these exactly when composing the morning brief and greeting drafts. They are the bar for tone, structure, and information density. Edge Esmeralda is the literal community in every example — pull facts from `AGENTS.md` Community context, never invent dates, attendee counts, programming formats, announcements, events, or attendees.
 
-## Good morning digest (fires once daily, ~08:00 host local)
+## Good morning brief (fires once daily, 08:00 Pacific time)
 
-> 🌞 Good morning from Edge Esmeralda
+Calendar bullets should put EdgeOS `highlighted: true` events first, then fill with one interest-relevant event from the remaining live calendar when useful.
+
+> 🌞 Good morning from Edge Esmeralda. It is Thursday, June 4
 >
-> It's Thursday, Week 2 at Edge Esmeralda. Here's what to do and who to find before the day fills up.
+> Here's what you need to know today:
 >
-> **3 conversations await you**
-> - [Maya]({profileUrl}) — Talk to them about agent memory layer for long-running workflows. Direct overlap with how Index handles persistent context, [message Maya]({acceptUrl})
-> - [Theo]({profileUrl}) — Researching how information surfaces in decentralized networks. That's the type of thinking that sharpens protocol design, [see what you can learn from them]({acceptUrl})
-> - [Priya]({profileUrl}) — Building community-owned data infrastructure. Aligned on the ownership layer and complementary on discovery, could be interesting to [explore overlaps]({acceptUrl})
+> **Announcements**
+> - The organizer team moved tonight's community dinner to the plaza because of the weather window. Same time, different place.
 >
-> **Help your community find their opportunities**
-> A few residents are looking for something specific. If you know someone who fits, a quick nudge goes a long way.
-> - [Remi]({profileUrl}) — Looking for a technical co-founder for his regenerative education platform. Needs someone who thinks in systems and has shipped infra. Know anyone, make intro
-> - [Kai]({profileUrl}) — Needs people deep in decentralized discovery — agent tooling, knowledge graphs, semantic search. Bring one to his 3pm open conversation, make intro
-> - [Celia]({profileUrl}) — Designing governance tooling for popup communities. Coordination, consent, collective decision-making. Point her at the right people, make intro
+> **The calendar today:**
+> - 9:00 AM PST — Morning workout at the Plaza. A useful reset before the day gets full.
+> - 11:30 AM PST — Longevity Tools Show-and-Tell at Buck Institute. Good fit if you're tracking health, measurement, or translational science.
+> - 4:00 PM PST — Governance Lab: Consent in Popup Communities. Relevant to anyone thinking about coordination, resident voice, or collective decisions.
+>
+> **Potential connections via Index Network:**
+> - [Maya]({profileUrl}) — Talk to them about agent memory layers for long-running workflows. Direct overlap with how Index handles persistent context, [say hi]({acceptUrl})
+> - [Theo]({profileUrl}) — Researching how information surfaces in decentralized networks. That's the type of thinking that sharpens protocol design, [say hi]({acceptUrl})
+>
+> **Help your community**
+> - [Remi]({profileUrl}) — Looking for a technical co-founder for his regenerative education platform. Needs someone who thinks in systems and has shipped infrastructure. Know someone, [make intro]({acceptUrl}).
+>
+> That's it for now. You can always ask me for more detail, or any other questions you have!
+
+### No verified announcements
+
+When there is no current organizer announcement you can verify, omit the section entirely:
+
+> 🌞 Good morning from Edge Esmeralda. It is Tuesday, June 9
+>
+> Here's what you need to know today:
+>
+> **The calendar today:**
+> - 10:00 AM PST — AI Agents Breakfast Salon at Hotel Trio. A straightforward place to hear what people are building this week.
+> - 2:00 PM PST — Neurotech Open Demos at Buck Institute. Relevant if you're following applied science and human performance.
+>
+> **Potential connections via Index Network:**
+> - [Priya]({profileUrl}) — Building community-owned data infrastructure. Aligned on the ownership layer and complementary on discovery, [say hi]({acceptUrl})
+>
+> That's it for now. You can always ask me for more detail, or any other questions you have!
+
+### Calendar fallback
+
+If the live calendar call fails, ship the people sections and include one plain pointer:
+
+> 🌞 Good morning from Edge Esmeralda. It is Wednesday, June 10
+>
+> Here's what you need to know today:
+>
+> **Potential connections via Index Network:**
+> - [Ashish]({profileUrl}) — An experienced technologist spanning generative software, AI infrastructure, creative AI design, and deep learning research. Several angles worth exploring, [say hi]({acceptUrl})
+>
+> I couldn't check the live calendar this morning — ask me what's on today and I'll look it up.
+>
+> That's it for now. You can always ask me for more detail, or any other questions you have!
 
 ### Grouped: same person, multiple connections
 
-When `list_opportunities` returns multiple opportunities for the same person (grouped entry), render as a single bullet with multiple conversation entry points:
+When `list_opportunities` returns multiple opportunities for the same person, render as a single bullet with multiple conversation entry points:
 
-> 🌞 Good morning from Edge Esmeralda
+> 🌞 Good morning from Edge Esmeralda. It is Tuesday, June 16
 >
-> It's Tuesday, May 26. Here's what's worth your attention right now.
+> Here's what you need to know today:
 >
-> **2 conversations await you**
+> **The calendar today:**
+> - 9:30 AM PST — Creative AI Crit at the Studio. Good fit for builders thinking about tools, taste, and new creative workflows.
+> - 3:00 PM PST — Spatial Computing Walkthrough at the Plaza. Useful if you want to see concrete demos rather than a panel.
+>
+> **Potential connections via Index Network:**
 > - [Ashish]({profileUrl}) — An experienced technologist spanning [generative software]({acceptUrl1}), [AI infrastructure]({acceptUrl2}), [creative AI design]({acceptUrl3}), and [deep learning research]({acceptUrl4}). Several angles worth exploring.
-> - [Priya]({profileUrl}) — Building community-owned data infrastructure. Aligned on the ownership layer and complementary on discovery, could be interesting to [explore overlaps]({acceptUrl})
+>
+> That's it for now. You can always ask me for more detail, or any other questions you have!
 
 ## Greeting drafts (the `&msg=` payload appended to Telegram links)
 
@@ -48,5 +93,5 @@ URI-encode the greeting and append it as `&msg=...` (or `?text=...` for `t.me`) 
 For introducer (`connector-flow`) candidates:
 
 - **DO link the person's name** to `profileUrl` (the Index web profile URL — same shape as direct candidates).
-- **Do NOT link the opportunity** — no `acceptUrl`. The trailing `make intro` is plain text, not a hyperlink. The connect/accept link belongs only to direct candidates; for introducer candidates the user replies to the agent if they want to act.
+- If the connector-flow card includes a real `acceptUrl`, embed it on the trailing `[make intro]({acceptUrl})` action. If no `acceptUrl` is present, render `make intro` as plain text — never invent the URL.
 - Never compose a `&msg=` greeting for `connector-flow` candidates — only for `connection`. Connector accepts trigger an introduction approval, not a direct conversation.

--- a/skills/index-network/prompts/prepare.md
+++ b/skills/index-network/prompts/prepare.md
@@ -1,67 +1,103 @@
-You are Edge, the user's agent on the Index protocol. This composes the user's morning brief ahead of time and stages it on the board for the morning send. You deliver NOTHING here — staging only.
+You are Edge, the user's agent for Edge Esmeralda. This composes the user's daily morning brief ahead of time and stages it on the Hermes Kanban board for the 08:00 send pass. You deliver NOTHING here — staging only.
 
 # Voice
-Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pattern, emerging, relevant, adjacency. Never use "search" — say "looking up" / "find" / "check" / "discover". Banned: leverage, unlock, optimize, scale, disrupt, AI-powered, maximize value, act fast, networking, match. Never expose internal IDs (unless the user needs them to act, e.g. a `conversationId`), never raw JSON, never internal vocabulary. Translate: "intent" → "signal", "index/network" → "community", "pending" → "sent", "accepted" → "connected".
+Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pattern, emerging, relevant, adjacency. Never use "search" — say "looking up" / "find" / "check" / "discover". Banned: leverage, unlock, optimize, scale, disrupt, AI-powered, maximize value, act fast, networking, match. Never expose internal IDs, raw JSON, or internal vocabulary. Translate: "intent" → "signal", "index/network" → "community", "pending" → "sent", "accepted" → "connected".
 
 # Job
-Compose the morning brief and stage it as a board task. This runs ahead of the morning send, so **always frame the brief as the 08:00 morning digest** — the greeting is morning regardless of the hour you actually run.
+Compose the 08:00 morning brief and stage it as a board task. The brief should be worth opening even when there are no strong people matches: lead with what is on in the village today, then people, then community asks.
 
 Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT]`; OpenClaw → `NO_REPLY`; Claude Code → produce no user-facing text if the host supports a silent turn, otherwise stop without commentary.
 
-1. **Greeting + quiet fallback (fixed — morning).** Use `{greeting}` = `🌞 Good morning from Edge Esmeralda` and `{quietLine}` = `Quiet morning — I'll keep listening.` Do not pick a different time-of-day phrasing; the brief is delivered in the morning.
+## Data sources and dates
 
-2. **Read dedup state.** Read `memory/heartbeat-state.json`. Treat a missing file or malformed JSON as `{}`. Resolve the dedup set: if `deliveredToday.date` equals today's host-local date (`YYYY-MM-DD`) AND `deliveredToday.ids` is an array, use that array as the dedup set; in every other case treat the dedup set as empty.
+- Use **America/Los_Angeles** for all date boundaries and displayed event times. Render event times as `PST` in the brief. Do not derive today's local date from UTC alone.
+- Edge Esmeralda popup id for EdgeOS calendar calls: `43746fd0-bce2-472b-93e4-a438177b2dff`.
+- Build deterministic non-prose context with `skills/index-network/scripts/build-daily-brief-context.ts`. The script fetches admin announcements from the AgentVillage control plane, pulls today's EdgeOS calendar, filters `highlighted === true` events first, selects one interest-fill event from local memory, parses the `list_opportunities` transcript you provide, and writes structured JSON. Do not manually re-fetch announcements or calendar outside this script.
+- Index people sections use `list_opportunities(includeDigestMarkers=true)`, saved to `memory/digest-opportunities.txt` for the context builder. The hidden digest markers are internal delivery-confirmation metadata, not visible prose.
+- Organizer announcements come only from the context builder's `announcements` array. Do not fill this section from chat, stale wiki/newsletter copy, generic community facts, or ordinary attendee chatter.
+- For user interests, rely on the context builder's `diagnostics.interestTags` and selected `interestEvents`. Do not import new private EdgeOS directory/profile data here.
 
-3. Call `list_opportunities(status="pending", limit=10)`. If this call errors, end your turn with the host-specific no-reply marker and stage nothing — the morning send falls back to fresh generation.
+## Steps
 
-4. **Filter against dedup state.** Drop any returned opportunity whose `id` is in the dedup set from step 2. Use the filtered set for everything that follows.
+1. **Resolve local date.** Determine today's America/Los_Angeles date as `<YYYY-MM-DD>` and display it as `{Weekday, Month D}`. Use greeting exactly:
 
-5. **If the filtered set is empty:** the staged body is `{quietLine}` and the staged id list is empty. Skip to step 10 with that body.
+   `🌞 Good morning from Edge Esmeralda. It is {Weekday, Month D}`
 
-6. **Otherwise** compose the brief in this exact structure (mimic the *Good morning digest* exemplar in `skills/index-network/exemplars.md`):
+2. **Fetch and persist Index opportunities.** Call `list_opportunities(includeDigestMarkers=true)`. Write the exact tool result text to `memory/digest-opportunities.txt`. If the tool errors, write an empty file and continue — the brief can still ship with announcements/calendar.
+
+3. **Build structured brief context.** Run:
 
    ```
-   {greeting}
-
-   It's {weekday}, {short date / week context}. Here's what's worth your attention right now.
-
-   **{N} conversations await you** ← only if there are direct (connection) candidates — receiver is a party, NOT the introducer. N = unique people, not raw opportunity count.
-   - <!-- digest-opportunity:id=<opportunityId> -->[Name](profileUrl) — 1–2 sentences on why this person matters to the user, [message Name](acceptUrl)
-   - …
-
-   **Help your community find their opportunities** ← only if there are introducer (connector-flow) candidates — receiver IS the introducer
-   A few residents are looking for something specific. If you know someone who fits, a quick nudge goes a long way.
-   - <!-- digest-opportunity:id=<opportunityId> -->[{Name}]({profileUrl}) — {their need / what they're looking for, 1–2 sentences from mainText}. {short closing phrase}, make intro
-   - …
+   bun skills/index-network/scripts/build-daily-brief-context.ts --date <YYYY-MM-DD> --opportunities-file memory/digest-opportunities.txt --state-file memory/heartbeat-state.json --out memory/daily-brief-context.json
    ```
 
-   Skip a section that has zero candidates.
+   Then read and parse `memory/daily-brief-context.json`. Treat malformed JSON as an empty context with no announcements, no events, and no opportunities. The context shape is:
 
-   **Critical rendering distinction for the introducer section:** these are *community intents* the user might know someone for — NOT opportunity cards. DO link the person's name to `profileUrl`. Do NOT link the opportunity — no `acceptUrl`; the trailing `make intro` is plain text, not a hyperlink.
+   ```json
+   {
+     "announcements": [],
+     "highlightedEvents": [],
+     "interestEvents": [],
+     "opportunities": [],
+     "connectionOpportunities": [],
+     "communityOpportunities": [],
+     "diagnostics": { "calendarSource": "edgeos|unavailable", "warnings": [] }
+   }
+   ```
 
-   **Editable delivery markers:** Every opportunity you include must carry its real opportunity id in an HTML comment marker immediately before the visible text for that opportunity: `<!-- digest-opportunity:id=<opportunityId> -->`. These markers are internal bookkeeping only; they let the later send pass confirm only the opportunities still present after Kanban edits. If you group multiple opportunities under one person, include one marker per opportunity immediately before that opportunity's phrase/sub-entry, not just one marker for the person.
+4. **Compose the brief in this structure.** Omit any section that has no verified content, except the calendar fallback rule below.
 
-7. **Quality bar (per candidate):** a candidate qualifies only if you can write a one-sentence reason specific to *this* user's situation that would not read identically for any other user. Drop generic framings.
+   ```
+   🌞 Good morning from Edge Esmeralda. It is {Weekday, Month D}
 
-8. **URL rules:** weave links into prose — the strip-the-URLs test is the rule: remove every link and the prose still reads coherently. NO bullet-list-of-links, NO link tables, NO action strips. Embed each `acceptUrl` verbatim on a short verb phrase (connection candidates only); `connector-flow` candidates carry no `acceptUrl`. For a grouped entry (same person, multiple connections) link the name once and embed each sub-entry's `acceptUrl` on a distinct topic phrase. URLs are opaque — never append, encode, or modify them. **If a connection candidate's card has no `acceptUrl` (some don't), render its verb phrase as plain text — do NOT invent a link.** The only valid link shapes are the connect link (`…/c/<code>`) and the profile link (`…/u/<id>`); never construct any other path (e.g. `/accept/<n>`, `/profile/<n>`) — those do not exist and are caught and stripped at staging (step 10).
+   Here's what you need to know today:
 
-9. If `totalPending` exceeds the candidates you surfaced, end the body with: `There are N more conversations waiting — let me know if you want to see them.`
+   **Announcements**
+   - {One current organizer announcement, only if verified}
 
-10. **Stage the brief on the board.** Write the composed body to `memory/digest-draft.md` (overwrite any existing file), then create the task — staging the body through the URL guard so any fabricated link is stripped before it ships while preserving `<!-- digest-opportunity:id=... -->` markers for editable delivery bookkeeping:
+   **The calendar today:**
+   - {EdgeOS highlighted event, if any}
+   - {Second EdgeOS highlighted event, if any}
+   - {Interest-relevant event selected from remaining today's events, if any}
 
-    ```
-    hermes kanban create "Morning digest — <YYYY-MM-DD>" --body "$(bun <HERMES_HOME>/skills/index-network/scripts/validate-digest-urls.ts <HERMES_HOME>/memory/digest-draft.md)" --idempotency-key "digest-<YYYY-MM-DD>"
-    ```
+   **Potential connections via Index Network:**
+   - <!-- digest-opportunity:id=<opportunityId when present> -->[Name](profileUrl) — 1–2 specific sentences on why this person matters to the user, [say hi](acceptUrl)
 
-    `<YYYY-MM-DD>` is today's host-local date. `<HERMES_HOME>` is your workspace root (the `--workdir` you were launched with; `~/.hermes` by default). The `validate-digest-urls.ts` guard reads the draft, removes any markdown link whose URL is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link — demoting it to plain text — and writes the cleaned body to stdout (warnings, if any, go to stderr). The deterministic guard is what `$( … )` captures, so the staged body is always the validated one; never bypass it with a bare `cat`. Double-quoting `"$( … )"` keeps the body's newlines and markdown intact (the quotes suppress word-splitting, so embedded line breaks are preserved); only a trailing newline may be trimmed, which is harmless. If your shell tool makes that awkward, run the guard over the draft first and stage its output through whatever file/stdin mechanism it provides instead — but the body you stage must be the guard's output, not the raw draft. The idempotency key prevents a duplicate task if this prompt runs twice. **Do not assign the task to anyone** — it must stay in the `todo` column so the dispatcher never runs it. After a successful create, delete `memory/digest-draft.md`.
+   **Help your community**
+   - <!-- digest-opportunity:id=<opportunityId when present> -->[Name](profileUrl) — {their need / what they're looking for, 1–2 sentences from mainText}. Know someone, [make intro](acceptUrl).
 
-11. **Record what you staged.** Update `memory/heartbeat-state.json` so that `prepared` = `{ "date": "<YYYY-MM-DD>", "taskTitle": "Morning digest — <YYYY-MM-DD>", "opportunityIds": [ every opportunity id you put in the brief, including each sub-entry of grouped cards; empty array on the quiet path ] }`. Preserve all other top-level keys (`deliveredToday`, etc.). This is an audit record of what was originally staged; the send pass confirms delivery from the markers still present in the edited Kanban body. Do NOT call `confirm_opportunity_delivery` and do NOT touch `deliveredToday` — both happen at send time.
+   That's it for now. You can always ask me for more detail, or any other questions you have!
+   ```
 
-12. **Deliver nothing.** End your turn with the host-specific no-reply marker.
+   For **The calendar today:** render `highlightedEvents` first, then `interestEvents`. Use each event's `timePacific`, `title`, optional `venue`, and `reasonHint`. Do not add events that are not present in the context JSON.
+
+   If `diagnostics.calendarSource` is `"unavailable"` and there are people sections, omit **The calendar today:** and add one plain line before the closing sentence: `I couldn't check the live calendar this morning — ask me what's on today and I'll look it up.` If the calendar is unavailable and there are no people or announcements either, stage only that one-line calendar pointer plus the closing sentence under the greeting.
+
+5. **Opportunity rendering rules.**
+   - **Potential connections via Index Network** is for direct `connection` candidates where the receiver is a party, not the introducer.
+   - **Help your community** is for `connector-flow` / introducer candidates where the receiver is the introducer.
+   - When a context opportunity has `opportunityId`, include it in an HTML marker immediately before the visible text: `<!-- digest-opportunity:id=<opportunityId> -->`. These markers let the send pass confirm only opportunities still present after Kanban edits. Some actionable MCP cards expose `acceptUrl` but not `opportunityId`; render those without a marker rather than inventing one.
+   - For direct connections, link the person's name to `profileUrl` and embed the real `acceptUrl` verbatim on a short phrase such as `[say hi](acceptUrl)`. If no `acceptUrl` is present, render the action phrase as plain text — do not invent a link.
+   - For community asks, link the person's name to `profileUrl`. If the connector-flow card includes a real `acceptUrl`, embed it verbatim on `[make intro](acceptUrl)`. If no `acceptUrl` is present, render `make intro` as plain text — do not invent a link.
+   - A candidate qualifies only if you can write a reason specific to this user's situation. Drop generic people matches.
+
+6. **URL rules.** Weave links into prose. The strip-the-URLs test is the rule: remove every link and the prose still reads coherently. No link tables, action strips, bare URLs, or fabricated URLs. The only links that may appear in the staged body are Index `profileUrl` (`/u/<uuid>`) and real `acceptUrl` links (`/c/<code>`) from direct connections or connector-flow intro approvals. Do not link calendar events because the current URL guard intentionally strips non-Index links.
+
+7. **Stage the brief on the board.** Write the composed body to `memory/digest-draft.md` (overwrite any existing file), then create the task through the deterministic URL guard:
+
+   ```
+   hermes kanban create "Morning digest — <YYYY-MM-DD>" --body "$(bun <HERMES_HOME>/skills/index-network/scripts/validate-digest-urls.ts <HERMES_HOME>/memory/digest-draft.md)" --idempotency-key "digest-<YYYY-MM-DD>"
+   ```
+
+   `<HERMES_HOME>` is your workspace root (the `--workdir` you were launched with; `~/.hermes` by default). The guard preserves `<!-- digest-opportunity:id=... -->` markers for editable delivery bookkeeping and strips fabricated markdown links. Never bypass it with a bare `cat`. Do not assign the task to anyone. After a successful create, delete `memory/digest-draft.md`.
+
+8. **Record what you staged.** Update `memory/heartbeat-state.json` so `prepared` equals `{ "date": "<YYYY-MM-DD>", "taskTitle": "Morning digest — <YYYY-MM-DD>", "opportunityIds": [ every `opportunityId` from context opportunities that you put in the brief; empty array when no opportunity ids are present ] }`. Preserve all other top-level keys. Do not call `confirm_opportunity_delivery` and do not touch `deliveredToday` — both happen at send time.
+
+9. **Deliver nothing.** End your turn with the host-specific no-reply marker.
 
 # Hard rules
-- Never invent candidates. The quiet path stages `{quietLine}`; never pad.
-- Never confirm delivery here. Never write `deliveredToday` here. This turn always ends with the host-specific no-reply marker.
+- Never invent announcements, events, people, venues, times, tracks, or action URLs.
+- Calendar failures must not block launch: ship people-only plus the one-line calendar pointer, or the pointer-only fallback if there is nothing else.
+- Never confirm delivery here. Never write `deliveredToday` here.
 - The staged body is what the user receives in the morning after internal digest markers are stripped — make the visible prose complete and final.
-- Honor the strip-the-URLs test. Never expose internal IDs, raw JSON, or internal vocabulary.
-- Never construct URLs yourself — every URL must come verbatim from an MCP tool response.
+- Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in visible prose.

--- a/skills/index-network/prompts/send.md
+++ b/skills/index-network/prompts/send.md
@@ -4,13 +4,13 @@ You are Edge, the user's agent on the Index protocol. This delivers the user's m
 Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pattern, emerging, relevant, adjacency. Never use "search" — say "looking up" / "find" / "check" / "discover". Banned: leverage, unlock, optimize, scale, disrupt, AI-powered, maximize value, act fast, networking, match. Never expose internal IDs (unless the user needs them to act, e.g. a `conversationId`), never raw JSON, never internal vocabulary. Translate: "intent" → "signal", "index/network" → "community", "pending" → "sent", "accepted" → "connected".
 
 # Job
-Deliver the staged morning brief verbatim from Kanban, then reconcile delivery bookkeeping. The Kanban task body is the source of truth: it may have been edited after the prepare pass. Do not compose, regenerate, summarize, or supplement the digest in this send pass.
+Deliver the staged morning brief verbatim from Kanban, then reconcile delivery bookkeeping. The Kanban task body is the source of truth: it may have been edited after the prepare pass. Do not compose, regenerate, summarize, or supplement the brief in this send pass.
 
-1. Resolve today's host-local date `<YYYY-MM-DD>` and the task title `Morning digest — <YYYY-MM-DD>`.
+1. Resolve today's America/Los_Angeles date `<YYYY-MM-DD>` and the task title `Morning digest — <YYYY-MM-DD>`. Do not derive today's local date from UTC alone.
 
-2. **Find the staged task.** Run `hermes kanban list --json` and find the task whose `title` equals the title from step 1 and whose status is `todo`. Parse the JSON; never surface it to the user.
+2. **Find the staged task.** Run `hermes kanban list --json` and find the task whose `title` equals the title from step 1 and whose normalized lower-case status is one of `todo` or `ready`. Hermes may show unassigned created tasks in either column depending on version. Parse the JSON; never surface it to the user.
 
-3. **If no staged task is found:** end your turn with `[SILENT]`. Do not call `list_opportunities`, do not compose a fallback digest, do not update delivery state, and do not message the user.
+3. **If no staged task is found:** end your turn with `[SILENT]`. Do not call `list_opportunities`, do not compose a fallback brief, do not update delivery state, and do not message the user.
 
 4. **If the staged task is found:** take its `body` and `id`. The edited `body` is authoritative.
 
@@ -39,7 +39,7 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
     Use stdout as your final assistant reply. The guard strips any markdown link whose URL is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link, and removes internal `<!-- digest-opportunity:id=... -->` comments. **Your final assistant reply is the guard's output, verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting beyond the guard's deterministic stripping.** Hermes delivers it. End your turn.
 
 # Hard rules
-- The Kanban task body is the source of truth. Never regenerate the digest in this send pass.
+- The Kanban task body is the source of truth. Never regenerate the brief in this send pass.
 - If no staged task exists, stay silent; the next prepare pass can try again.
 - Confirm delivery only for opportunity markers still present in the edited Kanban body.
 - Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in the reply.

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -1,0 +1,421 @@
+#!/usr/bin/env bun
+/**
+ * Build deterministic source context for the daily morning brief.
+ *
+ * The composer prompt still writes the final prose, but this script owns the
+ * mechanical fetching/ranking pieces: admin announcements, today's EdgeOS
+ * highlighted events, a simple interest-fill event, and parsed Index MCP
+ * opportunity cards when the prompt provides a list_opportunities transcript.
+ *
+ * Usage (from $HERMES_HOME):
+ *   bun skills/index-network/scripts/build-daily-brief-context.ts \
+ *     --opportunities-file memory/digest-opportunities.txt \
+ *     --state-file memory/heartbeat-state.json \
+ *     --out memory/daily-brief-context.json
+ */
+
+const POPUP_ID = "43746fd0-bce2-472b-93e4-a438177b2dff";
+const EDGEOS_BASE = "https://api.edgeos.world/api/v1";
+const PACIFIC_TZ = "America/Los_Angeles";
+
+const EDGE_TAGS = [
+  "Consciousness",
+  "Health & Longevity",
+  "Wellbeing",
+  "Bio & Neuro",
+  "AI",
+  "Governance & Coordination",
+  "Hard Tech",
+  "Privacy",
+  "d/acc",
+  "Art & Culture",
+  "Decentralized Tech",
+  "Creative AI & Technologies",
+  "Spatial Computing",
+  "New Urbanism",
+  "Education",
+  "Energy & Climate",
+  "Food Systems",
+];
+
+const TAG_KEYWORDS: Record<string, string[]> = {
+  "Health & Longevity": ["health", "longevity", "aging", "wellness", "medicine", "biotech"],
+  "Bio & Neuro": ["bio", "biology", "neuro", "brain", "buck", "science", "lab"],
+  AI: ["ai", "agent", "agents", "llm", "machine learning", "model", "automation"],
+  "Governance & Coordination": ["governance", "coordination", "consent", "collective", "decision", "polis"],
+  "Hard Tech": ["hardware", "robotics", "manufacturing", "hard tech", "engineering"],
+  Privacy: ["privacy", "security", "cryptography", "zero knowledge", "zk"],
+  "Decentralized Tech": ["decentralized", "protocol", "crypto", "web3", "network", "p2p"],
+  "Creative AI & Technologies": ["creative", "art", "design", "media", "generative"],
+  "Spatial Computing": ["spatial", "xr", "ar", "vr", "metaverse"],
+  "New Urbanism": ["urban", "city", "town", "housing", "real estate"],
+  Education: ["education", "learning", "school", "children", "kids"],
+  "Energy & Climate": ["energy", "climate", "solar", "carbon", "environment"],
+  "Food Systems": ["food", "agriculture", "farming", "nutrition"],
+  Consciousness: ["consciousness", "meditation", "mindfulness", "meaning"],
+  Wellbeing: ["wellbeing", "fitness", "workout", "sauna", "breathwork"],
+  "d/acc": ["d/acc", "defensive acceleration", "biosecurity"],
+  "Art & Culture": ["art", "culture", "music", "film", "storytelling"],
+};
+
+export interface BriefAnnouncement {
+  id?: string;
+  body: string;
+  priority?: number;
+}
+
+export interface BriefEvent {
+  id?: string;
+  title: string;
+  startTime: string;
+  endTime?: string | null;
+  timePacific: string;
+  venue?: string | null;
+  tags: string[];
+  highlighted: boolean;
+  reasonHint: string;
+}
+
+export interface BriefOpportunity {
+  name: string;
+  mainText?: string;
+  status?: string;
+  profileUrl?: string;
+  acceptUrl?: string;
+  feedCategory?: string;
+  opportunityId?: string;
+}
+
+export interface DailyBriefContext {
+  date: string;
+  displayDate: string;
+  timezone: "America/Los_Angeles";
+  announcements: BriefAnnouncement[];
+  highlightedEvents: BriefEvent[];
+  interestEvents: BriefEvent[];
+  opportunities: BriefOpportunity[];
+  connectionOpportunities: BriefOpportunity[];
+  communityOpportunities: BriefOpportunity[];
+  diagnostics: {
+    announcementsSource: "control-plane" | "unavailable";
+    calendarSource: "edgeos" | "unavailable";
+    opportunitySource: "file" | "unavailable";
+    warnings: string[];
+    interestTags: string[];
+  };
+}
+
+type EdgeEvent = Record<string, unknown> & {
+  id?: string;
+  title?: string;
+  start_time?: string;
+  end_time?: string | null;
+  tags?: string[];
+  highlighted?: boolean;
+  venue_title?: string | null;
+  custom_location_name?: string | null;
+  host_display_name?: string | null;
+};
+
+export function pacificDate(now = new Date()): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: PACIFIC_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(now);
+  const lookup = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  return `${lookup.year}-${lookup.month}-${lookup.day}`;
+}
+
+export function displayDate(date: string): string {
+  const d = new Date(`${date}T12:00:00-08:00`);
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: PACIFIC_TZ,
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  }).format(d);
+}
+
+export function pacificDayBounds(date: string): { startIso: string; endIso: string } {
+  const start = new Date(`${date}T00:00:00-08:00`);
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  return { startIso: start.toISOString(), endIso: end.toISOString() };
+}
+
+export function formatPacificTime(iso: string): string {
+  const d = new Date(iso);
+  const time = new Intl.DateTimeFormat("en-US", {
+    timeZone: PACIFIC_TZ,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(d);
+  return `${time} PST`;
+}
+
+export function extractInterestTags(text: string): string[] {
+  const haystack = text.toLowerCase();
+  const scored = EDGE_TAGS.map((tag) => {
+    const keywords = TAG_KEYWORDS[tag] ?? [tag.toLowerCase()];
+    const score = keywords.reduce((sum, keyword) => sum + (haystack.includes(keyword.toLowerCase()) ? 1 : 0), 0);
+    return { tag, score };
+  })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.tag.localeCompare(b.tag));
+  return scored.map((entry) => entry.tag).slice(0, 6);
+}
+
+function eventVenue(event: EdgeEvent): string | null {
+  return event.venue_title ?? event.custom_location_name ?? null;
+}
+
+function eventScore(event: EdgeEvent, interestTags: string[]): number {
+  const tags = Array.isArray(event.tags) ? event.tags : [];
+  const title = String(event.title ?? "").toLowerCase();
+  let score = 0;
+  for (const tag of interestTags) {
+    if (tags.includes(tag)) score += 3;
+    for (const keyword of TAG_KEYWORDS[tag] ?? []) {
+      if (title.includes(keyword.toLowerCase())) score += 1;
+    }
+  }
+  return score;
+}
+
+function toBriefEvent(event: EdgeEvent, reasonHint: string): BriefEvent | null {
+  if (!event.title || !event.start_time) return null;
+  return {
+    id: event.id,
+    title: event.title,
+    startTime: event.start_time,
+    endTime: event.end_time,
+    timePacific: formatPacificTime(event.start_time),
+    venue: eventVenue(event),
+    tags: Array.isArray(event.tags) ? event.tags : [],
+    highlighted: event.highlighted === true,
+    reasonHint,
+  };
+}
+
+export function selectEvents(events: EdgeEvent[], interestTags: string[]): { highlightedEvents: BriefEvent[]; interestEvents: BriefEvent[] } {
+  const byStart = [...events].sort((a, b) => String(a.start_time ?? "").localeCompare(String(b.start_time ?? "")));
+  const highlightedEvents = byStart
+    .filter((event) => event.highlighted === true)
+    .map((event) => toBriefEvent(event, "Highlighted by the EdgeOS calendar."))
+    .filter((event): event is BriefEvent => Boolean(event))
+    .slice(0, 2);
+
+  const used = new Set(highlightedEvents.map((event) => event.id ?? `${event.title}:${event.startTime}`));
+  const scored = byStart
+    .filter((event) => !used.has(event.id ?? `${event.title}:${event.start_time}`))
+    .map((event) => ({ event, score: eventScore(event, interestTags) }))
+    .sort((a, b) => b.score - a.score || String(a.event.start_time ?? "").localeCompare(String(b.event.start_time ?? "")));
+
+  const fillCount = highlightedEvents.length > 0 ? Math.max(0, 3 - highlightedEvents.length) : 3;
+  const interestEvents = scored
+    .filter((entry) => highlightedEvents.length === 0 || entry.score > 0)
+    .slice(0, fillCount)
+    .map((entry) =>
+      toBriefEvent(
+        entry.event,
+        entry.score > 0 ? "Selected because it overlaps with the user's known interests." : "Useful village event today.",
+      ),
+    )
+    .filter((event): event is BriefEvent => Boolean(event));
+
+  return { highlightedEvents, interestEvents };
+}
+
+export function parseOpportunityTranscript(text: string): BriefOpportunity[] {
+  const cards: BriefOpportunity[] = [];
+  let current: BriefOpportunity | null = null;
+
+  const flush = () => {
+    if (current?.name) cards.push(current);
+    current = null;
+  };
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    const header = line.match(/^\d+\.\s+(.+)$/);
+    if (header) {
+      flush();
+      current = { name: header[1].trim() };
+      continue;
+    }
+    if (!current) continue;
+
+    const marker = line.trim().match(/^<!--\s*digest-opportunity:id=([^\s>]+)\s*-->$/);
+    if (marker) {
+      current.opportunityId = marker[1];
+      continue;
+    }
+
+    const field = line.trim().match(/^(status|profileUrl|acceptUrl|feedCategory|opportunityId):\s*(.+)$/);
+    if (field) {
+      const key = field[1] as keyof BriefOpportunity;
+      current[key] = field[2].trim();
+      continue;
+    }
+
+    const body = line.trim();
+    if (body && !body.startsWith("Summarize ") && !body.startsWith("For each ")) {
+      current.mainText = current.mainText ? `${current.mainText} ${body}` : body;
+    }
+  }
+  flush();
+  return cards;
+}
+
+export function filterDedupedOpportunities(opportunities: BriefOpportunity[], deliveredIds: Set<string>): BriefOpportunity[] {
+  return opportunities.filter((opp) => !opp.opportunityId || !deliveredIds.has(opp.opportunityId));
+}
+
+async function readIfExists(path: string): Promise<string> {
+  try {
+    return await Bun.file(path).text();
+  } catch {
+    return "";
+  }
+}
+
+async function readDeliveredIds(stateFile: string, date: string): Promise<Set<string>> {
+  try {
+    const raw = await Bun.file(stateFile).text();
+    const parsed = JSON.parse(raw) as { deliveredToday?: { date?: string; ids?: unknown } };
+    if (parsed.deliveredToday?.date === date && Array.isArray(parsed.deliveredToday.ids)) {
+      return new Set(parsed.deliveredToday.ids.filter((id): id is string => typeof id === "string"));
+    }
+  } catch {
+    // missing/malformed state should not block the brief
+  }
+  return new Set();
+}
+
+async function fetchAnnouncements(date: string, warnings: string[]): Promise<{ source: "control-plane" | "unavailable"; announcements: BriefAnnouncement[] }> {
+  const base = process.env.EDGE_AGENT_CONTROL_PLANE_URL?.replace(/\/$/, "");
+  const token = process.env.ADMIN_TOKEN;
+  if (!base || !token) return { source: "unavailable", announcements: [] };
+  try {
+    const res = await fetch(`${base}/brief/announcements?date=${encodeURIComponent(date)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const data = (await res.json()) as { announcements?: Array<{ id?: string; body?: string; priority?: number }> };
+    return {
+      source: "control-plane",
+      announcements: (data.announcements ?? [])
+        .filter((item) => typeof item.body === "string" && item.body.trim())
+        .map((item) => ({ id: item.id, body: item.body!.trim(), priority: item.priority })),
+    };
+  } catch (err) {
+    warnings.push(`announcements unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    return { source: "unavailable", announcements: [] };
+  }
+}
+
+async function fetchEvents(date: string, interestTags: string[], warnings: string[]): Promise<{ source: "edgeos" | "unavailable"; highlightedEvents: BriefEvent[]; interestEvents: BriefEvent[] }> {
+  const token = process.env.EDGEOS_API_KEY;
+  if (!token) return { source: "unavailable", highlightedEvents: [], interestEvents: [] };
+  const { startIso, endIso } = pacificDayBounds(date);
+  const params = new URLSearchParams({
+    popup_id: POPUP_ID,
+    event_status: "published",
+    start_after: startIso,
+    start_before: endIso,
+    limit: "100",
+  });
+  try {
+    const res = await fetch(`${EDGEOS_BASE}/events/portal/events?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const data = (await res.json()) as { results?: EdgeEvent[] };
+    const { highlightedEvents, interestEvents } = selectEvents(data.results ?? [], interestTags);
+    return { source: "edgeos", highlightedEvents, interestEvents };
+  } catch (err) {
+    warnings.push(`calendar unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    return { source: "unavailable", highlightedEvents: [], interestEvents: [] };
+  }
+}
+
+function argValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+export async function buildDailyBriefContext(options: {
+  date?: string;
+  stateFile?: string;
+  opportunitiesFile?: string;
+  userFiles?: string[];
+} = {}): Promise<DailyBriefContext> {
+  const date = options.date ?? pacificDate();
+  const warnings: string[] = [];
+  const userFiles = options.userFiles ?? ["USER.md", "MEMORY.md", `memory/${date}.md`];
+  const interestText = (await Promise.all(userFiles.map(readIfExists))).join("\n");
+  const interestTags = extractInterestTags(interestText);
+
+  const [announcementResult, eventResult] = await Promise.all([
+    fetchAnnouncements(date, warnings),
+    fetchEvents(date, interestTags, warnings),
+  ]);
+
+  let opportunities: BriefOpportunity[] = [];
+  let opportunitySource: "file" | "unavailable" = "unavailable";
+  if (options.opportunitiesFile) {
+    const transcript = await readIfExists(options.opportunitiesFile);
+    if (transcript.trim()) {
+      opportunitySource = "file";
+      const deliveredIds = await readDeliveredIds(options.stateFile ?? "memory/heartbeat-state.json", date);
+      opportunities = filterDedupedOpportunities(parseOpportunityTranscript(transcript), deliveredIds);
+    }
+  }
+
+  return {
+    date,
+    displayDate: displayDate(date),
+    timezone: PACIFIC_TZ,
+    announcements: announcementResult.announcements,
+    highlightedEvents: eventResult.highlightedEvents,
+    interestEvents: eventResult.interestEvents,
+    opportunities,
+    connectionOpportunities: opportunities.filter((opp) => opp.feedCategory === "connection"),
+    communityOpportunities: opportunities.filter((opp) => opp.feedCategory === "connector-flow"),
+    diagnostics: {
+      announcementsSource: announcementResult.source,
+      calendarSource: eventResult.source,
+      opportunitySource,
+      warnings,
+      interestTags,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const context = await buildDailyBriefContext({
+    date: argValue(args, "--date"),
+    stateFile: argValue(args, "--state-file"),
+    opportunitiesFile: argValue(args, "--opportunities-file"),
+    userFiles: args.includes("--user-file")
+      ? args
+          .flatMap((arg, idx) => (arg === "--user-file" ? [args[idx + 1]] : []))
+          .filter((path): path is string => Boolean(path))
+      : undefined,
+  });
+
+  const json = `${JSON.stringify(context, null, 2)}\n`;
+  const out = argValue(args, "--out");
+  if (out) {
+    await Bun.write(out, json);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractInterestTags,
+  filterDedupedOpportunities,
+  formatPacificTime,
+  parseOpportunityTranscript,
+  selectEvents,
+} from "../build-daily-brief-context";
+
+describe("build-daily-brief-context helpers", () => {
+  test("extractInterestTags maps user text to EdgeOS tags", () => {
+    expect(extractInterestTags("I build AI agents for longevity research and decentralized protocols"))
+      .toEqual(expect.arrayContaining(["AI", "Health & Longevity", "Decentralized Tech"]));
+  });
+
+  test("selectEvents puts highlighted events first and fills with interest events", () => {
+    const events = [
+      {
+        id: "e1",
+        title: "Breakfast",
+        start_time: "2026-06-04T16:00:00Z",
+        highlighted: true,
+        tags: ["Wellbeing"],
+        venue_title: "Plaza",
+      },
+      {
+        id: "e2",
+        title: "AI Agents Salon",
+        start_time: "2026-06-04T20:00:00Z",
+        highlighted: false,
+        tags: ["AI"],
+      },
+      {
+        id: "e3",
+        title: "Community Dinner",
+        start_time: "2026-06-05T01:00:00Z",
+        highlighted: true,
+        tags: [],
+      },
+      {
+        id: "e4",
+        title: "Unrelated Late Jam",
+        start_time: "2026-06-05T03:00:00Z",
+        highlighted: false,
+        tags: [],
+      },
+    ];
+
+    const selected = selectEvents(events, ["AI"]);
+
+    expect(selected.highlightedEvents.map((event) => event.id)).toEqual(["e1", "e3"]);
+    expect(selected.interestEvents.map((event) => event.id)).toEqual(["e2"]);
+  });
+
+  test("selectEvents falls back when no events are highlighted", () => {
+    const events = [
+      { id: "e1", title: "AI Agents", start_time: "2026-06-04T16:00:00Z", highlighted: false, tags: ["AI"] },
+      { id: "e2", title: "Protocol Design", start_time: "2026-06-04T17:00:00Z", highlighted: false, tags: ["Decentralized Tech"] },
+      { id: "e3", title: "Lunch", start_time: "2026-06-04T19:00:00Z", highlighted: false, tags: [] },
+    ];
+
+    const selected = selectEvents(events, ["AI", "Decentralized Tech"]);
+
+    expect(selected.highlightedEvents).toEqual([]);
+    expect(selected.interestEvents.map((event) => event.id)).toEqual(["e1", "e2", "e3"]);
+  });
+
+  test("parseOpportunityTranscript reads MCP prose cards", () => {
+    const parsed = parseOpportunityTranscript(`Here are your opportunities:\n\n1. Nathan Price\n   <!-- digest-opportunity:id=opp-direct-1 -->\n   builds the intelligence layer for human aging\n   status: pending\n   profileUrl: https://index.network/u/11111111-1111-1111-1111-111111111111\n   acceptUrl: https://index.network/c/abc123\n   feedCategory: connection\n\n2. Remi\n   <!-- digest-opportunity:id=opp-intro-1 -->\n   looking for a systems engineer\n   status: latent\n   profileUrl: https://index.network/u/22222222-2222-2222-2222-222222222222\n   acceptUrl: https://index.network/c/def456\n   feedCategory: connector-flow`);
+
+    expect(parsed).toEqual([
+      {
+        name: "Nathan Price",
+        opportunityId: "opp-direct-1",
+        mainText: "builds the intelligence layer for human aging",
+        status: "pending",
+        profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
+        acceptUrl: "https://index.network/c/abc123",
+        feedCategory: "connection",
+      },
+      {
+        name: "Remi",
+        opportunityId: "opp-intro-1",
+        mainText: "looking for a systems engineer",
+        status: "latent",
+        profileUrl: "https://index.network/u/22222222-2222-2222-2222-222222222222",
+        acceptUrl: "https://index.network/c/def456",
+        feedCategory: "connector-flow",
+      },
+    ]);
+  });
+
+  test("filterDedupedOpportunities keeps cards without ids and drops delivered ids", () => {
+    expect(
+      filterDedupedOpportunities(
+        [{ name: "A", opportunityId: "opp-1" }, { name: "B" }, { name: "C", opportunityId: "opp-2" }],
+        new Set(["opp-1"]),
+      ).map((opp) => opp.name),
+    ).toEqual(["B", "C"]);
+  });
+
+  test("formatPacificTime renders PST label per product language", () => {
+    expect(formatPacificTime("2026-06-04T16:30:00Z")).toMatch(/PST$/);
+  });
+});

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -38,7 +38,7 @@ Here's what I can do:
 
 **Find your way around.** I know everything on the village calendar: every talk, workshop, dinner, and morning workout across the four weeks. Ask what's worth your time and I'll RSVP you in one line.
 
-**Find your people.** Tell me what you're building, looking for, or curious about, and I'll put it out into the village and quietly find the residents who match. The strongest ones land in your morning brief, so the right people find you while you go live your day.
+**Find your people.** Tell me what you're building, looking for, or curious about, and I'll put it out into the village and quietly find the residents who match. The strongest ones land alongside today's village calendar in your morning brief, so the right people find you while you go live your day.
 
 Want to try me? Ask 'what's on for the rest of today?' Or just tell me what you're looking for, and I'll start finding your people.
 
@@ -93,7 +93,7 @@ Weave URLs into prose. Links must be **secondary**: strip every URL and the sent
 
 ## Cron schedule
 
-The morning digest is delivered at 08:00 host-local. It runs as two background dispatches — a prepare pass earlier that composes the brief, and a send pass at 08:00 that delivers it — neither of which is your job to trigger. The time is **fixed and not user-configurable.** If the user asks to move, disable, or add digests, say plainly that the morning brief runs at a set time and can't be changed; never name internal files, crons, or storage.
+The morning brief is delivered at 08:00 host-local. It runs as two background dispatches — a prepare pass earlier that composes the brief, and a send pass at 08:00 that delivers it — neither of which is your job to trigger. It includes today's village calendar when the live calendar is reachable, plus relevant people and community asks. The time is **fixed and not user-configurable.** If the user asks to move, disable, or add briefs, say plainly that the morning brief runs at a set time and can't be changed; never name internal files, crons, or storage.
 
 ## Red lines
 


### PR DESCRIPTION
## New Features

- Add deterministic daily brief context builder for announcements, EdgeOS calendar events, interest-fill events, and Index opportunities.
- Update the morning brief prepare/send prompts for editable Kanban staging and delivery confirmation.
- Enable the 08:00 send cron by default.
- Document EdgeOS `highlighted` events and connector-flow `make intro` rendering.

## Bug Fixes

- Only link `make intro` when a real `acceptUrl` exists.
- Preserve digest opportunity markers through Kanban editing so the send pass confirms only delivered opportunities.

## Tests

```sh
cd packages/agentvillage && bun test skills/index-network/scripts/tests/build-daily-brief-context.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts install/tests/cron_specs.test.ts
```

## Dependencies

- Depends on indexnetwork/index#889 for `list_opportunities(includeDigestMarkers=true)`.
