### PR TITLE
fix(index-network): rename digest people section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -154,7 +154,7 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
 
   const connectionOpportunities = context.connectionOpportunities.slice(0, CONNECTION_DIGEST_LIMIT);
   if (connectionOpportunities.length > 0) {
-    lines.push("**Potential connections via Index Network:**");
+    lines.push("**People worth meeting today:**");
     for (const opp of connectionOpportunities) {
       if (opp.opportunityId) opportunityIds.push(opp.opportunityId);
       const action = opp.acceptUrl ? ` [Say hi](${opp.acceptUrl}).` : " Say hi.";

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -78,6 +78,8 @@ describe("composeDailyBrief", () => {
     });
 
     expect(opportunityIds).toEqual(["opp-1"]);
+    expect(body).toContain("**People worth meeting today:**");
+    expect(body).not.toContain("Potential connections via Index Network");
     expect(body).toContain("<!-- digest-opportunity:id=opp-1 -->[Maya]");
     expect(body).toContain("[Say hi](https://protocol.index.network/c/abc123)");
   });


### PR DESCRIPTION
## Summary
- rename the digest connection section from `Potential connections via Index Network` to `People worth meeting today`
- add a regression assertion for the user-facing heading
- bump AgentVillage to 0.3.22

## Verification
- `bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts`
