### PR TITLE
Stop truncating digest opportunity summaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -17,7 +17,6 @@ import { sanitizeDigestUrls } from "./validate-digest-urls";
 
 const CONNECTION_DIGEST_LIMIT = 1;
 const COMMUNITY_DIGEST_LIMIT = 1;
-const OPPORTUNITY_REASON_MAX_CHARS = 170;
 
 function argValue(args: string[], name: string): string | undefined {
   const idx = args.indexOf(name);
@@ -57,13 +56,6 @@ function firstName(name: string): string {
   return name.trim().split(/\s+/)[0] || name;
 }
 
-function truncateAtWord(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  const slice = text.slice(0, maxChars + 1);
-  const boundary = slice.lastIndexOf(" ");
-  return `${slice.slice(0, boundary > 80 ? boundary : maxChars).trimEnd()}…`;
-}
-
 function linkifyOpportunityName(text: string, opp: BriefOpportunity): { text: string; includesLabel: boolean } {
   if (!opp.profileUrl) return { text, includesLabel: false };
 
@@ -88,7 +80,7 @@ function opportunityReason(
 ): { text: string; includesLabel: boolean } {
   const text = normalizeOpportunityText(opp.mainText || fallback);
   const firstSentence = text.split(/(?<=[.!?])\s+/)[0]?.trim() ?? text;
-  const reason = truncateAtWord(firstSentence, OPPORTUNITY_REASON_MAX_CHARS).replace(/[,.]$/, "");
+  const reason = firstSentence.replace(/[,.]$/, "");
   return linkifyOpportunityName(reason, opp);
 }
 

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -168,6 +168,36 @@ describe("composeDailyBrief", () => {
     expect(body).not.toContain("Helen");
   });
 
+  test("does not truncate presenter-provided digest summaries", () => {
+    const longSummary = "You might like meeting Paul because his online trust work overlaps with your AI orchestration interests and his builder-investor background could make for a useful conversation.";
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      opportunities: [
+        {
+          name: "Paul McKellar",
+          opportunityId: "opp-paul",
+          mainText: longSummary,
+          profileUrl: "https://index.network/u/paul",
+          acceptUrl: "https://protocol.index.network/c/paul",
+          feedCategory: "connection",
+        },
+      ],
+      connectionOpportunities: [
+        {
+          name: "Paul McKellar",
+          opportunityId: "opp-paul",
+          mainText: longSummary,
+          profileUrl: "https://index.network/u/paul",
+          acceptUrl: "https://protocol.index.network/c/paul",
+          feedCategory: "connection",
+        },
+      ],
+    });
+
+    expect(body).toContain("could make for a useful conversation. [Say hi]");
+    expect(body).not.toContain("…");
+  });
+
   test("prefixes the linked name when presenter summary omits it", () => {
     const { body } = composeDailyBrief({
       ...baseContext,


### PR DESCRIPTION
## Summary
- Remove AgentVillage ellipsis truncation for presenter-provided opportunity digest summaries.
- Keep only linkification/prefixing; length control now belongs to the protocol presenter contract.
- Bump package version to 0.3.28.

## Verification
- bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts
