### PR TITLE
Repair appositive digest opportunity grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -93,6 +93,13 @@ function thirdPersonToTheyClause(text: string, name: string): string {
   if (/^who\s+is\s+/i.test(withoutName)) return withoutName.replace(/^who\s+is\s+/i, "they’re ");
   if (/^who\s+are\s+/i.test(withoutName)) return withoutName.replace(/^who\s+are\s+/i, "they’re ");
   if (/^who\s+has\s+/i.test(withoutName)) return withoutName.replace(/^who\s+has\s+/i, "they have ");
+  const appositive = withoutName.match(/^((?:a|an|the)\s+.+?),\s+(is|are|has|needs|wants|seeks)\s+(.+)$/i);
+  if (appositive) {
+    const descriptor = appositive[1];
+    const verb = appositive[2].toLowerCase();
+    const rest = appositive[3];
+    return `they’re ${descriptor} who ${verb} ${rest}`;
+  }
   if (/^(?:a|an|the)\s+/i.test(withoutName)) return `they’re ${withoutName}`;
   if (/^is\s+/i.test(withoutName)) return withoutName.replace(/^is\s+/i, "they’re ");
   if (/^are\s+/i.test(withoutName)) return withoutName.replace(/^are\s+/i, "they’re ");

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -222,8 +222,38 @@ describe("composeDailyBrief", () => {
       ],
     });
 
-    expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re an experienced founder and investor");
+    expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re an experienced founder and investor who is keenly interested in connecting with creative builders");
     expect(body).not.toContain("mcKellar");
+    expect(body).not.toContain(", is keenly interested");
+  });
+
+  test("rewrites appositive summaries with following verbs into grammatical clauses", () => {
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      opportunities: [
+        {
+          name: "Paul McKellar",
+          opportunityId: "opp-paul",
+          mainText: "Paul McKellar, an experienced founder and angel investor, is actively seeking creative builders with skills in art, craft, design, tech, and software.",
+          profileUrl: "https://index.network/u/paul",
+          acceptUrl: "https://protocol.index.network/c/paul",
+          feedCategory: "connection",
+        },
+      ],
+      connectionOpportunities: [
+        {
+          name: "Paul McKellar",
+          opportunityId: "opp-paul",
+          mainText: "Paul McKellar, an experienced founder and angel investor, is actively seeking creative builders with skills in art, craft, design, tech, and software.",
+          profileUrl: "https://index.network/u/paul",
+          acceptUrl: "https://protocol.index.network/c/paul",
+          feedCategory: "connection",
+        },
+      ],
+    });
+
+    expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re an experienced founder and angel investor who is actively seeking creative builders");
+    expect(body).not.toContain("they’re an experienced founder and angel investor, is actively seeking");
   });
 
   test("sorts opportunities by confidence descending before applying limit", () => {


### PR DESCRIPTION
## Summary
- Rewrite appositive presenter summaries like `Name, an X, is Y` as `they’re an X who is Y`.
- Prevent prepared digest lines like `they’re an experienced founder, is actively seeking...`.
- Bump package version to 0.3.25.

## Verification
- bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts
