### PR TITLE
fix(workspace): halt fabrication when a user-referenced term can't be found

### DIFF
--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -110,6 +110,7 @@ The morning brief is delivered at 08:00 host-local. It runs as two background di
 
 - No raw JSON, internal IDs, or internal vocabulary in user-facing replies.
 - Never invent or guess events, tracks, week themes, or attendee names. State only what you just read from a skill or a live lookup; if you cannot reach the source, say so plainly.
+- Never label or characterize the user's projects, missions, or signals with a term you did not find verbatim in a tool result or memory file. If the user asks what a term means and your tools return nothing, say "I don't see that anywhere in what I have about you" — do not synthesize from adjacent keywords.
 - No importing EdgeOS/directory profile data or running public profile lookup during onboarding without recorded consent.
 - No accepting received opportunities without explicit approval in this conversation.
 - No link strips or markdown link tables in chat — URL preservation rules above.

--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -18,6 +18,7 @@ This rule extends to your own workspace files. Never mention `AGENTS.md`, `SOUL.
 - **Quiet by default.** Skipping is the rule, surfacing is the exception. Anything you skip on the heartbeat lands in the next morning's digest. Silence is correct routing, not a failure mode.
 - **Earn the interruption.** Surface what only this user can act on. A candidate qualifies only when the reason you'd give for surfacing them is specific to *this* user's situation — generic framings ("interesting profile", "might be useful", "works in a related space") do not earn the interruption.
 - **Evidence over assertion.** Never fabricate. If you don't have it, call the appropriate tool. If a tool fails, say so plainly — don't paper over it.
+- **Unknown terms: admit it, don't synthesize.** When the user asks about a specific term — a project name, label, or phrase — and your tools return nothing for it, say plainly "I don't see any reference to '[term]' in what I have about you" and ask where they encountered it. Do *not* synthesize an explanation from related data. Finding "meditation" in a user's premises does not mean you know what "Meditation Artifacts" is. Partial matches are not evidence. Confident-sounding fabrications based on adjacent keywords are the most harmful failure mode.
 - **Be resourceful before asking.** Read the file. Check the context. Call the tool. *Then* ask the user if you're stuck.
 
 ## Boundaries


### PR DESCRIPTION
## Summary

- Adds a new **SOUL.md** core truth — *Unknown terms: admit it, don't synthesize* — that names the specific failure mode: agent can't find a term after exhausting tools, gets nudged after returning empty, then confabulates a confident explanation from adjacent keywords.
- Adds a matching **AGENTS.md** Red Line: never label/characterize the user's projects or signals with a term not found verbatim in a tool result or memory file. Unknown term → "I don't see that anywhere in what I have about you" → ask where they encountered it.

## Root cause (Timour's feedback)

ogreenius asked "What's 'Meditation Artifacts'??" after seeing it referenced somewhere. The Curio agent ran 15+ tool calls, found nothing, returned empty (got a nudge-to-continue), and then fabricated: invented "Meditation Artifacts" as the user's project/mission by synthesizing from their meditation-related premises (`meditation literacy`, `cognitive equity`). Timour confirmed the term is completely made up.

The existing `"Evidence over assertion. Never fabricate."` principle was too abstract — it didn't prevent the model from reasoning *"I found 'meditation' in their premises, therefore 'Meditation Artifacts' must be their project."* The new rules call out this exact pattern by name.

## Test plan
- [ ] Deploy and verify Curio responds "I don't see any reference to [X] in what I have about you" when asked about an unknown term, rather than synthesizing from partial matches.