### PR TITLE
fix(index-network): improve digest opportunity reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -79,6 +79,38 @@ function normalizeOpportunityText(text: string): string {
     .trim();
 }
 
+function firstName(name: string): string {
+  return name.trim().split(/\s+/)[0] || name;
+}
+
+function opportunityTemplate(opp: BriefOpportunity, text: string): string | null {
+  const first = firstName(opp.name);
+  const escaped = first.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const profileExpertise = text.match(new RegExp(`(?:${escaped}\\s+\\w+|${escaped})['’]s profile indicates strong expertise in ([^,.]+)`, "i"));
+  if (profileExpertise?.[1]) return `${first} has strong ${profileExpertise[1].trim()} expertise`;
+
+  const wantsFeedback = text.match(new RegExp(`${escaped}[^.]*seeking feedback[^.]*?(?:on|about) ['“\"]?([^'.“”\"]+)`, "i"));
+  if (wantsFeedback?.[1]) return `${first} wants feedback on ${wantsFeedback[1].trim()}`;
+
+  const building = text.match(new RegExp(`${escaped}[^.]*building ['“\"]([^'“”\"]+)['”\"][^.]*seeking ([^.]+)`, "i"));
+  if (building?.[1]) return `${first} is building ${building[1].trim()}`;
+
+  const exploring = text.match(new RegExp(`${escaped}[^.]*exploration of ['“\"]([^'“”\"]+)['”\"][^.]*['“\"]([^'“”\"]+)['”\"]`, "i"));
+  if (exploring?.[1] && exploring?.[2]) return `${first} is exploring ${exploring[1].trim()} and ${exploring[2].trim()}`;
+
+  const focusing = text.match(new RegExp(`${escaped}[^.]*focusing on ([^,.;]+)`, "i"));
+  if (focusing?.[1]) return `${first} is focused on ${focusing[1].trim()}`;
+
+  return null;
+}
+
+function readableSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence && !/\b(Yankı|you are|your)\b/i.test(sentence));
+}
+
 function truncateAtWord(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
   const slice = text.slice(0, maxChars + 1);
@@ -88,7 +120,9 @@ function truncateAtWord(text: string, maxChars: number): string {
 
 function opportunityReason(opp: BriefOpportunity, fallback: string): string {
   const cleaned = normalizeOpportunityText(opp.mainText || fallback);
-  return truncateAtWord(cleaned, OPPORTUNITY_REASON_MAX_CHARS).replace(/[,.]$/, "");
+  const templated = opportunityTemplate(opp, cleaned);
+  const sentence = templated ?? readableSentences(cleaned)[0] ?? cleaned;
+  return truncateAtWord(sentence, OPPORTUNITY_REASON_MAX_CHARS).replace(/[,.]$/, "");
 }
 
 export function composeDailyBrief(context: DailyBriefContext): { body: string; opportunityIds: string[] } {

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -82,6 +82,48 @@ describe("composeDailyBrief", () => {
     expect(body).toContain("[Say hi](https://protocol.index.network/c/abc123)");
   });
 
+  test("renders common digest opportunity reasons as concise user-facing prose", () => {
+    const opportunities = [
+      {
+        name: "Seref Yarar",
+        opportunityId: "opp-seref",
+        mainText: "Seref Yarar's profile indicates strong expertise in AI, especially in user profiling and modeling, and he is involved with arXiv publications on these topics, suggesting deep engagement with advanced AI concepts relevant to the discoverer's query.",
+        profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
+        acceptUrl: "https://protocol.index.network/c/seref",
+        feedCategory: "connection",
+      },
+      {
+        name: "Seren Sandikci",
+        opportunityId: "opp-seren",
+        mainText: "The discoverer, Seren, is seeking feedback and deep technical or design insights on 'protocol design'. Yankı is a tech professional with engineering expertise, focusing on back-end development and full-stack development.",
+        profileUrl: "https://index.network/u/22222222-2222-2222-2222-222222222222",
+        acceptUrl: "https://protocol.index.network/c/seren",
+        feedCategory: "connection",
+      },
+      {
+        name: "Helen Huang",
+        opportunityId: "opp-helen",
+        mainText: "The discoverer, Helen, is building 'portable digital identity of character and behavior through gameplay' and is seeking research collaboration. you, the candidate, is a tech professional with engineering expertise focusing on back-end development.",
+        profileUrl: "https://index.network/u/33333333-3333-3333-3333-333333333333",
+        acceptUrl: "https://protocol.index.network/c/helen",
+        feedCategory: "connection",
+      },
+    ];
+
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      opportunities,
+      connectionOpportunities: opportunities,
+    });
+
+    expect(body).toContain("Seref has strong AI expertise. [Say hi]");
+    expect(body).toContain("Seren wants feedback on protocol design. [Say hi]");
+    expect(body).toContain("Helen is building portable digital identity of character and behavior through gameplay. [Say hi]");
+    expect(body).not.toContain("profile indicates");
+    expect(body).not.toContain("Yankı is a tech professional");
+    expect(body).not.toContain("you are a tech professional");
+  });
+
   test("keeps digest opportunity bullets short and drops raw presenter artifacts", () => {
     const longReason = "The discoverer, Helen, is building portable digital identity through gameplay and is seeking research collaboration. you, the candidate, is a tech professional with engineering expertise focusing on back-end development and has an intent to meet researchers. While their location is elsewhere, remote collaboration makes this less of a barrier.";
     const opportunities = Array.from({ length: 4 }, (_, idx) => ({


### PR DESCRIPTION
## Summary
- replace raw/truncated opportunity reasoning with deterministic concise first-person-friendly summaries
- add templates for common minimal-card shapes: profile expertise, feedback requests, building/research collaboration, exploration, and focus areas
- avoid draft artifacts like "profile indicates", "Yankı is...", and "you are a tech professional..." in digest bullets
- bump AgentVillage to 0.3.21

## Verification
- `bun test skills/index-network/scripts/tests/build-daily-brief-context.test.ts skills/index-network/scripts/tests/stage-daily-brief.test.ts skills/index-network/scripts/tests/validate-digest-urls.test.ts`
