### PR TITLE
fix(index-network): harden digest opportunities and weather

### DIFF
--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -62,7 +62,7 @@ const TAG_KEYWORDS: Record<string, string[]> = {
 export interface DailyBriefWeather {
   forecast: string;
   emoji: string;
-  source: "open-meteo" | "unavailable";
+  source: "open-meteo" | "nws" | "unavailable";
 }
 
 export interface BriefAnnouncement {
@@ -112,7 +112,7 @@ export interface DailyBriefContext {
     calendarSource: "edgeos" | "unavailable";
     rsvpSource: "edgeos" | "unavailable";
     opportunitySource: "file" | "unavailable";
-    weatherSource?: "open-meteo" | "unavailable";
+    weatherSource?: "open-meteo" | "nws" | "unavailable";
     warnings: string[];
     interestTags: string[];
   };
@@ -290,6 +290,20 @@ export function selectEvents(events: EdgeEvent[], interestTags: string[]): { hig
   return { highlightedEvents, interestEvents };
 }
 
+function decodeJsonStringLiteral(raw: string): string | null {
+  try {
+    return JSON.parse(`"${raw}"`) as string;
+  } catch {
+    return null;
+  }
+}
+
+function extractMessageFieldFromMalformedJson(text: string): string | null {
+  const match = text.match(/"message"\s*:\s*"((?:\\.|[^"\\])*)"/s);
+  if (!match) return null;
+  return decodeJsonStringLiteral(match[1]);
+}
+
 function unwrapOpportunityTranscript(text: string): string {
   const trimmed = text.trim();
   if (!trimmed.startsWith("{")) return text;
@@ -305,7 +319,7 @@ function unwrapOpportunityTranscript(text: string): string {
         : "";
     return message || text;
   } catch {
-    return text;
+    return extractMessageFieldFromMalformedJson(trimmed) ?? text;
   }
 }
 
@@ -381,33 +395,80 @@ async function readDeliveredIds(stateFile: string, date: string): Promise<Set<st
   return new Set();
 }
 
