### PR TITLE
fix(index-network): resolve hermes binary in digest scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/send-daily-brief.ts
+++ b/skills/index-network/scripts/send-daily-brief.ts
@@ -11,6 +11,7 @@
  */
 
 import { existsSync } from "node:fs";
+import { access } from "node:fs/promises";
 
 import { extractDigestOpportunityIds, sanitizeDigestUrls } from "./validate-digest-urls";
 
@@ -31,7 +32,7 @@ interface HermesTask {
   body?: string;
 }
 
-type HermesRunner = (args: string[]) => string;
+type HermesRunner = (args: string[]) => string | Promise<string>;
 
 function argValue(args: string[], name: string): string | undefined {
   const idx = args.indexOf(name);
@@ -63,8 +64,24 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function runHermes(args: string[]): string {
-  const result = Bun.spawnSync(["hermes", ...args], {
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveHermesCommand(): Promise<string> {
+  if (process.env.HERMES_BIN) return process.env.HERMES_BIN;
+  if (await fileExists("/opt/hermes/.venv/bin/hermes")) return "/opt/hermes/.venv/bin/hermes";
+  return "hermes";
+}
+
+async function runHermes(args: string[]): Promise<string> {
+  const hermes = await resolveHermesCommand();
+  const result = Bun.spawnSync([hermes, ...args], {
     stdout: "pipe",
     stderr: "pipe",
     env: { ...process.env, HOME: process.env.HERMES_HOME ?? process.env.HOME, HERMES_HOME: process.env.HERMES_HOME ?? process.cwd() },
@@ -72,7 +89,7 @@ function runHermes(args: string[]): string {
   if (!result.success) {
     const stderr = new TextDecoder().decode(result.stderr).trim();
     const stdout = new TextDecoder().decode(result.stdout).trim();
-    throw new Error(`hermes ${args.join(" ")} failed: ${stderr || stdout}`);
+    throw new Error(`${hermes} ${args.join(" ")} failed: ${stderr || stdout}`);
   }
   return new TextDecoder().decode(result.stdout);
 }
@@ -113,7 +130,7 @@ export async function sendDailyBrief(options: {
     return { silent: true, reason: "no-staged-task" };
   }
 
-  const task = parseTask(hermes(["kanban", "show", taskId, "--json"]));
+  const task = parseTask(await hermes(["kanban", "show", taskId, "--json"]));
   if (!task) return { silent: true, reason: "task-unreadable" };
 
   const status = String(task.status ?? "").toLowerCase();
@@ -137,7 +154,7 @@ export async function sendDailyBrief(options: {
   };
   await writeJson(stateFile, state);
 
-  hermes(["kanban", "complete", taskId, "--summary", "delivered"]);
+  await hermes(["kanban", "complete", taskId, "--summary", "delivered"]);
 
   const { output: finalBrief } = sanitizeDigestUrls(body, { stripDigestMetadata: true });
   return { taskId, opportunityIds, finalBrief };

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -10,6 +10,7 @@
  */
 
 import { existsSync, rmSync } from "node:fs";
+import { access } from "node:fs/promises";
 
 import { buildDailyBriefContext, type BriefOpportunity, type DailyBriefContext } from "./build-daily-brief-context";
 import { sanitizeDigestUrls } from "./validate-digest-urls";
@@ -122,8 +123,24 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function runHermes(args: string[]): string {
-  const result = Bun.spawnSync(["hermes", ...args], {
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveHermesCommand(): Promise<string> {
+  if (process.env.HERMES_BIN) return process.env.HERMES_BIN;
+  if (await fileExists("/opt/hermes/.venv/bin/hermes")) return "/opt/hermes/.venv/bin/hermes";
+  return "hermes";
+}
+
+async function runHermes(args: string[]): Promise<string> {
+  const hermes = await resolveHermesCommand();
+  const result = Bun.spawnSync([hermes, ...args], {
     stdout: "pipe",
     stderr: "pipe",
     env: { ...process.env, HOME: process.env.HERMES_HOME ?? process.env.HOME, HERMES_HOME: process.env.HERMES_HOME ?? process.cwd() },
@@ -131,7 +148,7 @@ function runHermes(args: string[]): string {
   if (!result.success) {
     const stderr = new TextDecoder().decode(result.stderr).trim();
     const stdout = new TextDecoder().decode(result.stdout).trim();
-    throw new Error(`hermes ${args.join(" ")} failed: ${stderr || stdout}`);
+    throw new Error(`${hermes} ${args.join(" ")} failed: ${stderr || stdout}`);
   }
   return new TextDecoder().decode(result.stdout);
 }
@@ -168,7 +185,7 @@ export async function stageDailyBrief(options: {
   const { output: sanitizedBody } = sanitizeDigestUrls(body);
   await Bun.write("memory/digest-draft.md", `${sanitizedBody}\n`);
 
-  const createOutput = runHermes([
+  const createOutput = await runHermes([
     "kanban",
     "create",
     `Morning digest — ${date}`,
@@ -180,7 +197,7 @@ export async function stageDailyBrief(options: {
   ]);
   const taskId = extractTaskId(createOutput);
 
-  runHermes(["kanban", "block", taskId, `review-required: morning brief — ${date}`]);
+  await runHermes(["kanban", "block", taskId, `review-required: morning brief — ${date}`]);
 
   const state = await readJsonObject(stateFile);
   state.prepared = {


### PR DESCRIPTION
## Summary
- make digest prepare/send scripts resolve `/opt/hermes/.venv/bin/hermes` before falling back to `hermes` on PATH
- support `HERMES_BIN` override for future deployments
- bump AgentVillage to 0.3.18

## Root cause
Hosted cron tool sessions do not include `hermes` on PATH. When the model tried `/opt/hermes/hermes`, it used the source-tree entrypoint outside the virtualenv and failed with `ModuleNotFoundError: No module named 'yaml'`. The working entrypoint in the container is `/opt/hermes/.venv/bin/hermes`.

## Verification
- `bun test skills/index-network/scripts/tests/send-daily-brief.test.ts skills/index-network/scripts/tests/stage-daily-brief.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts`
- verified `/opt/hermes/.venv/bin/hermes --version` works in `hermes-pool-939a1476`
