### PR TITLE
chore: scope Copilot review of skill/prose files to substantive issues

### DIFF
--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: "skills/**"
+---
+
+# Reviewing skill files
+
+Files under `skills/**` are **agent instructions** — Markdown prose (and a few helper scripts) that an LLM agent reads at runtime to drive a flow. They are not application source code, and they are tuned by prompt engineering, not by tests or types. Review them as operational instructions for a model, not as code.
+
+## Raise comments only for substantive issues
+
+- **Correctness of the described flow** — wrong tool name or arguments, a step that contradicts an earlier step, a branch that can't be reached, or guidance that would make the agent call a tool at the wrong time (e.g. ignoring a stated turn boundary or polling contract).
+- **Safety and policy** — privacy/consent gating, anti-fabrication rules (never invent handles, URLs, names, or facts; use values verbatim from a verifiable source), and anything that could route a user's data or an introduction to the wrong person.
+- **Cross-section consistency** — two parts of the same file (or sibling skill files) that disagree on the same rule or example list.
+
+## Do not raise
+
+- Stylistic or wording preferences, tone, or "this could be phrased more precisely."
+- Marginal edge cases that don't change the agent's actual behavior, or hypothetical placeholder/formatting concerns in example prose the agent composes naturally.
+- Points already covered elsewhere in the same file, or ones a prior review round already resolved.
+- Suggestions that simply add more words; prose precision is asymptotic, so prefer fewer, higher-signal comments over exhaustive rewordings.
+
+If a change is correct, safe, and internally consistent, approve it. A clean review with no comments is the expected outcome for a sound skill edit.


### PR DESCRIPTION
Adds a path-scoped Copilot custom-instructions file (`.github/instructions/skills.instructions.md`, `applyTo: skills/**`) so Copilot reviews of agent-instruction prose focus on correctness, safety, and cross-section consistency — and stop generating open-ended stylistic/precision rewordings.

## Why
Skill files under `skills/**` are agent instructions (Markdown prose), not code. With no test/type bound on "correct," Copilot's per-push re-review surfaces a fresh subset of phrasing nits each round and doesn't converge — the recent IND-350 onboarding-gate PR (#76) took 7 rounds, of which rounds 3–7 were diminishing-returns rewordings of the same line. Copilot's own review on that PR suggested adding custom instructions.

## Scope
- `applyTo: skills/**` only — review of actual TypeScript/code elsewhere in the repo is unaffected.
- Tells Copilot to raise: wrong tool calls/arguments, contradictory or unreachable steps, broken turn-boundary/polling contracts, privacy/consent/anti-fabrication issues, and cross-section inconsistencies.
- Tells Copilot not to raise: stylistic/wording preferences, behavior-neutral edge cases, already-covered/already-resolved points, or comments that just add words. A clean no-comment review is the expected outcome for a sound skill edit.