### PR TITLE
Trust presenter-provided digest summaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -64,115 +64,32 @@ function truncateAtWord(text: string, maxChars: number): string {
   return `${slice.slice(0, boundary > 80 ? boundary : maxChars).trimEnd()}…`;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+function linkifyOpportunityName(text: string, opp: BriefOpportunity): { text: string; includesLabel: boolean } {
+  if (!opp.profileUrl) return { text, includesLabel: false };
 
-function startsViewerCentered(text: string): boolean {
-  return /^\s*(you|your|you're|you’re|you'll|you’ll|you'd|you’d)\b/i.test(text);
-}
-
-function lowerFirst(value: string): string {
-  return value ? `${value[0].toLowerCase()}${value.slice(1)}` : value;
-}
-
-function normalizeViewerGrammar(text: string): string {
-  return text
-    .replace(/^\s*you\s+is\b/i, "You are")
-    .replace(/\byou\s+is\b/gi, "you are")
-    .replace(/\bthe discoverer's query\b/gi, "this connection")
-    .replace(/\bdiscoverer's query\b/gi, "this connection");
-}
-
-function normalizeTheyAgreement(text: string): string {
-  return text
-    .replace(/\b(and|but)\s+is\b/gi, "$1 are")
-    .replace(/\b(and|but)\s+has\b/gi, "$1 have")
-    .replace(/\b(and|but)\s+he(?:'|’)s\b/gi, "$1 they’re")
-    .replace(/\b(and|but)\s+she(?:'|’)s\b/gi, "$1 they’re")
-    .replace(/\bhe(?:'|’)s\b/gi, "they’re")
-    .replace(/\bshe(?:'|’)s\b/gi, "they’re");
-}
-
-function appositiveDescriptor(descriptor: string): string {
-  const trimmed = descriptor.trim();
-  return /^(?:a|an|the)\s+/i.test(trimmed) ? trimmed : `the ${trimmed}`;
-}
-
-function thirdPersonToTheyClause(text: string, name: string): string {
-  const first = firstName(name);
-  const namePattern = [name, first]
-    .filter(Boolean)
-    .sort((a, b) => b.length - a.length)
-    .map(escapeRegExp)
-    .join("|");
-
-  let remainder = text.trim();
-  let strippedName = false;
-  if (namePattern) {
-    const withoutName = remainder
-      .replace(new RegExp(`^(?:${namePattern})(?:\\s+|[,—–-]\\s*)`, "i"), "")
-      .trim();
-    strippedName = withoutName !== remainder;
-    remainder = withoutName;
+  const label = opportunityLabel(opp);
+  const candidates = [opp.name, firstName(opp.name)].filter(Boolean);
+  for (const candidate of candidates) {
+    const idx = text.indexOf(candidate);
+    if (idx >= 0) {
+      return {
+        text: `${text.slice(0, idx)}${label}${text.slice(idx + candidate.length)}`,
+        includesLabel: true,
+      };
+    }
   }
 
-  if (/^who\s+is\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^who\s+is\s+/i, "they’re "));
-  if (/^who\s+are\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^who\s+are\s+/i, "they’re "));
-  if (/^who\s+has\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^who\s+has\s+/i, "they have "));
-
-  const appositive = remainder.match(/^(.{3,100}?),\s+(is|are|has|needs|wants|seeks)\s+(.+)$/i);
-  if (appositive && !/^(?:this|that|it|they|you|your)\b/i.test(appositive[1])) {
-    const descriptor = appositiveDescriptor(appositive[1]);
-    const verb = appositive[2].toLowerCase();
-    const rest = appositive[3];
-    return normalizeTheyAgreement(`they’re ${descriptor} who ${verb} ${rest}`);
-  }
-
-  if (/^(?:a|an|the)\s+/i.test(remainder)) return normalizeTheyAgreement(`they’re ${remainder}`);
-  if (/^is\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^is\s+/i, "they’re "));
-  if (/^are\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^are\s+/i, "they’re "));
-  if (/^has\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^has\s+/i, "they have "));
-  if (/^needs\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^needs\s+/i, "they need "));
-  if (/^wants\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^wants\s+/i, "they want "));
-  if (/^seeks\s+/i.test(remainder)) return normalizeTheyAgreement(remainder.replace(/^seeks\s+/i, "they seek "));
-  if (/^would\s+/i.test(remainder)) return normalizeTheyAgreement(`they ${remainder}`);
-
-  return normalizeTheyAgreement(strippedName ? lowerFirst(remainder) : remainder);
+  return { text, includesLabel: false };
 }
 
 function opportunityReason(
   opp: BriefOpportunity,
   fallback: string,
-  kind: "connection" | "community",
 ): { text: string; includesLabel: boolean } {
-  const text = normalizeViewerGrammar(normalizeOpportunityText(opp.mainText || fallback));
+  const text = normalizeOpportunityText(opp.mainText || fallback);
   const firstSentence = text.split(/(?<=[.!?])\s+/)[0]?.trim() ?? text;
-  let reason = firstSentence;
-  let includesLabel = false;
-
-  if (!startsViewerCentered(reason)) {
-    const label = opportunityLabel(opp);
-    const visiblePrefix = kind === "community"
-      ? `You may be able to help ${opp.name}: `
-      : `You might like meeting ${opp.name}: `;
-    const markdownPrefix = kind === "community"
-      ? `You may be able to help ${label}: `
-      : `You might like meeting ${label}: `;
-    const clauseMaxChars = Math.max(80, OPPORTUNITY_REASON_MAX_CHARS - visiblePrefix.length);
-    const clause = truncateAtWord(
-      thirdPersonToTheyClause(reason, opp.name).replace(/[,.]$/, ""),
-      clauseMaxChars,
-    ).replace(/[,.]$/, "");
-    reason = `${markdownPrefix}${clause}`;
-    includesLabel = true;
-    return { text: reason, includesLabel };
-  }
-
-  return {
-    text: truncateAtWord(reason, OPPORTUNITY_REASON_MAX_CHARS).replace(/[,.]$/, ""),
-    includesLabel,
-  };
+  const reason = truncateAtWord(firstSentence, OPPORTUNITY_REASON_MAX_CHARS).replace(/[,.]$/, "");
+  return linkifyOpportunityName(reason, opp);
 }
 
 export function composeDailyBrief(context: DailyBriefContext): { body: string; opportunityIds: string[] } {
@@ -228,7 +145,7 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
     for (const opp of connectionOpportunities) {
       if (opp.opportunityId) opportunityIds.push(opp.opportunityId);
       const action = opp.acceptUrl ? ` [Say hi](${opp.acceptUrl}).` : " Say hi.";
-      const reason = opportunityReason(opp, "Relevant overlap with your current signals.", "connection");
+      const reason = opportunityReason(opp, "Relevant overlap with your current signals.");
       const lineBody = reason.includesLabel ? reason.text : `${opportunityLabel(opp)} — ${reason.text}`;
       lines.push(`- ${opportunityMarker(opp)}${lineBody}.${action}`);
     }
@@ -244,7 +161,7 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
     for (const opp of communityOpportunities) {
       if (opp.opportunityId) opportunityIds.push(opp.opportunityId);
       const action = opp.acceptUrl ? ` Know someone? [Make intro](${opp.acceptUrl}).` : " Know someone? Make intro.";
-      const reason = opportunityReason(opp, "They are looking for a relevant introduction.", "community");
+      const reason = opportunityReason(opp, "They are looking for a relevant introduction.");
       const lineBody = reason.includesLabel ? reason.text : `${opportunityLabel(opp)} — ${reason.text}`;
       lines.push(`- ${opportunityMarker(opp)}${lineBody}.${action}`);
     }

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -125,12 +125,12 @@ describe("composeDailyBrief", () => {
     expect(body).toContain("[Say hi](https://protocol.index.network/c/abc123)");
   });
 
-  test("renders common digest opportunity reasons as concise user-facing prose", () => {
+  test("renders digest-ready presenter summaries and linkifies the person name", () => {
     const opportunities = [
       {
         name: "Seref Yarar",
         opportunityId: "opp-seref",
-        mainText: "Seref has deep expertise in AI, especially in user profiling and modeling, with arXiv publications on these topics. His work aligns with your interest in advanced AI concepts.",
+        mainText: "You might like meeting Seref because his protocol work overlaps with your interest in advanced AI concepts.",
         profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
         acceptUrl: "https://protocol.index.network/c/seref",
         feedCategory: "connection",
@@ -139,7 +139,7 @@ describe("composeDailyBrief", () => {
       {
         name: "Seren Sandikci",
         opportunityId: "opp-seren",
-        mainText: "Seren is seeking feedback on protocol design and would benefit from your engineering expertise. You both share an interest in decentralized systems.",
+        mainText: "You might like meeting Seren because she wants protocol design feedback and your engineering expertise is directly relevant.",
         profileUrl: "https://index.network/u/22222222-2222-2222-2222-222222222222",
         acceptUrl: "https://protocol.index.network/c/seren",
         feedCategory: "connection",
@@ -148,7 +148,7 @@ describe("composeDailyBrief", () => {
       {
         name: "Helen Huang",
         opportunityId: "opp-helen",
-        mainText: "Helen is building a portable digital identity system through gameplay and is seeking research collaboration. Your background in back-end development could be a great fit.",
+        mainText: "You might like meeting Helen because her digital identity work overlaps with your backend development background.",
         profileUrl: "https://index.network/u/33333333-3333-3333-3333-333333333333",
         acceptUrl: "https://protocol.index.network/c/helen",
         feedCategory: "connection",
@@ -162,20 +162,20 @@ describe("composeDailyBrief", () => {
       connectionOpportunities: opportunities,
     });
 
-    // Seren has the highest confidence (91) — she should be the one picked
-    expect(body).toContain("You might like meeting [Seren Sandikci](https://index.network/u/22222222-2222-2222-2222-222222222222): they’re seeking feedback on protocol design and would benefit from your engineering expertise. [Say hi]");
+    // Seren has the highest confidence (91) — she should be the one picked.
+    expect(body).toContain("You might like meeting [Seren Sandikci](https://index.network/u/22222222-2222-2222-2222-222222222222) because she wants protocol design feedback and your engineering expertise is directly relevant. [Say hi]");
     expect(body).not.toContain("Seref");
     expect(body).not.toContain("Helen");
   });
 
-  test("rewrites third-person presenter summaries into warmer viewer-centered digest reasons", () => {
+  test("prefixes the linked name when presenter summary omits it", () => {
     const { body } = composeDailyBrief({
       ...baseContext,
       opportunities: [
         {
           name: "Paul McKellar",
           opportunityId: "opp-paul",
-          mainText: "Paul McKellar is deeply involved in online trust and AI orchestration, living fully in the AI mania.",
+          mainText: "Worth meeting because his online trust work overlaps with your AI orchestration interests.",
           profileUrl: "https://index.network/u/paul",
           acceptUrl: "https://protocol.index.network/c/paul",
           feedCategory: "connection",
@@ -185,7 +185,7 @@ describe("composeDailyBrief", () => {
         {
           name: "Paul McKellar",
           opportunityId: "opp-paul",
-          mainText: "Paul McKellar is deeply involved in online trust and AI orchestration, living fully in the AI mania.",
+          mainText: "Worth meeting because his online trust work overlaps with your AI orchestration interests.",
           profileUrl: "https://index.network/u/paul",
           acceptUrl: "https://protocol.index.network/c/paul",
           feedCategory: "connection",
@@ -193,121 +193,7 @@ describe("composeDailyBrief", () => {
       ],
     });
 
-    expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re deeply involved in online trust and AI orchestration");
-    expect(body).not.toContain("[Paul McKellar](https://index.network/u/paul) — Paul McKellar is deeply involved");
-  });
-
-  test("preserves full names when rewriting appositive presenter summaries", () => {
-    const { body } = composeDailyBrief({
-      ...baseContext,
-      opportunities: [
-        {
-          name: "Paul McKellar",
-          opportunityId: "opp-paul",
-          mainText: "Paul McKellar, an experienced founder and investor, is keenly interested in connecting with creative builders in tech and software.",
-          profileUrl: "https://index.network/u/paul",
-          acceptUrl: "https://protocol.index.network/c/paul",
-          feedCategory: "connection",
-        },
-      ],
-      connectionOpportunities: [
-        {
-          name: "Paul McKellar",
-          opportunityId: "opp-paul",
-          mainText: "Paul McKellar, an experienced founder and investor, is keenly interested in connecting with creative builders in tech and software.",
-          profileUrl: "https://index.network/u/paul",
-          acceptUrl: "https://protocol.index.network/c/paul",
-          feedCategory: "connection",
-        },
-      ],
-    });
-
-    expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re an experienced founder and investor who is keenly interested in connecting with creative builders");
-    expect(body).not.toContain("mcKellar");
-    expect(body).not.toContain(", is keenly interested");
-  });
-
-  test("rewrites appositive summaries with following verbs into grammatical clauses", () => {
-    const { body } = composeDailyBrief({
-      ...baseContext,
-      opportunities: [
-        {
-          name: "Paul McKellar",
-          opportunityId: "opp-paul",
-          mainText: "Paul McKellar, an experienced founder and angel investor, is actively seeking creative builders with skills in art, craft, design, tech, and software.",
-          profileUrl: "https://index.network/u/paul",
-          acceptUrl: "https://protocol.index.network/c/paul",
-          feedCategory: "connection",
-        },
-      ],
-      connectionOpportunities: [
-        {
-          name: "Paul McKellar",
-          opportunityId: "opp-paul",
-          mainText: "Paul McKellar, an experienced founder and angel investor, is actively seeking creative builders with skills in art, craft, design, tech, and software.",
-          profileUrl: "https://index.network/u/paul",
-          acceptUrl: "https://protocol.index.network/c/paul",
-          feedCategory: "connection",
-        },
-      ],
-    });
-
-    expect(body).toContain("You might like meeting [Paul McKellar](https://index.network/u/paul): they’re an experienced founder and angel investor who is actively seeking creative builders");
-    expect(body).not.toContain("they’re an experienced founder and angel investor, is actively seeking");
-  });
-
-  test("repairs fleet-observed digest grammar issues", () => {
-    const samples = [
-      {
-        name: "Amer Ameen",
-        text: "Amer Ameen is building 'Pluto' in Toronto as a 'fourth space,' directly inspired by Edge Esmeralda, and is developing co-living hubs.",
-        expected: "they’re building 'Pluto' in Toronto as a 'fourth space,' directly inspired by Edge Esmeralda, and are developing",
-        forbidden: "and is developing",
-      },
-      {
-        name: "Scott Brylow",
-        text: "Scott Brylow has extensive experience in cutting-edge hardware, including cameras for Mars missions, and is keenly interested in future tools.",
-        expected: "they have extensive experience in cutting-edge hardware, including cameras for Mars missions, and are keenly interested",
-        forbidden: "and is keenly interested",
-      },
-      {
-        name: "Scott Brylow",
-        text: "Scott Brylow is a retired engineer with deep experience in spaceflight imaging and early web/VR, and he's actively looking to connect with builders.",
-        expected: "they’re a retired engineer with deep experience in spaceflight imaging and early web/VR, and they’re actively looking",
-        forbidden: "and he's actively looking",
-      },
-      {
-        name: "Seref Yarar",
-        text: "co-founder of Index Network, is deeply involved in Web3, decentralized technology, and programmable discovery protocols.",
-        expected: "they’re the co-founder of Index Network who is deeply involved in Web3",
-        forbidden: "co-founder of Index Network, is deeply involved",
-      },
-      {
-        name: "Athena Aktipis",
-        text: "you is an AI researcher whose primary focus areas directly align with the discoverer's query.",
-        expected: "You are an AI researcher whose primary focus areas directly align with this connection",
-        forbidden: "you is",
-      },
-    ];
-
-    for (const sample of samples) {
-      const opp = {
-        name: sample.name,
-        opportunityId: `opp-${sample.name}`,
-        mainText: sample.text,
-        profileUrl: `https://index.network/u/${encodeURIComponent(sample.name)}`,
-        acceptUrl: "https://protocol.index.network/c/sample",
-        feedCategory: "connection",
-      };
-      const { body } = composeDailyBrief({
-        ...baseContext,
-        opportunities: [opp],
-        connectionOpportunities: [opp],
-      });
-      expect(body).toContain(sample.expected);
-      expect(body).not.toContain(sample.forbidden);
-      expect(body).not.toContain("discoverer's query");
-    }
+    expect(body).toContain("[Paul McKellar](https://index.network/u/paul) — Worth meeting because his online trust work overlaps with your AI orchestration interests. [Say hi]");
   });
 
   test("sorts opportunities by confidence descending before applying limit", () => {


### PR DESCRIPTION
## Summary
- Remove post-hoc grammar rewrites from the daily digest composer.
- Treat protocol presenter output as the digest-ready source of truth.
- Only linkify the person name or prefix the existing profile link when needed.
- Bump package version to 0.3.27.

## Verification
- bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts
