### PR TITLE
fix(index-network): stage daily brief deterministically

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/prompts/prepare.md
+++ b/skills/index-network/prompts/prepare.md
@@ -19,92 +19,21 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 
 ## Steps
 
-1. **Resolve local date.** Determine today's America/Los_Angeles date as `<YYYY-MM-DD>` and display it as `{Weekday, Month D}`. Use greeting exactly:
+1. **Fetch and persist Index opportunities.** Call `list_opportunities(includeDigestMarkers=true)`. Write the exact tool result text to `memory/digest-opportunities.txt`. If the tool errors, write an empty file and continue — the brief can still ship with announcements/calendar.
 
-   `🌞 Good morning from Edge Esmeralda. It is {Weekday, Month D}`
-
-2. **Fetch and persist Index opportunities.** Call `list_opportunities(includeDigestMarkers=true)`. Write the exact tool result text to `memory/digest-opportunities.txt`. If the tool errors, write an empty file and continue — the brief can still ship with announcements/calendar.
-
-3. **Build structured brief context.** Run:
+2. **Run the deterministic staging script.** Do not compose the brief yourself, do not write ad-hoc Python/JavaScript, do not shell-quote a body, and do not call `hermes kanban create` or `hermes kanban block` directly. Run exactly:
 
    ```
-   bun skills/index-network/scripts/build-daily-brief-context.ts --date <YYYY-MM-DD> --opportunities-file memory/digest-opportunities.txt --state-file memory/heartbeat-state.json --out memory/daily-brief-context.json
+   bun skills/index-network/scripts/stage-daily-brief.ts --opportunities-file memory/digest-opportunities.txt --state-file memory/heartbeat-state.json --context-out memory/daily-brief-context.json
    ```
 
-   Then read and parse `memory/daily-brief-context.json`. Treat malformed JSON as an empty context with no announcements, no events, and no opportunities. The context shape is:
+   The script resolves the America/Los_Angeles date, builds structured context, composes the markdown body, runs the URL guard, creates the Kanban task with argv-safe `--body`, blocks it for review, and records `prepared.taskId` in `memory/heartbeat-state.json`. Its JSON stdout is for diagnostics only; do not expose it.
 
