### PR TITLE
fix(index-network): treat ready digest card as approved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/prompts/send.md
+++ b/skills/index-network/prompts/send.md
@@ -10,7 +10,7 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
 
 2. **Find today's staged task by id.** Read `memory/heartbeat-state.json` (missing/malformed → treat as no staged task). Take `prepared.taskId` and `prepared.date`. If `prepared.date` is not today's `<YYYY-MM-DD>`, or `prepared.taskId` is absent, there is nothing staged for today — go to the silent path in step 3. Otherwise run `hermes kanban show <prepared.taskId> --json` and read its `status` and `body`. Parse the JSON; never surface it to the user.
 
-3. **Apply the approval gate.** The prepare pass stages the brief **blocked** (held for review); a human approves it by **unblocking** it. Deliver only when the task's normalized lower-case `status` is `todo` (unblocked = approved). In every other case — `blocked` (not yet approved), `done` (already delivered), `ready` or `running` (assigned to the dispatcher, not this flow), `archived`, or the task cannot be found — end your turn with `[SILENT]`: do not call `list_opportunities`, do not compose a fallback brief, do not update delivery state, and do not message the user.
+3. **Apply the approval gate.** The prepare pass stages the brief **blocked** (held for review); a human approves it by **unblocking** it. Deliver only when the task's normalized lower-case `status` is `ready` or `todo` (unblocked = approved; Hermes versions differ on the unblocked column name). In every other case — `blocked` (not yet approved), `done` (already delivered), `running` (assigned to the dispatcher, not this flow), `archived`, or the task cannot be found — end your turn with `[SILENT]`: do not call `list_opportunities`, do not compose a fallback brief, do not update delivery state, and do not message the user.
 
 4. **Take the approved brief.** Use the task `body` and `id` from step 2. The edited `body` is authoritative.
 
@@ -40,7 +40,7 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
 
 # Hard rules
 - The Kanban task body is the source of truth. Never regenerate the brief in this send pass.
-- Deliver only a brief a human has approved by unblocking it (status `todo`). A still-`blocked` task means no approval yet — stay silent; the next prepare pass can try again.
+- Deliver only a brief a human has approved by unblocking it (status `ready` or `todo`, depending on Hermes version). A still-`blocked` task means no approval yet — stay silent; the next prepare pass can try again.
 - Confirm delivery only for opportunity markers still present in the edited Kanban body.
 - Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in the reply.
 - Never construct URLs yourself. The URL guard strips anything except `/c/<code>` connect links and `/u/<uuid>` profile links.


### PR DESCRIPTION
## Summary
- update daily digest send prompt to deliver approved cards whose status is `ready` as well as `todo`
- bump AgentVillage to 0.3.15

## Root cause
Hermes `kanban unblock` returns blocked cards to `ready`, not `todo`, in the deployed version. The send prompt only delivered `todo`, so after approval it treated the card as non-deliverable and returned `[SILENT]`.

## Verification
- inspected yanki@index.network resident state: `prepared.taskId` points to `t_f03f29a9`, status is `ready`
- send cron returned `[SILENT]` because the prompt rejected `ready`
