### PR TITLE
fix(index-network): parse digest MCP JSON results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -275,7 +275,27 @@ export function selectEvents(events: EdgeEvent[], interestTags: string[]): { hig
   return { highlightedEvents, interestEvents };
 }
 
+function unwrapOpportunityTranscript(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{")) return text;
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown;
+      data?: { message?: unknown };
+    };
+    const message = typeof parsed.data?.message === "string"
+      ? parsed.data.message
+      : typeof parsed.message === "string"
+        ? parsed.message
+        : "";
+    return message || text;
+  } catch {
+    return text;
+  }
+}
+
 export function parseOpportunityTranscript(text: string): BriefOpportunity[] {
+  const transcript = unwrapOpportunityTranscript(text);
   const cards: BriefOpportunity[] = [];
   let current: BriefOpportunity | null = null;
 
@@ -284,7 +304,7 @@ export function parseOpportunityTranscript(text: string): BriefOpportunity[] {
     current = null;
   };
 
-  for (const rawLine of text.split(/\r?\n/)) {
+  for (const rawLine of transcript.split(/\r?\n/)) {
     const line = rawLine.trimEnd();
     const header = line.match(/^\d+\.\s+(.+)$/);
     if (header) {

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -92,6 +92,31 @@ describe("build-daily-brief-context helpers", () => {
     ]);
   });
 
+  test("parseOpportunityTranscript unwraps direct MCP JSON tool results", () => {
+    const result = {
+      success: true,
+      data: {
+        found: true,
+        count: 1,
+        message: `You have 1 opportunity.\n\n1. Nathan Price\n   <!-- digest-opportunity:id=opp-direct-1 -->\n   builds the intelligence layer for human aging\n   status: pending\n   profileUrl: https://index.network/u/11111111-1111-1111-1111-111111111111\n   acceptUrl: https://index.network/c/abc123\n   feedCategory: connection`,
+      },
+    };
+
+    const parsed = parseOpportunityTranscript(JSON.stringify(result));
+
+    expect(parsed).toEqual([
+      {
+        name: "Nathan Price",
+        opportunityId: "opp-direct-1",
+        mainText: "builds the intelligence layer for human aging",
+        status: "pending",
+        profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
+        acceptUrl: "https://index.network/c/abc123",
+        feedCategory: "connection",
+      },
+    ]);
+  });
+
   test("filterDedupedOpportunities keeps cards without ids and drops delivered ids", () => {
     expect(
       filterDedupedOpportunities(


### PR DESCRIPTION
## Summary
- unwrap direct MCP JSON tool results before parsing digest opportunities
- keep existing plain-prose transcript parsing behavior
- add regression test for `{"success":true,"data":{"message":"..."}}` list_opportunities output
- bump AgentVillage to 0.3.20

## Root cause
The prepare prompt now correctly writes the direct MCP tool result to `memory/digest-opportunities.txt`. That result is JSON whose useful transcript is nested in `data.message`; the context builder only parsed plain prose, so it dropped all opportunities and staged calendar-only cards.

## Verification
- `bun test skills/index-network/scripts/tests/build-daily-brief-context.test.ts skills/index-network/scripts/tests/stage-daily-brief.test.ts`