-   ```json
-   {
-     "announcements": [],
-     "highlightedEvents": [],
-     "interestEvents": [],
-     "opportunities": [],
-     "connectionOpportunities": [],
-     "communityOpportunities": [],
-     "diagnostics": { "calendarSource": "edgeos|unavailable", "warnings": [] }
-   }
-   ```
-
-4. **Compose the brief in this structure.** Omit any section that has no verified content, except the calendar fallback rule below.
-
-   ```
-   🌞 Good morning from Edge Esmeralda. It is {Weekday, Month D}
-
-   Here's what you need to know today:
-
-   **Announcements**
-   - {One current organizer announcement, only if verified}
-
-   **The calendar today:**
-   - {EdgeOS highlighted event, if any}
-   - {Second EdgeOS highlighted event, if any}
-   - {Interest-relevant event selected from remaining today's events, if any}
-
-   **Potential connections via Index Network:**
-   - <!-- digest-opportunity:id=<opportunityId when present> -->[Name](profileUrl) — 1–2 specific sentences on why this person matters to the user, [say hi](acceptUrl)
-
-   **Help your community**
-   - <!-- digest-opportunity:id=<opportunityId when present> -->[Name](profileUrl) — {their need / what they're looking for, 1–2 sentences from mainText}. Know someone, [make intro](acceptUrl).
-
-   That's it for now. You can always ask me for more detail, or any other questions you have!
-   ```
-
-   For **The calendar today:** render `highlightedEvents` first, then `interestEvents`. Use each event's `timePacific`, `title`, optional `venue`, and `reasonHint`. Do not add events that are not present in the context JSON.
-
-   If `diagnostics.calendarSource` is `"unavailable"` and there are people sections, omit **The calendar today:** and add one plain line before the closing sentence: `I couldn't check the live calendar this morning — ask me what's on today and I'll look it up.` If the calendar is unavailable and there are no people or announcements either, stage only that one-line calendar pointer plus the closing sentence under the greeting.
-
-5. **Opportunity rendering rules.**
-   - **Potential connections via Index Network** is for direct `connection` candidates where the receiver is a party, not the introducer.
-   - **Help your community** is for `connector-flow` / introducer candidates where the receiver is the introducer.
-   - When a context opportunity has `opportunityId`, include it in an HTML marker immediately before the visible text: `<!-- digest-opportunity:id=<opportunityId> -->`. These markers let the send pass confirm only opportunities still present after Kanban edits. Some actionable MCP cards expose `acceptUrl` but not `opportunityId`; render those without a marker rather than inventing one.
-   - For direct connections, link the person's name to `profileUrl` and embed the real `acceptUrl` verbatim on a short phrase such as `[say hi](acceptUrl)`. If no `acceptUrl` is present, render the action phrase as plain text — do not invent a link.
-   - For community asks, link the person's name to `profileUrl`. If the connector-flow card includes a real `acceptUrl`, embed it verbatim on `[make intro](acceptUrl)`. If no `acceptUrl` is present, render `make intro` as plain text — do not invent a link.
-   - A candidate qualifies only if you can write a reason specific to this user's situation. Drop generic people matches.
-
-6. **URL rules.** Weave links into prose. The strip-the-URLs test is the rule: remove every link and the prose still reads coherently. No link tables, action strips, bare URLs, or fabricated URLs. The only links that may appear in the staged body are Index `profileUrl` (`/u/<uuid>`) and real `acceptUrl` links (`/c/<code>`) from direct connections or connector-flow intro approvals. Do not link calendar events because the current URL guard intentionally strips non-Index links.
-
-7. **Stage the brief on the board, then hold it for review.** Write the composed body to `memory/digest-draft.md` (overwrite any existing file), then create the task through the deterministic URL guard and capture its id with `--json`:
-
-   ```
-   hermes kanban create "Morning digest — <YYYY-MM-DD>" --body "$(bun <HERMES_HOME>/skills/index-network/scripts/validate-digest-urls.ts <HERMES_HOME>/memory/digest-draft.md)" --idempotency-key "digest-<YYYY-MM-DD>" --json
-   ```
-
-   `<HERMES_HOME>` is your workspace root (the `--workdir` you were launched with; `~/.hermes` by default). The guard preserves `<!-- digest-opportunity:id=... -->` markers for editable delivery bookkeeping and strips fabricated markdown links. Never bypass it with a bare `cat`. Parse the `--json` output for the created task's `id` (`<taskId>`). Do not assign the task to anyone.
-
-   Then **block the task to hold it for human review:**
-
-   ```
-   hermes kanban block <taskId> "review-required: morning brief — <YYYY-MM-DD>"
-   ```
-
-   This parks the brief in the **Blocked** column. The 08:00 send pass delivers it **only after a human approves it by unblocking it** (`hermes kanban unblock <taskId>`, or the board's unblock control). Never assign the task or move it to **Ready** — Ready/assigned hands the task to the dispatcher, which is not how the brief ships. After a successful create + block, delete `memory/digest-draft.md`. (Re-running this prompt is safe: the idempotency key prevents a duplicate task, and re-blocking an already-staged task is harmless.)
-
-8. **Record what you staged.** Update `memory/heartbeat-state.json` so `prepared` equals `{ "date": "<YYYY-MM-DD>", "taskId": "<taskId>", "taskTitle": "Morning digest — <YYYY-MM-DD>", "opportunityIds": [ every `opportunityId` from context opportunities that you put in the brief; empty array when no opportunity ids are present ] }`. Preserve all other top-level keys. The send pass finds the staged task by this `taskId`, so it must be recorded. Do not call `confirm_opportunity_delivery` and do not touch `deliveredToday` — both happen at send time.
-
-9. **Deliver nothing.** End your turn with the host-specific no-reply marker.
+3. **Deliver nothing.** End your turn with the host-specific no-reply marker.
 
 # Hard rules
 - Never invent announcements, events, people, venues, times, tracks, or action URLs.
+- Do not compose or stage the Kanban card manually; `stage-daily-brief.ts` is the only allowed staging path.
 - Always stage the brief **blocked** (held for review) and record its `taskId`; it ships only if a human unblocks (approves) it before the send pass. Never assign it or move it to **Ready**.
 - Calendar failures must not block launch: ship people-only plus the one-line calendar pointer, or the pointer-only fallback if there is nothing else.
 - Never confirm delivery here. Never write `deliveredToday` here.

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+/**
+ * Deterministically compose and stage the daily morning brief.
+ *
+ * The cron prompt still fetches Index opportunities through MCP and writes the
+ * transcript to `memory/digest-opportunities.txt`. This script owns everything
+ * after that: context building, markdown composition, URL validation, Kanban
+ * create/block, and heartbeat bookkeeping. Keeping this deterministic avoids
+ * prompt-generated shell quoting bugs and CLI flag drift.
+ */
+
+import { existsSync, rmSync } from "node:fs";
+
+import { buildDailyBriefContext, type BriefOpportunity, type DailyBriefContext } from "./build-daily-brief-context";
+import { sanitizeDigestUrls } from "./validate-digest-urls";
+
+function argValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function pacificDate(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Los_Angeles",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+function eventLine(event: DailyBriefContext["highlightedEvents"][number]): string {
+  const venue = event.venue ? ` at ${event.venue}` : "";
+  const hint = event.reasonHint ? ` (${event.reasonHint})` : "";
+  return `- ${event.timePacific} — ${event.title}${venue}${hint}`;
+}
+
+function opportunityLabel(opp: BriefOpportunity): string {
+  return opp.profileUrl ? `[${opp.name}](${opp.profileUrl})` : opp.name;
+}
+
+function opportunityMarker(opp: BriefOpportunity): string {
+  return opp.opportunityId ? `<!-- digest-opportunity:id=${opp.opportunityId} -->` : "";
+}
+
+export function composeDailyBrief(context: DailyBriefContext): { body: string; opportunityIds: string[] } {
+  const lines: string[] = [
+    `🌞 Good morning from Edge Esmeralda. It is ${context.displayDate}`,
+    "",
+    "Here's what you need to know today:",
+    "",
+  ];
+  const opportunityIds: string[] = [];
+  let hasVerifiedContent = false;
+
+  if (context.announcements.length > 0) {
+    lines.push("**Announcements**");
+    for (const announcement of context.announcements) {
+      lines.push(`- ${announcement.body}`);
+    }
+    lines.push("");
+    hasVerifiedContent = true;
+  }
+
+  const events = [...context.highlightedEvents, ...context.interestEvents];
+  if (events.length > 0) {
+    lines.push("**The calendar today:**");
+    for (const event of events) lines.push(eventLine(event));
+    lines.push("");
+    hasVerifiedContent = true;
+  }
+
+  if (context.connectionOpportunities.length > 0) {
+    lines.push("**Potential connections via Index Network:**");
+    for (const opp of context.connectionOpportunities) {
+      if (opp.opportunityId) opportunityIds.push(opp.opportunityId);
+      const action = opp.acceptUrl ? `, [say hi](${opp.acceptUrl})` : ", say hi";
+      const reason = opp.mainText || "Relevant overlap with your current signals.";
+      lines.push(`- ${opportunityMarker(opp)}${opportunityLabel(opp)} — ${reason}${action}`);
+    }
+    lines.push("");
+    hasVerifiedContent = true;
+  }
+
+  if (context.communityOpportunities.length > 0) {
+    lines.push("**Help your community**");
+    for (const opp of context.communityOpportunities) {
+      if (opp.opportunityId) opportunityIds.push(opp.opportunityId);
+      const action = opp.acceptUrl ? ` Know someone, [make intro](${opp.acceptUrl}).` : " Know someone, make intro.";
+      const reason = opp.mainText || "They are looking for a relevant introduction.";
+      lines.push(`- ${opportunityMarker(opp)}${opportunityLabel(opp)} — ${reason}.${action}`);
+    }
+    lines.push("");
+    hasVerifiedContent = true;
+  }
+
+  if (context.diagnostics.calendarSource === "unavailable" && (context.connectionOpportunities.length > 0 || context.communityOpportunities.length > 0)) {
+    lines.push("I couldn't check the live calendar this morning — ask me what's on today and I'll look it up.", "");
+  }
+
+  if (!hasVerifiedContent) {
+    lines.push("I couldn't check the live calendar this morning — ask me what's on today and I'll look it up.", "");
+  }
+
+  lines.push("That's it for now. You can always ask me for more detail, or any other questions you have!");
+
+  return { body: lines.join("\n").replace(/\n{3,}/g, "\n\n"), opportunityIds };
+}
+
+async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+  try {
+    if (!existsSync(path)) return {};
+    const parsed = JSON.parse(await Bun.file(path).text());
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function runHermes(args: string[]): string {
+  const result = Bun.spawnSync(["hermes", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, HOME: process.env.HERMES_HOME ?? process.env.HOME, HERMES_HOME: process.env.HERMES_HOME ?? process.cwd() },
+  });
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    const stdout = new TextDecoder().decode(result.stdout).trim();
+    throw new Error(`hermes ${args.join(" ")} failed: ${stderr || stdout}`);
+  }
+  return new TextDecoder().decode(result.stdout);
+}
+
+function extractTaskId(raw: string): string {
+  const trimmed = raw.trim();
+  try {
+    const parsed = JSON.parse(trimmed) as { id?: unknown; task?: { id?: unknown } };
+    const id = typeof parsed.id === "string" ? parsed.id : typeof parsed.task?.id === "string" ? parsed.task.id : "";
+    if (id) return id;
+  } catch {
+    // fall through to regex extraction
+  }
+  const match = trimmed.match(/\b(t_[A-Za-z0-9_-]+)\b/);
+  if (match) return match[1];
+  throw new Error(`could not parse task id from kanban create output: ${trimmed.slice(0, 200)}`);
+}
+
+export async function stageDailyBrief(options: {
+  date?: string;
+  opportunitiesFile?: string;
+  stateFile?: string;
+  contextOut?: string;
+} = {}): Promise<{ taskId: string; body: string; opportunityIds: string[] }> {
+  const date = options.date ?? pacificDate();
+  const opportunitiesFile = options.opportunitiesFile ?? "memory/digest-opportunities.txt";
+  const stateFile = options.stateFile ?? "memory/heartbeat-state.json";
+  const contextOut = options.contextOut ?? "memory/daily-brief-context.json";
+
+  const context = await buildDailyBriefContext({ date, opportunitiesFile, stateFile });
+  await writeJson(contextOut, context);
+
+  const { body, opportunityIds } = composeDailyBrief(context);
+  const { output: sanitizedBody } = sanitizeDigestUrls(body);
+  await Bun.write("memory/digest-draft.md", `${sanitizedBody}\n`);
+
+  const createOutput = runHermes([
+    "kanban",
+    "create",
+    `Morning digest — ${date}`,
+    "--body",
+    sanitizedBody,
+    "--idempotency-key",
+    `digest-${date}`,
+    "--json",
+  ]);
+  const taskId = extractTaskId(createOutput);
+
+  runHermes(["kanban", "block", taskId, `review-required: morning brief — ${date}`]);
+
+  const state = await readJsonObject(stateFile);
+  state.prepared = {
+    date,
+    taskId,
+    taskTitle: `Morning digest — ${date}`,
+    opportunityIds,
+  };
+  await writeJson(stateFile, state);
+
+  rmSync("memory/digest-draft.md", { force: true });
+
+  return { taskId, body: sanitizedBody, opportunityIds };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const result = await stageDailyBrief({
+    date: argValue(args, "--date"),
+    opportunitiesFile: argValue(args, "--opportunities-file"),
+    stateFile: argValue(args, "--state-file"),
+    contextOut: argValue(args, "--context-out"),
+  });
+  process.stdout.write(`${JSON.stringify({ taskId: result.taskId, opportunityIds: result.opportunityIds })}\n`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import { composeDailyBrief } from "../stage-daily-brief";
+import type { DailyBriefContext } from "../build-daily-brief-context";
+
+const baseContext: DailyBriefContext = {
+  date: "2026-06-04",
+  displayDate: "Thursday, June 4",
+  timezone: "America/Los_Angeles",
+  announcements: [],
+  highlightedEvents: [],
+  interestEvents: [],
+  opportunities: [],
+  connectionOpportunities: [],
+  communityOpportunities: [],
+  diagnostics: {
+    announcementsSource: "unavailable",
+    calendarSource: "unavailable",
+    opportunitySource: "unavailable",
+    warnings: [],
+    interestTags: [],
+  },
+};
+
+describe("composeDailyBrief", () => {
+  test("renders real calendar content instead of calendar-unavailable fallback", () => {
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      highlightedEvents: [
+        {
+          id: "event-1",
+          title: "GNOSIS Journey",
+          startTime: "2026-06-04T16:00:00Z",
+          timePacific: "9:00 AM PDT",
+          venue: "The Hub",
+          tags: [],
+          highlighted: true,
+          reasonHint: "Highlighted by the EdgeOS calendar.",
+        },
+      ],
+      diagnostics: { ...baseContext.diagnostics, calendarSource: "edgeos" },
+    });
+
+    expect(body).toContain("🌞 Good morning from Edge Esmeralda. It is Thursday, June 4");
+    expect(body).toContain("**The calendar today:**");
+    expect(body).toContain("9:00 AM PDT — GNOSIS Journey at The Hub");
+    expect(body).not.toContain("I couldn't check the live calendar this morning");
+    expect(body).not.toContain("\\n");
+    expect(body).not.toContain("\\ud83c");
+  });
+
+  test("renders opportunities with digest markers and collects ids", () => {
+    const { body, opportunityIds } = composeDailyBrief({
+      ...baseContext,
+      opportunities: [
+        {
+          name: "Maya",
+          opportunityId: "opp-1",
+          mainText: "You both care about privacy-preserving agents",
+          profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
+          acceptUrl: "https://protocol.index.network/c/abc123",
+          feedCategory: "connection",
+        },
+      ],
+      connectionOpportunities: [
+        {
+          name: "Maya",
+          opportunityId: "opp-1",
+          mainText: "You both care about privacy-preserving agents",
+          profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
+          acceptUrl: "https://protocol.index.network/c/abc123",
+          feedCategory: "connection",
+        },
+      ],
+    });
+
+    expect(opportunityIds).toEqual(["opp-1"]);
+    expect(body).toContain("<!-- digest-opportunity:id=opp-1 -->[Maya]");
+    expect(body).toContain("[say hi](https://protocol.index.network/c/abc123)");
+  });
+});


### PR DESCRIPTION
## Summary
- move daily brief composition/staging into deterministic `stage-daily-brief.ts`
- reduce the prepare prompt to only fetch MCP opportunities, write the transcript, and run the staging script
- create/block Kanban cards with argv-safe calls instead of LLM-generated shell quoting
- add tests that catch escaped `\n` / `\ud83c` bodies and calendar fallback when real events exist
- bump AgentVillage to 0.3.13

## Root cause
The cron agent was inventing its own Python staging script despite the prompt. The captured run showed it:
- parsed `read_file()` output in a broad `except`, causing a false empty context fallback even when `daily-brief-context.json` had EdgeOS events
- used `json.dumps(validated_body)` inside a shell command, which staged literal escaped strings like `\ud83c\udf1e ... \n\n ...`
- called stale/incorrect Kanban blocking syntax in earlier runs

This PR removes those failure modes from the LLM path.

## Verification
- `bun test install/tests/cron_specs.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts skills/index-network/scripts/tests/build-daily-brief-context.test.ts skills/index-network/scripts/tests/stage-daily-brief.test.ts`