+async function fetchOpenMeteoWeather(date: string): Promise<DailyBriefWeather> {
+  const params = new URLSearchParams({
+    latitude: String(HEALDSBURG_LAT),
+    longitude: String(HEALDSBURG_LON),
+    daily: "temperature_2m_max,weather_code",
+    temperature_unit: "fahrenheit",
+    timezone: PACIFIC_TZ,
+    start_date: date,
+    end_date: date,
+  });
+  const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const data = (await res.json()) as {
+    daily?: { temperature_2m_max?: number[]; weather_code?: number[] };
+  };
+  const high = data.daily?.temperature_2m_max?.[0];
+  const code = data.daily?.weather_code?.[0];
+  if (high == null || code == null) throw new Error("missing daily forecast data");
+  const mapping = WEATHER_CODE_MAP[code] ?? { description: "mixed conditions", emoji: "🌤️" };
+  return {
+    forecast: `Expect ${mapping.description} and a high of ${Math.round(high)}°F`,
+    emoji: mapping.emoji,
+    source: "open-meteo",
+  };
+}
+
+function nwsEmoji(shortForecast: string): string {
+  const text = shortForecast.toLowerCase();
+  if (text.includes("thunder")) return "⛈️";
+  if (text.includes("rain") || text.includes("shower")) return "🌦️";
+  if (text.includes("snow")) return "❄️";
+  if (text.includes("fog")) return "🌫️";
+  if (text.includes("sunny") || text.includes("clear")) return "☀️";
+  if (text.includes("cloud")) return text.includes("partly") || text.includes("mostly") ? "⛅" : "☁️";
+  return "🌤️";
+}
+
+async function fetchNwsWeather(date: string): Promise<DailyBriefWeather> {
+  const headers = { "User-Agent": "AgentVillage daily digest (https://github.com/Edge-City/agentvillage)" };
+  const pointRes = await fetch(`https://api.weather.gov/points/${HEALDSBURG_LAT},${HEALDSBURG_LON}`, { headers });
+  if (!pointRes.ok) throw new Error(`${pointRes.status} ${pointRes.statusText}`);
+  const pointData = (await pointRes.json()) as { properties?: { forecast?: string } };
+  if (!pointData.properties?.forecast) throw new Error("missing NWS forecast URL");
+
+  const forecastRes = await fetch(pointData.properties.forecast, { headers });
+  if (!forecastRes.ok) throw new Error(`${forecastRes.status} ${forecastRes.statusText}`);
+  const forecastData = (await forecastRes.json()) as {
+    properties?: {
+      periods?: Array<{ startTime?: string; isDaytime?: boolean; temperature?: number; shortForecast?: string }>;
+    };
+  };
+  const periods = forecastData.properties?.periods ?? [];
+  const period = periods.find((p) => p.isDaytime === true && p.startTime && pacificDate(new Date(p.startTime)) === date)
+    ?? periods.find((p) => p.isDaytime === true);
+  if (!period?.shortForecast || period.temperature == null) throw new Error("missing NWS daytime forecast");
+  const description = period.shortForecast.trim().toLowerCase();
+  return {
+    forecast: `Expect ${description} and a high of ${Math.round(period.temperature)}°F`,
+    emoji: nwsEmoji(period.shortForecast),
+    source: "nws",
+  };
+}
+
 async function fetchWeather(date: string, warnings: string[]): Promise<DailyBriefWeather> {
   try {
-    const params = new URLSearchParams({
-      latitude: String(HEALDSBURG_LAT),
-      longitude: String(HEALDSBURG_LON),
-      daily: "temperature_2m_max,weather_code",
-      temperature_unit: "fahrenheit",
-      timezone: PACIFIC_TZ,
-      start_date: date,
-      end_date: date,
-    });
-    const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`);
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-    const data = (await res.json()) as {
-      daily?: { temperature_2m_max?: number[]; weather_code?: number[] };
-    };
-    const high = data.daily?.temperature_2m_max?.[0];
-    const code = data.daily?.weather_code?.[0];
-    if (high == null || code == null) throw new Error("missing daily forecast data");
-    const mapping = WEATHER_CODE_MAP[code] ?? { description: "mixed conditions", emoji: "🌤️" };
-    return {
-      forecast: `Expect ${mapping.description} and a high of ${Math.round(high)}°F`,
-      emoji: mapping.emoji,
-      source: "open-meteo",
-    };
+    return await fetchOpenMeteoWeather(date);
   } catch (err) {
-    warnings.push(`weather unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    warnings.push(`open-meteo weather unavailable: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  try {
+    return await fetchNwsWeather(date);
+  } catch (err) {
+    warnings.push(`nws weather unavailable: ${err instanceof Error ? err.message : String(err)}`);
     return { forecast: "", emoji: "", source: "unavailable" };
   }
 }

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildDailyBriefContext,
   extractInterestTags,
   filterDedupedOpportunities,
   formatPacificTime,
@@ -117,6 +118,23 @@ describe("build-daily-brief-context helpers", () => {
     ]);
   });
 
+  test("parseOpportunityTranscript tolerates malformed MCP wrappers with escaped message JSON", () => {
+    const malformed = `{"success":true,"data":{"message":"You have 1 opportunity.\\n\\n1. Athena Aktipis\\n   <!-- digest-opportunity:id=opp-athena -->\\n   Athena is seeking collaboration.\\n   status: draft\\n   profileUrl: https://index.network/u/athena\\n   acceptUrl: https://protocol.index.network/c/athena\\n   feedCategory: connection\\n   confidence: 85"}},path:`;
+
+    expect(parseOpportunityTranscript(malformed)).toEqual([
+      {
+        name: "Athena Aktipis",
+        opportunityId: "opp-athena",
+        mainText: "Athena is seeking collaboration.",
+        status: "draft",
+        profileUrl: "https://index.network/u/athena",
+        acceptUrl: "https://protocol.index.network/c/athena",
+        feedCategory: "connection",
+        confidence: 85,
+      },
+    ]);
+  });
+
   test("parseOpportunityTranscript parses confidence as a number and ignores invalid values", () => {
     const parsed = parseOpportunityTranscript(`1. Alice
    <!-- digest-opportunity:id=alice -->
@@ -165,5 +183,59 @@ describe("build-daily-brief-context helpers", () => {
       startIso: "2026-12-04T08:00:00.000Z",
       endIso: "2026-12-05T08:00:00.000Z",
     });
+  });
+
+  test("buildDailyBriefContext falls back to NWS when Open-Meteo rate limits", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalEdgeosKey = process.env.EDGEOS_API_KEY;
+    const originalControlPlaneUrl = process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    const originalAdminToken = process.env.ADMIN_TOKEN;
+    delete process.env.EDGEOS_API_KEY;
+    delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    delete process.env.ADMIN_TOKEN;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("https://api.open-meteo.com/")) {
+        return new Response("rate limited", { status: 429, statusText: "Too Many Requests" });
+      }
+      if (url.startsWith("https://api.weather.gov/points/")) {
+        return Response.json({ properties: { forecast: "https://api.weather.gov/gridpoints/MTR/84,106/forecast" } });
+      }
+      if (url === "https://api.weather.gov/gridpoints/MTR/84,106/forecast") {
+        return Response.json({
+          properties: {
+            periods: [
+              {
+                startTime: "2026-06-06T06:00:00-07:00",
+                isDaytime: true,
+                temperature: 82,
+                shortForecast: "Mostly Cloudy",
+              },
+            ],
+          },
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const context = await buildDailyBriefContext({ date: "2026-06-06", userFiles: [] });
+      expect(context.weather).toEqual({
+        forecast: "Expect mostly cloudy and a high of 82°F",
+        emoji: "⛅",
+        source: "nws",
+      });
+      expect(context.diagnostics.weatherSource).toBe("nws");
+      expect(context.diagnostics.warnings).toContain("open-meteo weather unavailable: 429 Too Many Requests");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalEdgeosKey === undefined) delete process.env.EDGEOS_API_KEY;
+      else process.env.EDGEOS_API_KEY = originalEdgeosKey;
+      if (originalControlPlaneUrl === undefined) delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+      else process.env.EDGE_AGENT_CONTROL_PLANE_URL = originalControlPlaneUrl;
+      if (originalAdminToken === undefined) delete process.env.ADMIN_TOKEN;
+      else process.env.ADMIN_TOKEN = originalAdminToken;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- parse malformed MCP wrapper output so digest opportunities are not dropped
- fall back to weather.gov/NWS when Open-Meteo rate limits a resident digest run
- add regression tests for malformed MCP JSON and weather fallback

## Tests
- bun test skills/index-network/scripts/tests/build-daily-brief-context.test.ts skills/index-network/scripts/tests/stage-daily-brief.test.ts