### PR TITLE
fix(index-network): polish digest calendar entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -16,6 +16,7 @@
 
 const POPUP_ID = "43746fd0-bce2-472b-93e4-a438177b2dff";
 const EDGEOS_BASE = "https://api.edgeos.world/api/v1";
+const EDGE_ESMERALDA_EVENT_BASE_URL = "https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events";
 const PACIFIC_TZ = "America/Los_Angeles";
 
 const EDGE_TAGS = [
@@ -71,6 +72,7 @@ export interface BriefEvent {
   endTime?: string | null;
   timePacific: string;
   venue?: string | null;
+  eventUrl?: string | null;
   tags: string[];
   highlighted: boolean;
   reasonHint: string;
@@ -192,7 +194,6 @@ export function formatPacificTime(iso: string): string {
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
-    timeZoneName: "short",
   }).format(d);
 }
 
@@ -210,6 +211,10 @@ export function extractInterestTags(text: string): string[] {
 
 function eventVenue(event: EdgeEvent): string | null {
   return event.venue_title ?? event.custom_location_name ?? null;
+}
+
+function eventUrl(event: EdgeEvent): string | null {
+  return event.id ? `${EDGE_ESMERALDA_EVENT_BASE_URL}/${event.id}` : null;
 }
 
 function eventScore(event: EdgeEvent, interestTags: string[]): number {
@@ -234,6 +239,7 @@ function toBriefEvent(event: EdgeEvent, reasonHint: string): BriefEvent | null {
     endTime: event.end_time,
     timePacific: formatPacificTime(event.start_time),
     venue: eventVenue(event),
+    eventUrl: eventUrl(event),
     tags: Array.isArray(event.tags) ? event.tags : [],
     highlighted: event.highlighted === true,
     reasonHint,

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -32,8 +32,8 @@ function pacificDate(): string {
 
 function eventLine(event: DailyBriefContext["highlightedEvents"][number]): string {
   const venue = event.venue ? ` at ${event.venue}` : "";
-  const hint = event.reasonHint ? ` (${event.reasonHint})` : "";
-  return `- ${event.timePacific} — ${event.title}${venue}${hint}`;
+  const title = event.eventUrl ? `[${event.title}](${event.eventUrl})` : event.title;
+  return `- ${event.timePacific} — ${title}${venue}`;
 }
 
 function opportunityLabel(opp: BriefOpportunity): string {

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -101,9 +101,9 @@ describe("build-daily-brief-context helpers", () => {
     ).toEqual(["B", "C"]);
   });
 
-  test("formatPacificTime renders the live Pacific time zone abbreviation", () => {
-    expect(formatPacificTime("2026-06-04T16:30:00Z")).toBe("9:30 AM PDT");
-    expect(formatPacificTime("2026-12-04T17:30:00Z")).toBe("9:30 AM PST");
+  test("formatPacificTime renders Pacific time without a timezone suffix", () => {
+    expect(formatPacificTime("2026-06-04T16:30:00Z")).toBe("9:30 AM");
+    expect(formatPacificTime("2026-12-04T17:30:00Z")).toBe("9:30 AM");
   });
 
   test("pacificDayBounds respects daylight saving offsets", () => {

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -31,8 +31,9 @@ describe("composeDailyBrief", () => {
           id: "event-1",
           title: "GNOSIS Journey",
           startTime: "2026-06-04T16:00:00Z",
-          timePacific: "9:00 AM PDT",
+          timePacific: "9:00 AM",
           venue: "The Hub",
+          eventUrl: "https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
           tags: [],
           highlighted: true,
           reasonHint: "Highlighted by the EdgeOS calendar.",
@@ -43,7 +44,9 @@ describe("composeDailyBrief", () => {
 
     expect(body).toContain("🌞 Good morning from Edge Esmeralda. It is Thursday, June 4");
     expect(body).toContain("**The calendar today:**");
-    expect(body).toContain("9:00 AM PDT — GNOSIS Journey at The Hub");
+    expect(body).toContain("9:00 AM — [GNOSIS Journey](https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa) at The Hub");
+    expect(body).not.toContain("PDT");
+    expect(body).not.toContain("Highlighted by the EdgeOS calendar");
     expect(body).not.toContain("I couldn't check the live calendar this morning");
     expect(body).not.toContain("\\n");
     expect(body).not.toContain("\\ud83c");

--- a/skills/index-network/scripts/tests/validate-digest-urls.test.ts
+++ b/skills/index-network/scripts/tests/validate-digest-urls.test.ts
@@ -48,7 +48,16 @@ describe("sanitizeDigestUrls", () => {
     expect(stripped).toEqual([]);
   });
 
-  test("strips fabricated path shapes other than /c/ and /u/", () => {
+  test("preserves Edge Esmeralda event links", () => {
+    const md = "[GNOSIS Journey](https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)";
+
+    const { output, stripped } = sanitizeDigestUrls(md);
+
+    expect(output).toBe(md);
+    expect(stripped).toEqual([]);
+  });
+
+  test("strips fabricated path shapes other than /c/, /u/, and known event links", () => {
     const md = "[x](https://index.network/profile/42) [y](https://index.network/opportunity/create?id=7) [z](https://index.network/connect/8)";
 
     const { output, stripped } = sanitizeDigestUrls(md);

--- a/skills/index-network/scripts/validate-digest-urls.ts
+++ b/skills/index-network/scripts/validate-digest-urls.ts
@@ -29,6 +29,8 @@
 const CONNECT_PATH = /^\/c\/[A-Za-z0-9_-]+\/?$/;
 /** Profile link: `/u/<uuid>`, optional trailing slash. */
 const PROFILE_PATH = /^\/u\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/?$/;
+/** Edge Esmeralda calendar event link. */
+const EDGE_ESMERALDA_EVENT_PATH = /^\/portal\/edge-esmeralda-2026\/events\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/?$/;
 
 /**
  * A markdown inline link: `[label](url)`. Label runs to the first `]`; url to the next `)`.
@@ -50,8 +52,10 @@ export interface SanitizeDigestOptions {
 }
 
 /**
- * Whether `url` is a legitimate digest action link (connect or profile shape).
- * Host-agnostic — only the path shape is checked, so dev/prod bases both pass.
+ * Whether `url` is a legitimate digest action link (connect/profile) or
+ * Edge Esmeralda calendar event link. Connect/profile links are host-agnostic
+ * by path shape so dev/prod bases both pass. Event links are intentionally
+ * pinned to the Edge City host + event path.
  * A non-absolute or unparseable URL is never allowed.
  */
 export function isAllowedDigestUrl(url: string): boolean {
@@ -61,7 +65,9 @@ export function isAllowedDigestUrl(url: string): boolean {
   } catch {
     return false;
   }
-  return CONNECT_PATH.test(parsed.pathname) || PROFILE_PATH.test(parsed.pathname);
+  return CONNECT_PATH.test(parsed.pathname)
+    || PROFILE_PATH.test(parsed.pathname)
+    || (parsed.hostname === "edgecity.simplefi.tech" && EDGE_ESMERALDA_EVENT_PATH.test(parsed.pathname));
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove `PDT` / `PST` suffixes from digest calendar times
- remove parenthesized reason-hint meta comments from calendar lines
- link event titles to Edge Esmeralda event pages when EdgeOS returns an event id
- allow known Edge Esmeralda event links through the digest URL guard
- bump AgentVillage to 0.3.16

## Verification
- `bun test skills/index-network/scripts/tests/build-daily-brief-context.test.ts skills/index-network/scripts/tests/stage-daily-brief.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts`
