### PR TITLE
fix(index-network): require direct opportunity MCP call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/prompts/prepare.md
+++ b/skills/index-network/prompts/prepare.md
@@ -19,7 +19,7 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 
 ## Steps
 
-1. **Fetch and persist Index opportunities.** Call `list_opportunities(includeDigestMarkers=true)`. Write the exact tool result text to `memory/digest-opportunities.txt`. If the tool errors, write an empty file and continue — the brief can still ship with announcements/calendar.
+1. **Fetch and persist Index opportunities.** Invoke the Index MCP opportunity tool directly (`mcp_index_list_opportunities` / `list_opportunities`) with `includeDigestMarkers=true`. Do **not** use terminal/shell for this step; never run `hermes mcp call`, `mcp_index_list_opportunities`, or any other MCP command through `terminal` or code. Write the exact tool result text to `memory/digest-opportunities.txt`. If the direct MCP tool call errors, write an empty file and continue — the brief can still ship with announcements/calendar.
 
 2. **Run the deterministic staging script.** Do not compose the brief yourself, do not write ad-hoc Python/JavaScript, do not shell-quote a body, and do not call `hermes kanban create` or `hermes kanban block` directly. Run exactly:
 


### PR DESCRIPTION
## Summary
- tighten the daily brief prepare prompt so opportunity fetching uses the direct Index MCP tool instead of shell/terminal
- prevents `hermes mcp call ...` failures from being written into `memory/digest-opportunities.txt`
- bump AgentVillage to 0.3.14

## Root cause
A triggered prepare run used a stale/prompt-generated Python script that attempted to fetch opportunities through `terminal('hermes mcp call ...')`. In the cron execution sandbox that command failed with `/usr/bin/bash: line 3: hermes: command not found`, so the context builder received an error string and parsed zero opportunities.

## Verification
- `bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts`
