### PR TITLE
Harden daily digest opportunity grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -69,11 +69,34 @@ function escapeRegExp(value: string): string {
 }
 
 function startsViewerCentered(text: string): boolean {
-  return /\b(you|your|you're|you’re|you'll|you’ll|you'd|you’d)\b/i.test(text);
+  return /^\s*(you|your|you're|you’re|you'll|you’ll|you'd|you’d)\b/i.test(text);
 }
 
 function lowerFirst(value: string): string {
   return value ? `${value[0].toLowerCase()}${value.slice(1)}` : value;
+}
+
+function normalizeViewerGrammar(text: string): string {
+  return text
+    .replace(/^\s*you\s+is\b/i, "You are")
+    .replace(/\byou\s+is\b/gi, "you are")
+    .replace(/\bthe discoverer's query\b/gi, "this connection")
+    .replace(/\bdiscoverer's query\b/gi, "this connection");
+}
+
+function normalizeTheyAgreement(text: string): string {
+  return text
+    .replace(/\b(and|but)\s+is\b/gi, "$1 are")
+    .replace(/\b(and|but)\s+has\b/gi, "$1 have")
+    .replace(/\b(and|but)\s+he(?:'|’)s\b/gi, "$1 they’re")
+    .replace(/\b(and|but)\s+she(?:'|’)s\b/gi, "$1 they’re")
+    .replace(/\bhe(?:'|’)s\b/gi, "they’re")
+    .replace(/\bshe(?:'|’)s\b/gi, "they’re");
+}
+
+function appositiveDescriptor(descriptor: string): string {
+  const trimmed = descriptor.trim();
+  return /^(?:a|an|the)\s+/i.test(trimmed) ? trimmed : `the ${trimmed}`;
 }
 
 function thirdPersonToTheyClause(text: string, name: string): string {
@@ -83,32 +106,39 @@ function thirdPersonToTheyClause(text: string, name: string): string {
     .sort((a, b) => b.length - a.length)
     .map(escapeRegExp)
     .join("|");
-  if (!namePattern) return text;
 
-  const withoutName = text
-    .replace(new RegExp(`^(?:${namePattern})(?:\\s+|[,—–-]\\s*)`, "i"), "")
-    .trim();
-  if (withoutName === text) return text;
+  let remainder = text.trim();
+  let strippedName = false;
+  if (namePattern) {
+    const withoutName = remainder
+      .replace(new RegExp(`^(?:${namePattern})(?:\\s+|[,—–-]\\s*)`, "i"), "")
+      .trim();
+    strippedName = withoutName !== remainder;
+    remainder = withoutName;
+  }
 
-  if (/^who\s+is\s+/i.test(withoutName)) return withoutName.replace(/^who\s+is\s+/i, "they’re ");
-  if (/^who\s+are\s+/i.test(withoutName)) return withoutName.replace(/^who\s+are\s+/i, "they’re ");
-  if (/^who\s+has\s+/i.test(withoutName)) return withoutName.replace(/^who\s+has\s+/i, "they have ");
-  const appositive = withoutName.match(/^((?:a|an|the)\s+.+?),\s+(is|are|has|needs|wants|seeks)\s+(.+)$/i);
-  if (appositive) {
-    const descriptor = appositive[1];
+  if (/^who\s+is\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^who\s+is\s+/i, "they’re "));
+  if (/^who\s+are\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^who\s+are\s+/i, "they’re "));
+  if (/^who\s+has\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^who\s+has\s+/i, "they have "));
+
+  const appositive = remainder.match(/^(.{3,100}?),\s+(is|are|has|needs|wants|seeks)\s+(.+)$/i);
+  if (appositive && !/^(?:this|that|it|they|you|your)\b/i.test(appositive[1])) {
+    const descriptor = appositiveDescriptor(appositive[1]);
     const verb = appositive[2].toLowerCase();
     const rest = appositive[3];
-    return `they’re ${descriptor} who ${verb} ${rest}`;
+    return normalizeTheyAgreement(`they’re ${descriptor} who ${verb} ${rest}`);
   }
-  if (/^(?:a|an|the)\s+/i.test(withoutName)) return `they’re ${withoutName}`;
-  if (/^is\s+/i.test(withoutName)) return withoutName.replace(/^is\s+/i, "they’re ");
-  if (/^are\s+/i.test(withoutName)) return withoutName.replace(/^are\s+/i, "they’re ");
-  if (/^has\s+/i.test(withoutName)) return withoutName.replace(/^has\s+/i, "they have ");
-  if (/^needs\s+/i.test(withoutName)) return withoutName.replace(/^needs\s+/i, "they need ");
-  if (/^wants\s+/i.test(withoutName)) return withoutName.replace(/^wants\s+/i, "they want ");
-  if (/^seeks\s+/i.test(withoutName)) return withoutName.replace(/^seeks\s+/i, "they seek ");
-  if (/^would\s+/i.test(withoutName)) return `they ${withoutName}`;
-  return lowerFirst(withoutName);
+
+  if (/^(?:a|an|the)\s+/i.test(remainder)) return normalizeTheyAgreement(`they’re ${remainder}`);
+  if (/^is\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^is\s+/i, "they’re "));
+  if (/^are\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^are\s+/i, "they’re "));
+  if (/^has\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^has\s+/i, "they have "));
+  if (/^needs\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^needs\s+/i, "they need "));
+  if (/^wants\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^wants\s+/i, "they want "));
+  if (/^seeks\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^seeks\s+/i, "they seek "));
+  if (/^would\s+/i.test(remainder)) return normalizeTheyAgreement(`they ${remainder}`);
+
+  return normalizeTheyAgreement(strippedName ? lowerFirst(remainder) : remainder);
 }
 
 function opportunityReason(
@@ -116,7 +146,7 @@ function opportunityReason(
   fallback: string,
   kind: "connection" | "community",
 ): { text: string; includesLabel: boolean } {
-  const text = normalizeOpportunityText(opp.mainText || fallback);
+  const text = normalizeViewerGrammar(normalizeOpportunityText(opp.mainText || fallback));
   const firstSentence = text.split(/(?<=[.!?])\s+/)[0]?.trim() ?? text;
   let reason = firstSentence;
   let includesLabel = false;

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -163,7 +163,7 @@ describe("composeDailyBrief", () => {
     });
 
     // Seren has the highest confidence (91) — she should be the one picked
-    expect(body).toContain("Seren is seeking feedback on protocol design and would benefit from your engineering expertise. [Say hi]");
+    expect(body).toContain("You might like meeting [Seren Sandikci](https://index.network/u/22222222-2222-2222-2222-222222222222): they’re seeking feedback on protocol design and would benefit from your engineering expertise. [Say hi]");
     expect(body).not.toContain("Seref");
     expect(body).not.toContain("Helen");
   });
@@ -254,6 +254,60 @@ describe("composeDailyBrief", () => {
 
     expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re an experienced founder and angel investor who is actively seeking creative builders");
     expect(body).not.toContain("they’re an experienced founder and angel investor, is actively seeking");
+  });
+
+  test("repairs fleet-observed digest grammar issues", () => {
+    const samples = [
+      {
+        name: "Amer Ameen",
+        text: "Amer Ameen is building 'Pluto' in Toronto as a 'fourth space,' directly inspired by Edge Esmeralda, and is developing co-living hubs.",
+        expected: "they’re building 'Pluto' in Toronto as a 'fourth space,' directly inspired by Edge Esmeralda, and are developing",
+        forbidden: "and is developing",
+      },
+      {
+        name: "Scott Brylow",
+        text: "Scott Brylow has extensive experience in cutting-edge hardware, including cameras for Mars missions, and is keenly interested in future tools.",
+        expected: "they have extensive experience in cutting-edge hardware, including cameras for Mars missions, and are keenly interested",
+        forbidden: "and is keenly interested",
+      },
+      {
+        name: "Scott Brylow",
+        text: "Scott Brylow is a retired engineer with deep experience in spaceflight imaging and early web/VR, and he's actively looking to connect with builders.",
+        expected: "they’re a retired engineer with deep experience in spaceflight imaging and early web/VR, and they’re actively looking",
+        forbidden: "and he's actively looking",
+      },
+      {
+        name: "Seref Yarar",
+        text: "co-founder of Index Network, is deeply involved in Web3, decentralized technology, and programmable discovery protocols.",
+        expected: "they’re the co-founder of Index Network who is deeply involved in Web3",
+        forbidden: "co-founder of Index Network, is deeply involved",
+      },
+      {
+        name: "Athena Aktipis",
+        text: "you is an AI researcher whose primary focus areas directly align with the discoverer's query.",
+        expected: "You are an AI researcher whose primary focus areas directly align with this connection",
+        forbidden: "you is",
+      },
+    ];
+
+    for (const sample of samples) {
+      const opp = {
+        name: sample.name,
+        opportunityId: `opp-${sample.name}`,
+        mainText: sample.text,
+        profileUrl: `https://index.network/u/${encodeURIComponent(sample.name)}`,
+        acceptUrl: "https://protocol.index.network/c/sample",
+        feedCategory: "connection",
+      };
+      const { body } = composeDailyBrief({
+        ...baseContext,
+        opportunities: [opp],
+        connectionOpportunities: [opp],
+      });
+      expect(body).toContain(sample.expected);
+      expect(body).not.toContain(sample.forbidden);
+      expect(body).not.toContain("discoverer's query");
+    }
   });
 
   test("sorts opportunities by confidence descending before applying limit", () => {


### PR DESCRIPTION
## Summary
- Fix fleet-observed opportunity grammar issues: `you is`, `discoverer's query`, `they ... and is`, `they ... and he's`, and bare appositive fragments.
- Warm more third-person opportunity summaries while preserving profile links.
- Bump package version to 0.3.26.

## Verification
- bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts
