### PR TITLE
fix(index-network): send daily brief deterministically

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/prompts/send.md
+++ b/skills/index-network/prompts/send.md
@@ -6,41 +6,30 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 # Job
 Deliver the staged morning brief verbatim from Kanban, then reconcile delivery bookkeeping. The Kanban task body is the source of truth: it may have been edited after the prepare pass. Do not compose, regenerate, summarize, or supplement the brief in this send pass.
 
-1. **Resolve today's date.** Determine today's America/Los_Angeles date as `<YYYY-MM-DD>` for delivery bookkeeping. Do not derive today's local date from UTC alone.
-
-2. **Find today's staged task by id.** Read `memory/heartbeat-state.json` (missing/malformed → treat as no staged task). Take `prepared.taskId` and `prepared.date`. If `prepared.date` is not today's `<YYYY-MM-DD>`, or `prepared.taskId` is absent, there is nothing staged for today — go to the silent path in step 3. Otherwise run `hermes kanban show <prepared.taskId> --json` and read its `status` and `body`. Parse the JSON; never surface it to the user.
-
-3. **Apply the approval gate.** The prepare pass stages the brief **blocked** (held for review); a human approves it by **unblocking** it. Deliver only when the task's normalized lower-case `status` is `ready` or `todo` (unblocked = approved; Hermes versions differ on the unblocked column name). In every other case — `blocked` (not yet approved), `done` (already delivered), `running` (assigned to the dispatcher, not this flow), `archived`, or the task cannot be found — end your turn with `[SILENT]`: do not call `list_opportunities`, do not compose a fallback brief, do not update delivery state, and do not message the user.
-
-4. **Take the approved brief.** Use the task `body` and `id` from step 2. The edited `body` is authoritative.
-
-5. **Persist the outgoing body for deterministic processing.** Write the task `body` exactly to `memory/digest-outgoing.md`.
-
-6. **Extract the opportunities still present after edits.** Run:
+1. **Run the deterministic send script exactly once.** Use the terminal from `/opt/data` / the configured Hermes home and run:
 
    ```
-   bun skills/index-network/scripts/validate-digest-urls.ts --opportunity-ids memory/digest-outgoing.md
+   bun skills/index-network/scripts/send-daily-brief.ts
    ```
 
-   Parse stdout as a JSON array of opportunity ids. These ids come from hidden `<!-- digest-opportunity:id=... -->` markers that the prepare pass placed next to each opportunity. If a human removed an opportunity from the Kanban body, its marker should be gone too, so it must not be confirmed as delivered. If the command errors or returns malformed JSON, treat the id list as empty and continue delivery of the body.
+   Do not write Python, shell pipelines, or replacement delivery logic. The script resolves today's America/Los_Angeles date, reads `memory/heartbeat-state.json`, checks the Kanban approval gate, writes `memory/digest-outgoing.md`, extracts digest opportunity markers, updates delivery state, marks the task complete, strips unsafe URLs/internal metadata, and prints either `[SILENT]` or one JSON object.
 
-7. **Confirm delivery only for the remaining ids.** For every id extracted in step 6, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. Do not confirm ids from `memory/heartbeat-state.json` unless they are also present in the edited body markers.
+2. **If stdout is exactly `[SILENT]`, end your turn with exactly `[SILENT]`.** Do not add commentary and do not try a fallback.
 
-8. **Update dedup state.** Read `memory/heartbeat-state.json` (missing/malformed → `{}`). Set `deliveredToday.date` = `<YYYY-MM-DD>` and `deliveredToday.ids` = (the existing `deliveredToday.ids` if `deliveredToday.date` already equals `<YYYY-MM-DD>`, else `[]`) unioned with the remaining ids from step 6. Preserve all other top-level keys, including `prepared`.
+3. **If stdout is JSON, parse it.** It has this shape:
 
-9. Mark the task done: `hermes kanban complete <id> --summary "delivered"`.
+   ```json
+   { "taskId": "...", "opportunityIds": ["..."], "finalBrief": "..." }
+   ```
 
-10. **Pass the edited body through the URL/metadata guard, then deliver its output verbatim.** Run:
+4. **Confirm delivery only for returned opportunity ids.** For every `opportunityIds[]` value, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. If the array is empty, skip this step.
 
-    ```
-    bun skills/index-network/scripts/validate-digest-urls.ts --strip-digest-metadata memory/digest-outgoing.md
-    ```
-
-    Use stdout as your final assistant reply. The guard strips any markdown link whose URL is not a real connect (`/c/<code>`) or profile (`/u/<id>`) link, and removes internal `<!-- digest-opportunity:id=... -->` comments. **Your final assistant reply is the guard's output, verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting beyond the guard's deterministic stripping.** Hermes delivers it. End your turn.
+5. **Deliver the final brief.** Your final assistant reply must be `finalBrief` verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting. Hermes delivers it. End your turn.
 
 # Hard rules
 - The Kanban task body is the source of truth. Never regenerate the brief in this send pass.
+- Never reimplement the send flow in generated code. Always call `bun skills/index-network/scripts/send-daily-brief.ts` exactly once.
 - Deliver only a brief a human has approved by unblocking it (status `ready` or `todo`, depending on Hermes version). A still-`blocked` task means no approval yet — stay silent; the next prepare pass can try again.
-- Confirm delivery only for opportunity markers still present in the edited Kanban body.
+- Confirm delivery only for opportunity ids returned by the deterministic script.
 - Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in the reply.
-- Never construct URLs yourself. The URL guard strips anything except `/c/<code>` connect links and `/u/<uuid>` profile links.
+- Never construct URLs yourself. The URL guard strips anything except approved connect, profile, and Edge Esmeralda event links.

--- a/skills/index-network/scripts/send-daily-brief.ts
+++ b/skills/index-network/scripts/send-daily-brief.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+/**
+ * Deterministically deliver the approved daily morning brief from Kanban.
+ *
+ * The send cron prompt should not reimplement file, Kanban, or URL-guard logic
+ * with model-generated Python. This script owns approval-gate checking, outgoing
+ * body persistence, digest marker extraction, delivery-state bookkeeping,
+ * Kanban completion, and final body sanitization. The prompt only needs to call
+ * this script, confirm the returned opportunity ids through MCP, and return the
+ * returned brief verbatim.
+ */
+
+import { existsSync } from "node:fs";
+
+import { extractDigestOpportunityIds, sanitizeDigestUrls } from "./validate-digest-urls";
+
+interface SendResult {
+  taskId: string;
+  opportunityIds: string[];
+  finalBrief: string;
+}
+
+interface SilentResult {
+  silent: true;
+  reason: string;
+}
+
+interface HermesTask {
+  id?: string;
+  status?: string;
+  body?: string;
+}
+
+type HermesRunner = (args: string[]) => string;
+
+function argValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function pacificDate(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Los_Angeles",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+  try {
+    if (!existsSync(path)) return {};
+    const parsed = JSON.parse(await Bun.file(path).text());
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function runHermes(args: string[]): string {
+  const result = Bun.spawnSync(["hermes", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, HOME: process.env.HERMES_HOME ?? process.env.HOME, HERMES_HOME: process.env.HERMES_HOME ?? process.cwd() },
+  });
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    const stdout = new TextDecoder().decode(result.stdout).trim();
+    throw new Error(`hermes ${args.join(" ")} failed: ${stderr || stdout}`);
+  }
+  return new TextDecoder().decode(result.stdout);
+}
+
+function parseTask(raw: string): HermesTask | null {
+  try {
+    const parsed = JSON.parse(raw) as { task?: HermesTask } & HermesTask;
+    const task = parsed.task && typeof parsed.task === "object" ? parsed.task : parsed;
+    return task && typeof task === "object" ? task : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+export async function sendDailyBrief(options: {
+  date?: string;
+  stateFile?: string;
+  outgoingFile?: string;
+  hermes?: HermesRunner;
+} = {}): Promise<SendResult | SilentResult> {
+  const date = options.date ?? pacificDate();
+  const stateFile = options.stateFile ?? "memory/heartbeat-state.json";
+  const outgoingFile = options.outgoingFile ?? "memory/digest-outgoing.md";
+  const hermes = options.hermes ?? runHermes;
+
+  const state = await readJsonObject(stateFile);
+  const prepared = state.prepared && typeof state.prepared === "object" && !Array.isArray(state.prepared)
+    ? state.prepared as Record<string, unknown>
+    : {};
+  const taskId = typeof prepared.taskId === "string" ? prepared.taskId : "";
+  const preparedDate = typeof prepared.date === "string" ? prepared.date : "";
+
+  if (!taskId || preparedDate !== date) {
+    return { silent: true, reason: "no-staged-task" };
+  }
+
+  const task = parseTask(hermes(["kanban", "show", taskId, "--json"]));
+  if (!task) return { silent: true, reason: "task-unreadable" };
+
+  const status = String(task.status ?? "").toLowerCase();
+  if (status !== "ready" && status !== "todo") {
+    return { silent: true, reason: `not-approved:${status || "unknown"}` };
+  }
+
+  const body = typeof task.body === "string" ? task.body : "";
+  if (!body.trim()) return { silent: true, reason: "empty-body" };
+
+  await Bun.write(outgoingFile, body);
+  const opportunityIds = extractDigestOpportunityIds(body);
+
+  const deliveredToday = state.deliveredToday && typeof state.deliveredToday === "object" && !Array.isArray(state.deliveredToday)
+    ? state.deliveredToday as Record<string, unknown>
+    : {};
+  const currentIds = deliveredToday.date === date ? stringArray(deliveredToday.ids) : [];
+  state.deliveredToday = {
+    date,
+    ids: Array.from(new Set([...currentIds, ...opportunityIds])),
+  };
+  await writeJson(stateFile, state);
+
+  hermes(["kanban", "complete", taskId, "--summary", "delivered"]);
+
+  const { output: finalBrief } = sanitizeDigestUrls(body, { stripDigestMetadata: true });
+  return { taskId, opportunityIds, finalBrief };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const result = await sendDailyBrief({
+    date: argValue(args, "--date"),
+    stateFile: argValue(args, "--state-file"),
+    outgoingFile: argValue(args, "--outgoing-file"),
+  });
+
+  if ("silent" in result) {
+    process.stdout.write("[SILENT]\n");
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/skills/index-network/scripts/tests/send-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/send-daily-brief.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { sendDailyBrief } from "../send-daily-brief";
+
+const originalCwd = process.cwd();
+
+function tempWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "send-daily-brief-"));
+  process.chdir(dir);
+  return dir;
+}
+
+afterEach(() => {
+  const cwd = process.cwd();
+  process.chdir(originalCwd);
+  if (cwd !== originalCwd && cwd.includes("send-daily-brief-")) rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("sendDailyBrief", () => {
+  test("returns silent when no prepared task exists for the date", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({ prepared: { date: "2026-06-03", taskId: "t_old" } }));
+
+    const result = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      hermes: () => {
+        throw new Error("hermes should not be called");
+      },
+    });
+
+    expect(result).toEqual({ silent: true, reason: "no-staged-task" });
+  });
+
+  test("returns silent when the staged task is still blocked", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({ prepared: { date: "2026-06-04", taskId: "t_digest" } }));
+
+    const result = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      hermes: () => JSON.stringify({ task: { id: "t_digest", status: "blocked", body: "draft" } }),
+    });
+
+    expect(result).toEqual({ silent: true, reason: "not-approved:blocked" });
+  });
+
+  test("delivers ready cards, strips metadata/unsafe links, updates state, and completes the task", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      prepared: { date: "2026-06-04", taskId: "t_digest", opportunityIds: ["opp-1", "opp-removed"] },
+      deliveredToday: { date: "2026-06-04", ids: ["opp-old"] },
+    }));
+    const calls: string[][] = [];
+    const body = [
+      "🌞 Good morning",
+      "<!-- digest-opportunity:id=opp-1 -->[Maya](https://index.network/u/11111111-1111-1111-1111-111111111111) — relevant overlap, [say hi](https://protocol.index.network/c/abc123)",
+      "[fabricated](https://index.network/accept/123)",
+    ].join("\n");
+
+    const result = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      outgoingFile: "outgoing.md",
+      hermes: (args) => {
+        calls.push(args);
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest", status: "ready", body } });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+    });
+
+    expect("silent" in result).toBe(false);
+    if ("silent" in result) throw new Error("unexpected silent result");
+    expect(result.taskId).toBe("t_digest");
+    expect(result.opportunityIds).toEqual(["opp-1"]);
+    expect(result.finalBrief).toContain("[Maya](https://index.network/u/11111111-1111-1111-1111-111111111111)");
+    expect(result.finalBrief).toContain("[say hi](https://protocol.index.network/c/abc123)");
+    expect(result.finalBrief).toContain("fabricated");
+    expect(result.finalBrief).not.toContain("digest-opportunity");
+    expect(result.finalBrief).not.toContain("accept/123");
+    expect(await Bun.file("outgoing.md").text()).toBe(body);
+    expect(JSON.parse(await Bun.file("state.json").text()).deliveredToday).toEqual({ date: "2026-06-04", ids: ["opp-old", "opp-1"] });
+    expect(calls).toEqual([
+      ["kanban", "show", "t_digest", "--json"],
+      ["kanban", "complete", "t_digest", "--summary", "delivered"],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `send-daily-brief.ts` to deterministically deliver approved Kanban digest cards
- reduce the send cron prompt to calling that script once and returning its `finalBrief` verbatim
- keep MCP `confirm_opportunity_delivery` in the prompt for script-returned opportunity ids
- add tests for silent gating, ready-card delivery, URL/metadata stripping, state updates, and Kanban completion
- bump AgentVillage to 0.3.17

## Root cause
Even after the prompt accepted `ready` as approved, the model generated its own Python during send. In production that generated code returned `[SILENT]` before delivery despite the card being `ready`. This moves the fragile flow out of model-generated code, matching the deterministic prepare fix.

## Verification
- `bun test skills/index-network/scripts/tests/send-daily-brief.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts`
