### PR TITLE
fix(edge-esmeralda): fail closed on staging/send script error

### DIFF
--- a/skills/edge-esmeralda/prompts/prepare.md
+++ b/skills/edge-esmeralda/prompts/prepare.md
@@ -29,11 +29,14 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 
    The script resolves the America/Los_Angeles date, builds structured context, composes the markdown body, runs the URL guard, creates the Kanban task with argv-safe `--body`, blocks it for review, and records `prepared.taskId` in `memory/heartbeat-state.json`. Its JSON stdout is for diagnostics only; do not expose it.
 
+   If the script exits with a non-zero code, end your turn immediately with the host-specific no-reply marker. Do not diagnose the failure, retry the script, or attempt alternative staging paths. One attempt only.
+
 3. **Deliver nothing.** End your turn with the host-specific no-reply marker.
 
 # Hard rules
 - Never invent announcements, events, people, venues, times, tracks, or action URLs.
 - Do not compose or stage the Kanban card manually; `stage-daily-brief.ts` is the only allowed staging path.
+- One attempt at the staging script. If it fails, end immediately with the no-reply marker — no retries, no diagnosis, no alternative paths.
 - Always stage the brief **blocked** (held for review) and record its `taskId`; it ships only if a human unblocks (approves) it before the send pass. Never assign it or move it to **Ready**.
 - Calendar failures must not block launch: ship people-only plus the one-line calendar pointer, or the pointer-only fallback if there is nothing else.
 - Never confirm delivery here. Never write `deliveredToday` here.

--- a/skills/edge-esmeralda/prompts/send.md
+++ b/skills/edge-esmeralda/prompts/send.md
@@ -14,6 +14,8 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
 
    Do not write Python, shell pipelines, or replacement delivery logic. The script resolves today's America/Los_Angeles date, reads `memory/heartbeat-state.json`, checks the Kanban approval gate, writes `memory/digest-outgoing.md`, extracts digest opportunity markers, updates delivery state, marks the task complete, strips unsafe URLs/internal metadata, and prints either `[SILENT]` or one JSON object.
 
+   If the script exits with a non-zero code, end your turn immediately with `[SILENT]`. Do not diagnose, retry, or attempt alternatives. One attempt only.
+
 2. **If stdout is exactly `[SILENT]`, end your turn with exactly `[SILENT]`.** Do not add commentary and do not try a fallback.
 
 3. **If stdout is JSON, parse it.** It has this shape:
@@ -29,6 +31,7 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
 # Hard rules
 - The Kanban task body is the source of truth. Never regenerate the brief in this send pass.
 - Never reimplement the send flow in generated code. Always call `bun skills/index-network/scripts/send-daily-brief.ts` exactly once.
+- One attempt at the send script. If it fails, end immediately with `[SILENT]` — no retries, no diagnosis, no alternative paths.
 - Deliver only a brief a human has approved by unblocking it (status `ready` or `todo`, depending on Hermes version). A still-`blocked` task means no approval yet — stay silent; the next prepare pass can try again.
 - Confirm delivery only for opportunity ids returned by the deterministic script.
 - Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in the reply.


### PR DESCRIPTION
## Problem

Two related incidents observed on 2026-06-07/08:

1. **Looping crons** — 35 tenants, 63 cron runs with ≥40 tool iterations; 9 hit the ~90 ceiling and never terminated naturally.
2. **Retry storms** — 60 tenants fired a daily cron ≥10×/day (tesmaneewong: 288× on 06-07, 95× already on 06-08, 500-session cap hit).

Both trace to the same root cause: when `bun stage-daily-brief.ts` or `bun send-daily-brief.ts` exits non-zero, neither `prepare.md` nor `send.md` instructs the agent to stop. The agent diagnoses the failure and retries the step in a loop until the ~90 tool-iteration ceiling kicks in. Hermes then kills the session and reschedules the job — which also loops — producing the observed fire storms.

## Fix

Add an explicit fail-closed instruction after each script invocation step, and a matching hard rule as a second guard:

- **Non-zero exit → emit the no-reply marker immediately.**
- **One attempt only** — no diagnosis, no retries, no alternative paths.

This applies to both the `prepare` pass (`stage-daily-brief.ts`) and the `send` pass (`send-daily-brief.ts`).

## After merge

Run `reconcile_digest_crons.ts` against the fleet (or trigger via `/update-all`) to push the updated prompt bodies to all resident cron jobs.

Note: tesmaneewong's `Event Reminder Worker` (`*/5 * * * *`, HTTP 402 failures) needs a separate admin action to pause the job and top up OpenRouter credits — that prompt is not part of this PR.