### PR TITLE
fix(index-network): keep digest opportunity bullets concise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -15,6 +15,10 @@ import { access } from "node:fs/promises";
 import { buildDailyBriefContext, type BriefOpportunity, type DailyBriefContext } from "./build-daily-brief-context";
 import { sanitizeDigestUrls } from "./validate-digest-urls";
 
+const CONNECTION_DIGEST_LIMIT = 3;
+const COMMUNITY_DIGEST_LIMIT = 2;
+const OPPORTUNITY_REASON_MAX_CHARS = 170;
+
 function argValue(args: string[], name: string): string | undefined {
   const idx = args.indexOf(name);
   return idx >= 0 ? args[idx + 1] : undefined;
@@ -45,6 +49,48 @@ function opportunityMarker(opp: BriefOpportunity): string {
   return opp.opportunityId ? `<!-- digest-opportunity:id=${opp.opportunityId} -->` : "";
 }
 
+function stripFillerSentences(text: string): string {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .filter((sentence) => {
+      const lower = sentence.toLowerCase();
+      return !lower.includes("while his location")
+        && !lower.includes("while her location")
+        && !lower.includes("while their location")
+        && !lower.includes("remote collaboration")
+        && !lower.includes("less of a barrier")
+        && !lower.includes("shared presence at edge esmeralda")
+        && !lower.includes("co-attending the event")
+        && !lower.includes("making an in-person meeting feasible");
+    })
+    .join(" ");
+}
+
+function normalizeOpportunityText(text: string): string {
+  return stripFillerSentences(text)
+    .replace(/\b[Tt]he discoverer,\s*([^,]+),\s*/g, "$1 ")
+    .replace(/\b[Tt]he discoverer\b/g, "they")
+    .replace(/\b[Tt]he discoverer's\b/g, "their")
+    .replace(/\byou,\s*the candidate,\s*is\b/gi, "you are")
+    .replace(/\byou is\b/gi, "you are")
+    .replace(/\byour profile indicates\b/gi, "you have")
+    .replace(/\bthe candidate\b/gi, "you")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncateAtWord(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const slice = text.slice(0, maxChars + 1);
+  const boundary = slice.lastIndexOf(" ");
+  return `${slice.slice(0, boundary > 80 ? boundary : maxChars).trimEnd()}…`;
+}
+
+function opportunityReason(opp: BriefOpportunity, fallback: string): string {
+  const cleaned = normalizeOpportunityText(opp.mainText || fallback);
+  return truncateAtWord(cleaned, OPPORTUNITY_REASON_MAX_CHARS).replace(/[,.]$/, "");
+}
+
 export function composeDailyBrief(context: DailyBriefContext): { body: string; opportunityIds: string[] } {
   const lines: string[] = [
     `🌞 Good morning from Edge Esmeralda. It is ${context.displayDate}`,
@@ -72,24 +118,26 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
     hasVerifiedContent = true;
   }
 
-  if (context.connectionOpportunities.length > 0) {
+  const connectionOpportunities = context.connectionOpportunities.slice(0, CONNECTION_DIGEST_LIMIT);
+  if (connectionOpportunities.length > 0) {
     lines.push("**Potential connections via Index Network:**");
-    for (const opp of context.connectionOpportunities) {
+    for (const opp of connectionOpportunities) {
       if (opp.opportunityId) opportunityIds.push(opp.opportunityId);
-      const action = opp.acceptUrl ? `, [say hi](${opp.acceptUrl})` : ", say hi";
-      const reason = opp.mainText || "Relevant overlap with your current signals.";
-      lines.push(`- ${opportunityMarker(opp)}${opportunityLabel(opp)} — ${reason}${action}`);
+      const action = opp.acceptUrl ? ` [Say hi](${opp.acceptUrl}).` : " Say hi.";
+      const reason = opportunityReason(opp, "Relevant overlap with your current signals.");
+      lines.push(`- ${opportunityMarker(opp)}${opportunityLabel(opp)} — ${reason}.${action}`);
     }
     lines.push("");
     hasVerifiedContent = true;
   }
 
-  if (context.communityOpportunities.length > 0) {
+  const communityOpportunities = context.communityOpportunities.slice(0, COMMUNITY_DIGEST_LIMIT);
+  if (communityOpportunities.length > 0) {
     lines.push("**Help your community**");
-    for (const opp of context.communityOpportunities) {
+    for (const opp of communityOpportunities) {
       if (opp.opportunityId) opportunityIds.push(opp.opportunityId);
-      const action = opp.acceptUrl ? ` Know someone, [make intro](${opp.acceptUrl}).` : " Know someone, make intro.";
-      const reason = opp.mainText || "They are looking for a relevant introduction.";
+      const action = opp.acceptUrl ? ` Know someone? [Make intro](${opp.acceptUrl}).` : " Know someone? Make intro.";
+      const reason = opportunityReason(opp, "They are looking for a relevant introduction.");
       lines.push(`- ${opportunityMarker(opp)}${opportunityLabel(opp)} — ${reason}.${action}`);
     }
     lines.push("");

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -79,6 +79,35 @@ describe("composeDailyBrief", () => {
 
     expect(opportunityIds).toEqual(["opp-1"]);
     expect(body).toContain("<!-- digest-opportunity:id=opp-1 -->[Maya]");
-    expect(body).toContain("[say hi](https://protocol.index.network/c/abc123)");
+    expect(body).toContain("[Say hi](https://protocol.index.network/c/abc123)");
+  });
+
+  test("keeps digest opportunity bullets short and drops raw presenter artifacts", () => {
+    const longReason = "The discoverer, Helen, is building portable digital identity through gameplay and is seeking research collaboration. you, the candidate, is a tech professional with engineering expertise focusing on back-end development and has an intent to meet researchers. While their location is elsewhere, remote collaboration makes this less of a barrier.";
+    const opportunities = Array.from({ length: 4 }, (_, idx) => ({
+      name: `Person ${idx + 1}`,
+      opportunityId: `opp-${idx + 1}`,
+      mainText: longReason,
+      profileUrl: `https://index.network/u/11111111-1111-1111-1111-11111111111${idx}`,
+      acceptUrl: `https://protocol.index.network/c/abc12${idx}`,
+      feedCategory: "connection",
+    }));
+
+    const { body, opportunityIds } = composeDailyBrief({
+      ...baseContext,
+      opportunities,
+      connectionOpportunities: opportunities,
+    });
+
+    expect(opportunityIds).toEqual(["opp-1", "opp-2", "opp-3"]);
+    expect(body).toContain("Person 1");
+    expect(body).toContain("Person 3");
+    expect(body).not.toContain("Person 4");
+    expect(body).not.toContain("The discoverer");
+    expect(body).not.toContain("candidate");
+    expect(body).not.toContain("remote collaboration");
+    const bullets = body.split("\n").filter((line) => line.startsWith("- <!-- digest-opportunity"));
+    expect(bullets).toHaveLength(3);
+    expect(bullets.every((line) => line.length < 360)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- cap digest connection opportunities to 3 and community-intro opportunities to 2
- shorten each opportunity reason to one concise sentence-ish line
- strip raw MCP/minimal-card artifacts like "discoverer", "candidate", "you is", location/remote-collaboration filler
- render action links as sentence actions (`Say hi.` / `Make intro.`)
- bump AgentVillage to 0.3.19

## Root cause
The morning digest uses `list_opportunities(includeDigestMarkers=true)`. That tool currently returns the fast minimal-card presentation, not the LLM `OpportunityPresenter`, so the digest was copying long heuristic reasoning directly into the Kanban body.

## Verification
- `bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts`
