### PR TITLE
fix(agentvillage): reconcile digest cron prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ The digest runs as a fixed prepare/send pair — **prepare `0 2 * * *`, send `0 
 |---|---|---|
 | Override the digest times for one install | `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the default. |
 | Change the default digest schedule for everyone | `install/install_index.ts` (`DIGEST_CRON_SPECS`) | The installer writes the cron entries from this table. Existing installs pick up changes on the next `install.ts` run. |
-| Change a cron prompt without changing the schedule | the matching `skills/index-network/prompts/<name>.md` | The installer references prompt files by name via `DIGEST_CRON_SPECS`; rename only if you also rename there. |
+| Change a cron prompt without changing the schedule | the matching `skills/index-network/prompts/<name>.md` | Hermes stores prompt copies in cron jobs. Hosted residents are refreshed by the control-plane post-merge sync, which calls each sidecar's `/update` endpoint and reruns the installer. For non-control-plane installs or recovery, run `HERMES_HOME=<resident-home> bun install/reconcile_digest_crons.ts` after updated skill files are copied. |
 
 ### Backends & skills
 

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -246,7 +246,7 @@ function hermesAvailable(bin: string): boolean {
   }
 }
 
-function installCronJobs(env: NodeJS.ProcessEnv): void {
+export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()): void {
   const home = hermesHome();
   const promptsDir = join(home, "skills/index-network/prompts");
 
@@ -260,7 +260,7 @@ function installCronJobs(env: NodeJS.ProcessEnv): void {
 
   // Ensure the Kanban store exists (idempotent; prepare/send stage tasks on it).
   try {
-    execFileSync(bin, ["kanban", "init"], { stdio: "ignore", env: hermesExecEnv() });
+    execFileSync(bin, ["kanban", "init"], { stdio: "ignore", env });
   } catch {
     console.warn("  warning: could not run `hermes kanban init` — board may auto-init on first use");
   }
@@ -280,14 +280,14 @@ function installCronJobs(env: NodeJS.ProcessEnv): void {
     try {
       execFileSync(bin, cronCreateArgs(resolved, promptBody, home), {
         stdio: ["ignore", "ignore", "inherit"],
-        env: hermesExecEnv(),
+        env,
       });
     } catch {
       console.warn(`  warning: could not install cron "${spec.name}" — gateway may still run`);
       continue;
     }
 
-    if (spec.paused) pauseCronByName(spec.name, hermesExecEnv());
+    if (spec.paused) pauseCronByName(spec.name, env);
   }
 }
 
@@ -302,6 +302,6 @@ export function installIndex(): void {
   writeMcpServerEntry(apiKey, telegramHandle);
 
   if (!process.argv.includes("--skip-crons")) {
-    installCronJobs(hermesExecEnv());
+    reconcileDigestCronJobs(hermesExecEnv());
   }
 }

--- a/install/reconcile_digest_crons.ts
+++ b/install/reconcile_digest_crons.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env bun
+/**
+ * Reconcile AgentVillage's stored Hermes digest cron jobs with the currently
+ * installed prompt files under `$HERMES_HOME/skills/index-network/prompts`.
+ *
+ * Hermes stores a copy of each cron prompt at creation time, so updating the
+ * workspace files alone does not update existing residents' scheduled jobs.
+ * Run this after copying new skill files into a resident workspace, or as a
+ * fleet repair command, to remove stale Edge digest jobs and recreate them with
+ * current prompt bodies while preserving all user memory and Kanban data.
+ *
+ * Usage:
+ *   HERMES_HOME=/opt/data bun install/reconcile_digest_crons.ts
+ */
+
+import { hermesExecEnv } from "./hermes_cli";
+import { reconcileDigestCronJobs } from "./install_index";
+
+console.log("AgentVillage digest cron reconciler");
+console.log("====================================");
+reconcileDigestCronJobs(hermesExecEnv());
+console.log("✓ digest crons reconciled");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- add a standalone digest cron reconciler for existing Hermes residents
- reuse the reconciler from the Index installer so digest crons are recreated from current prompt files
- document the required fleet reconciliation step after prompt changes
- bump package version to 0.3.11

## Verification
- bun test install/tests/cron_specs.test.ts skills/index-network/scripts/tests/build-daily-brief-context.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts
- operationally reconciled running configured Railway Hermes residents; yanki@index.network / hermes-pool-939a1476 now has current prepare/send cron prompts and enabled send cron

## Notes
- This preserves resident memory and Kanban data; reconciliation removes/recreates only Edge digest cron jobs.
- One exited Railway service (hermes-pool-ec827141) still needs restart before it can be reconciled.