### PR TITLE
fix(index-network): use say hi opportunity links

### DIFF
--- a/skills/index-network/scripts/tests/validate-digest-urls.test.ts
+++ b/skills/index-network/scripts/tests/validate-digest-urls.test.ts
@@ -8,12 +8,12 @@ import {
 
 describe("sanitizeDigestUrls", () => {
   test("strips a fabricated /accept/<n> link, keeping the link text as plain prose", () => {
-    const md = "- [Alex Rivera](https://index.network/u/11111111-1111-1111-1111-111111111111) — a specialist, [message Alex](https://index.network/accept/901)";
+    const md = "- [Alex Rivera](https://index.network/u/11111111-1111-1111-1111-111111111111) — a specialist, [say hi](https://index.network/accept/901)";
 
     const { output, stripped } = sanitizeDigestUrls(md);
 
     // The fabricated accept link is demoted to its label text.
-    expect(output).toContain("message Alex");
+    expect(output).toContain("say hi");
     expect(output).not.toContain("/accept/901");
     expect(output).not.toContain("(https://index.network/accept/901)");
     // The real profile link survives untouched.
@@ -22,7 +22,7 @@ describe("sanitizeDigestUrls", () => {
   });
 
   test("preserves a legitimate /c/<code> connect link including its query string", () => {
-    const md = "[message Maya](https://protocol.index.network/c/Abc1234567?link_preview=false)";
+    const md = "[say hi](https://protocol.index.network/c/Abc1234567?link_preview=false)";
 
     const { output, stripped } = sanitizeDigestUrls(md);
 

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -86,7 +86,7 @@ MCP tools (Index Network, Hermes built-ins) or HTTP recipes in skills (`edgeos/S
 Weave URLs into prose. Links must be **secondary**: strip every URL and the sentence still reads. No link strips, bullet lists of links, pipe rows, tables, or standalone link-label paragraphs.
 
 - Link names to `profileUrl` on first mention.
-- Embed `acceptUrl` on a short verb phrase ("message Alex", "make intro").
+- Embed `acceptUrl` on a short verb phrase ("say hi", "make intro").
 - URLs verbatim — do not edit, shorten, or proxy.
 - If you skip an opportunity, omit it — don't dump data without an inline action link.
 - **Never construct URLs yourself.** Every URL you output must come verbatim from an MCP tool response. If the user asks where to find their profile or data, and no tool has returned a URL for it, tell them you don't have a link for that — do not guess one.


### PR DESCRIPTION
## Summary
- Update AgentVillage URL guidance so opportunity accept links use "say hi" instead of "message <name>".
- Refresh digest URL guard tests to use the new link label in examples.

## Verification
- bun test skills/index-network/scripts/tests/validate-digest-urls.test.ts