### PR TITLE
Preserve names in digest opportunity rewrites

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -85,9 +85,15 @@ function thirdPersonToTheyClause(text: string, name: string): string {
     .join("|");
   if (!namePattern) return text;
 
-  const withoutName = text.replace(new RegExp(`^(?:${namePattern})\\s+`, "i"), "").trim();
+  const withoutName = text
+    .replace(new RegExp(`^(?:${namePattern})(?:\\s+|[,—–-]\\s*)`, "i"), "")
+    .trim();
   if (withoutName === text) return text;
 
+  if (/^who\s+is\s+/i.test(withoutName)) return withoutName.replace(/^who\s+is\s+/i, "they’re ");
+  if (/^who\s+are\s+/i.test(withoutName)) return withoutName.replace(/^who\s+are\s+/i, "they’re ");
+  if (/^who\s+has\s+/i.test(withoutName)) return withoutName.replace(/^who\s+has\s+/i, "they have ");
+  if (/^(?:a|an|the)\s+/i.test(withoutName)) return `they’re ${withoutName}`;
   if (/^is\s+/i.test(withoutName)) return withoutName.replace(/^is\s+/i, "they’re ");
   if (/^are\s+/i.test(withoutName)) return withoutName.replace(/^are\s+/i, "they’re ");
   if (/^has\s+/i.test(withoutName)) return withoutName.replace(/^has\s+/i, "they have ");

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -197,6 +197,35 @@ describe("composeDailyBrief", () => {
     expect(body).not.toContain("[Paul McKellar](https://index.network/u/paul) — Paul McKellar is deeply involved");
   });
 
+  test("preserves full names when rewriting appositive presenter summaries", () => {
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      opportunities: [
+        {
+          name: "Paul McKellar",
+          opportunityId: "opp-paul",
+          mainText: "Paul McKellar, an experienced founder and investor, is keenly interested in connecting with creative builders in tech and software.",
+          profileUrl: "https://index.network/u/paul",
+          acceptUrl: "https://protocol.index.network/c/paul",
+          feedCategory: "connection",
+        },
+      ],
+      connectionOpportunities: [
+        {
+          name: "Paul McKellar",
+          opportunityId: "opp-paul",
+          mainText: "Paul McKellar, an experienced founder and investor, is keenly interested in connecting with creative builders in tech and software.",
+          profileUrl: "https://index.network/u/paul",
+          acceptUrl: "https://protocol.index.network/c/paul",
+          feedCategory: "connection",
+        },
+      ],
+    });
+
+    expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re an experienced founder and investor");
+    expect(body).not.toContain("mcKellar");
+  });
+
   test("sorts opportunities by confidence descending before applying limit", () => {
     // 4 opportunities, all with confidence. Person 4 has highest, Person 1 lowest.
     const opportunities = Array.from({ length: 4 }, (_, idx) => ({


### PR DESCRIPTION
## Summary
- Fix appositive name rewrites so full names like `Paul McKellar, ...` do not become `mcKellar, ...`.
- Convert appositive presenter summaries into natural clauses like `they’re an experienced founder...`.
- Bump package version to 0.3.24.

## Verification
- bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts
