### PR TITLE
fix(index-network): use kanban block positional reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/prompts/prepare.md
+++ b/skills/index-network/prompts/prepare.md
@@ -94,7 +94,7 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
    Then **block the task to hold it for human review:**
 
    ```
-   hermes kanban block <taskId> --reason "review-required: morning brief — <YYYY-MM-DD>"
+   hermes kanban block <taskId> "review-required: morning brief — <YYYY-MM-DD>"
    ```
 
    This parks the brief in the **Blocked** column. The 08:00 send pass delivers it **only after a human approves it by unblocking it** (`hermes kanban unblock <taskId>`, or the board's unblock control). Never assign the task or move it to **Ready** — Ready/assigned hands the task to the dispatcher, which is not how the brief ships. After a successful create + block, delete `memory/digest-draft.md`. (Re-running this prompt is safe: the idempotency key prevents a duplicate task, and re-blocking an already-staged task is harmless.)


### PR DESCRIPTION
## Summary
- update the morning brief prepare prompt to call `hermes kanban block <taskId> "reason"`, matching the installed Hermes CLI
- bump AgentVillage to 0.3.12

## Verification
- manually confirmed the prepared digest card had a valid body but stayed ready because `hermes kanban block --reason ...` is not supported by the deployed CLI
- manually blocked `t_dedd9dde` for yanki@index.network
- `bun test install/tests/cron_specs.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts skills/index-network/scripts/tests/build-daily-brief-context.test.ts`
