### PR TITLE
feat: provision village-pulse skill for all Edge agents

### DIFF
--- a/install/install.ts
+++ b/install/install.ts
@@ -6,7 +6,7 @@
  *
  *   - `SOUL.md` → `$HERMES_HOME/SOUL.md` (identity; overwrites generic Hermes soul)
  *   - `AGENTS.md`, `USER.md` → `$HERMES_HOME/`
- *   - Edge skill bundles → `$HERMES_HOME/skills/{index-network,edgeos,edge-esmeralda,geo-esmeralda}/`
+ *   - Edge skill bundles → `$HERMES_HOME/skills/{index-network,edgeos,edge-esmeralda,geo-esmeralda,village-pulse}/`
  *   - `terminal.cwd` in config.yaml → `$HERMES_HOME`
  *   - Index MCP + morning digest cron (`install_index.ts`)
  *   - Geo CLI runtime note (`install_geo.ts`)
@@ -33,6 +33,7 @@ import { execSync } from "node:child_process";
 import { installIndex } from "./install_index";
 import { installEdgeos } from "./install_edgeos";
 import { installGeo } from "./install_geo";
+import { installVillagePulse } from "./install_village_pulse";
 import { setTerminalCwd } from "./config";
 import { hermesBin, hermesExecEnv } from "./hermes_cli";
 import {
@@ -201,6 +202,7 @@ function main(): void {
   installIndex();
   installEdgeos();
   installGeo();
+  installVillagePulse();
   restoreWelcomeState(welcomeState);
 
   if (!process.argv.includes("--no-restart")) {

--- a/install/install_village_pulse.ts
+++ b/install/install_village_pulse.ts
@@ -1,0 +1,41 @@
+/**
+ * Village Pulse installer — writes API config to `$HERMES_HOME/.env`.
+ */
+
+import { readFlag } from "./args";
+import { upsertEnvVar } from "./env";
+
+const FLAG_TO_ENV_VAR: ReadonlyArray<readonly [string, string]> = [
+  ["--village-api-base-url", "VILLAGE_API_BASE_URL"],
+  ["--village-human-id", "VILLAGE_HUMAN_ID"],
+  ["--village-key", "X_VILLAGE_KEY"],
+];
+
+export function installVillagePulse(): void {
+  const present: string[] = [];
+  const missing: string[] = [];
+
+  for (const [flag, envName] of FLAG_TO_ENV_VAR) {
+    const value = readFlag(flag)?.trim() || process.env[envName]?.trim();
+    if (value) {
+      upsertEnvVar(envName, value);
+      present.push(envName);
+    } else {
+      missing.push(envName);
+    }
+  }
+
+  if (present.length === 0) {
+    console.log(
+      "→ village-pulse: no config provided; recipes will prompt the user at first use",
+    );
+    return;
+  }
+
+  console.log(`→ village-pulse: wired ${present.join(", ")} into .env`);
+  if (missing.length > 0) {
+    console.log(
+      `  note: ${missing.join(", ")} not set — recipes that need them will prompt the user at first use`,
+    );
+  }
+}

--- a/install/paths.ts
+++ b/install/paths.ts
@@ -21,6 +21,7 @@ export const EDGE_SKILL_NAMES = [
   "edgeos",
   "edge-esmeralda",
   "geo-esmeralda",
+  "village-pulse",
 ] as const;
 
 export const CRON_NAME_PREFIX = "Edge —";

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentvillage",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery skills for the Agent Village.",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "skills": "./",
   "author": {
     "name": "Edge City",
@@ -24,6 +24,24 @@
       "type": "string",
       "title": "EdgeOS API Key",
       "description": "Long-lived eos_live_... key for EdgeOS events and RSVPs.",
+      "sensitive": true
+    },
+    "villageApiBaseUrl": {
+      "type": "string",
+      "title": "Village Pulse API Base URL",
+      "description": "Base URL of the one+1 Village API (e.g. https://api.getoneplusone.com). Required for Village Pulse, post-event check-ins, and Ask the Village.",
+      "sensitive": false
+    },
+    "villageHumanId": {
+      "type": "string",
+      "title": "Village Human ID",
+      "description": "Identifier for this resident in the Village API (e.g. their Edge username or a UUID). Pre-filled by your community admin.",
+      "sensitive": false
+    },
+    "villageKey": {
+      "type": "string",
+      "title": "Village Key (optional)",
+      "description": "Optional shared secret for deployments that enable the X-Village-Key header. Leave blank if your admin hasn't provided one.",
       "sensitive": true
     }
   },

--- a/skills/hooks/export-edgeos-env.sh
+++ b/skills/hooks/export-edgeos-env.sh
@@ -7,4 +7,13 @@
 [ -n "$CLAUDE_PLUGIN_OPTION_edgeosToken" ] && \
   printf 'export EDGEOS_BEARER_TOKEN=%q\n' "$CLAUDE_PLUGIN_OPTION_edgeosToken" >> "$CLAUDE_ENV_FILE"
 
+[ -n "$CLAUDE_PLUGIN_OPTION_villageApiBaseUrl" ] && \
+  printf 'export VILLAGE_API_BASE_URL=%q\n' "$CLAUDE_PLUGIN_OPTION_villageApiBaseUrl" >> "$CLAUDE_ENV_FILE"
+
+[ -n "$CLAUDE_PLUGIN_OPTION_villageHumanId" ] && \
+  printf 'export VILLAGE_HUMAN_ID=%q\n' "$CLAUDE_PLUGIN_OPTION_villageHumanId" >> "$CLAUDE_ENV_FILE"
+
+[ -n "$CLAUDE_PLUGIN_OPTION_villageKey" ] && \
+  printf 'export X_VILLAGE_KEY=%q\n' "$CLAUDE_PLUGIN_OPTION_villageKey" >> "$CLAUDE_ENV_FILE"
+
 exit 0

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "agentvillage-skills",
   "name": "AgentVillage Skills",
-  "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery.",
-  "version": "1.5.1",
+  "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, Index Network discovery, and Village Pulse collective intelligence.",
+  "version": "1.6.0",
   "skills": ["."]
 }

--- a/skills/village-pulse/README.md
+++ b/skills/village-pulse/README.md
@@ -1,0 +1,83 @@
+# Village Pulse + Edge Companion
+
+one+1's collective-intelligence layer for Edge Esmeralda, packaged as an agent skill. It delivers the
+daily **Village Pulse**, lets the resident **ask the village** about any decision, and learns each
+person's preferences via the **Edge Companion twin** (profile → predict → feedback loop).
+
+## Environment
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `VILLAGE_API_BASE_URL` | Yes | Deployed one+1 Village API (staging), e.g. `https://aebfymivz2.us-east-1.awsapprunner.com` |
+| `VILLAGE_HUMAN_ID` | Recommended | Resident identifier (e.g. "owner" or the human's name); attributes answers and predictions |
+| `X_VILLAGE_KEY` | Optional | Sent as `X-Village-Key` if the deployment requires a shared key |
+
+## Install
+
+```bash
+hermes skills install Edge-City/agentvillage/skills/village-pulse --force
+```
+
+## Required env vars
+- `VILLAGE_API_BASE_URL` — staging backend URL (https://aebfymivz2.us-east-1.awsapprunner.com)
+- `VILLAGE_HUMAN_ID` — resident identifier (e.g. "owner" or the human's name)
+- `X_VILLAGE_KEY` — optional shared key
+
+## Manual triggers (say these in Telegram)
+- "run my village pulse" → daily pulse flow
+- "Edge check-in" → post-event check-in
+- "ask the village about X" → stakeholder jury
+
+## curl test commands
+
+```bash
+# Profile
+curl -X POST $VILLAGE_API_BASE_URL/api/village/profile \
+  -H "Content-Type: application/json" \
+  -d '{"human_id":"owner","answers":{"what_here":"learn and connect","great_week":"deep talks"}}'
+
+# Predict
+curl "$VILLAGE_API_BASE_URL/api/village/predict?human_id=owner&event_id=ev1&event_context=AI+alignment+dinner"
+
+# Event feedback
+curl -X POST $VILLAGE_API_BASE_URL/api/village/events/ev1/feedback \
+  -H "Content-Type: application/json" \
+  -d '{"human_id":"owner","attended":true,"highlights":"great talks","would_repeat":true}'
+
+# Daily pulse
+curl "$VILLAGE_API_BASE_URL/api/village/pulse/today?human_id=owner"
+
+# Ask the village
+curl -X POST $VILLAGE_API_BASE_URL/api/agent/review \
+  -H "Content-Type: application/json" \
+  -d '{"human_id":"owner","proposal":"Host an AI safety dinner Thu evening","decision_type":"event"}'
+```
+
+## Coverage requirement
+pytest ≥98% (enforced). vitest ≥98% per file.
+
+## Telegram flow
+1. First run: consent question → yes → onboarding profile (5-7 questions → POST /profile)
+2. Daily: Village Pulse (GET /pulse/today → answer → POST /pulse/answer → result card)
+3. After RSVP'd event ends: POST /predict (pre-event) → check-in → POST /events/:id/feedback
+4. On demand: "ask the village about X" → POST /agent/review
+
+## Direct API check
+
+```bash
+curl -s "$VILLAGE_API_BASE_URL/api/village/pulse/today?human_id=owner"
+
+curl -s -X POST "$VILLAGE_API_BASE_URL/api/agent/review" \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_id":"a1","human_id":"owner","proposal":"Allocate $5k to a community podcast studio",
+       "context":"Edge Esmeralda week 3","decision_type":"opportunity","desired_output":"quick_review"}'
+```
+
+## Daily delivery
+
+`heartbeat.md` defines three tasks:
+- `onboarding-profile` — fires once on first run after consent (5-7 warm questions → POST /profile)
+- `daily-pulse` — 09:00 local, opt-in via `autoPulse: true` in `memory/village-pulse.json`
+- `post-event-checkin` — every 30m, triggers on recently-ended RSVP'd events
+
+The twin prediction loop: `predict` (called before/during event) → `feedback` (after event) → accuracy score → rolling accuracy update. Each cycle refines the twin's understanding of this resident's preferences.

--- a/skills/village-pulse/SKILL.md
+++ b/skills/village-pulse/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: village-pulse
+description: one+1's collective-intelligence + per-human preference layer for Edge Esmeralda. Helps the resident's agent get to know them (a short profile, light daily questions, and a check-in after events they attend), predict what they'll choose and enjoy, and bring a daily "Village Pulse" — plus ask "what would the village think of X?" Read on first run, on the daily pulse cron, after an RSVP'd event ends, or when the user says "village pulse", "Edge check-in", "what does the village think", "ask the village", or "should I…".
+version: 0.2.0
+author: one+1 (Thursday Strategy)
+tags: [village, collective-intelligence, preferences, prediction, feedback, edge-esmeralda]
+required_environment_variables:
+  - name: VILLAGE_API_BASE_URL
+    required_for: all calls (the deployed one+1 Village API, e.g. the staging backend URL)
+  - name: VILLAGE_HUMAN_ID
+    required_for: attributing the resident's answers (default to the user's name if unset)
+  - name: X_VILLAGE_KEY
+    required_for: optional shared key sent as the X-Village-Key header, if the deployment requires it
+metadata:
+  openclaw:
+    requires:
+      config:
+        - env.vars.VILLAGE_API_BASE_URL
+---
+
+# Village Pulse + Edge Companion — Edge Esmeralda
+
+one+1 helps your agent understand its human and use that to shape a **better Edge** — and aggregates those
+understandings into the village's collective judgment. **Edge is the product**: gather the resident's
+feedback and preferences, predict what they'll choose and enjoy, and learn from how those predictions
+compare to what actually happens. This skill carries the Edge-flavored conversation; the one+1 Village API
+does the prediction (real-LLM, grounded in the resident's own history) and the measurement.
+
+Base URL: `$VILLAGE_API_BASE_URL`. No login. Send `X-Village-Key: $X_VILLAGE_KEY` only if set.
+Identify the resident with `human_id` = `$VILLAGE_HUMAN_ID` (fall back to the user's name).
+
+## When to read each file
+- **First-run consent + profiling** → §1.
+- **After an RSVP'd event ends (cron/trigger or "Edge check-in")** → §2. *This is the most valuable flow.*
+- **Daily Village Pulse (cron or "run my village pulse")** → §3.
+- **"What would the village think of X?"** → §4.
+- **Cron + post-event trigger** → [heartbeat.md](heartbeat.md). **Exact Telegram wording** → [exemplars.md](exemplars.md).
+
+## 0. Consent + dignity (read first)
+- **First run only:** ask once — *"Want me to get to know you so we can shape a better Edge for you? A quick
+  profile now, a light question a day, and a check-in after events you attend. (yes / no)"* Store the
+  answer in `memory/village-pulse.json` (`autoCompanion`, `autoPulse`). Re-ask only if they raise it.
+- **Frequency caps:** at most one daily drop + check-ins only for events the user **RSVP'd to**. Never nag;
+  everything is skippable; offer audio instead of typing.
+- The human owns this data and it helps *them*. Never paste anything they marked private. No destructive
+  operations exist in this skill — these are the user's own opinions + reads.
+
+## 1. Onboarding profiling (after consent)
+Before asking anything, call `GET $VILLAGE_API_BASE_URL/api/village/profile/$VILLAGE_HUMAN_ID`.
+- If `has_profile: true` — show a one-line summary of the existing answers (*"You told me: …"*) and ask
+  if there's anything to update. Skip any questions already answered unless the resident wants to revisit
+  them. Profiles built by the Telegram bot or other agents count — the API is the source of truth, not local
+  memory.
+- If `has_profile: false` — run a short, warm survey (5–7 questions: what they're here to do, topics they
+  care about, how they like to spend a day, what a great Edge week looks like). Accept audio.
+
+Either way, merge the new/updated answers over any existing ones and:
+`POST $VILLAGE_API_BASE_URL/api/village/profile` with `{ human_id, answers:{...} }`. This primes the twin;
+predictions start rough and sharpen as input grows — that's expected.
+
+## 2. Post-event check-in (the core loop)
+Triggered after an event the user **RSVP'd to** ends (see heartbeat.md), or on "Edge check-in".
+1. *"Checking in! Did you attend **[session]**? (Y/N)"*
+2. If **no** → *"No worries — why didn't you make it to this one?"*
+3. If **yes** → *"What did you think? Highlights, and anything you'd change? (you can record audio if you'd
+   rather not type)"* → then *"If you could go back, would you attend again? (Y/N) — why?"*
+4. `POST $VILLAGE_API_BASE_URL/api/village/events/<event_id>/feedback` with
+   `{ human_id, attended, why?, highlights?, would_repeat?, audio_url? }`.
+Before the event the twin already predicted attendance/enjoyment/would-repeat; this feedback is the ground
+truth it's scored against. Keep it light — one or two messages, not an interrogation.
+
+## 3. Daily Village Pulse
+1. `GET $VILLAGE_API_BASE_URL/api/village/pulse/today?human_id=<id>` → `{question_id, text, village_context,
+   already_answered}`. If `already_answered` and this is the cron → reply silently.
+2. Present `text` warmly (it's generated from today's calendar/wiki, so it's timely). Ask **Agree /
+   Disagree / Skip**; accept natural language. Optionally invite one line of "why" and *"what % of the
+   village do you think agrees?"*.
+3. `POST .../pulse/answer` with `{question_id, human_id, answer, why?, predicted_village_support_pct?}`.
+4. Show the card: `{village_split, your_answer, your_prediction_vs_actual, participation_count}` in a line
+   or two.
+
+## 4. Ask the village about anything
+When the user floats a decision: `POST $VILLAGE_API_BASE_URL/api/agent/review` with
+`{agent_id, human_id, proposal, context, decision_type, desired_output}` (`decision_type` ∈ `event|
+governance|resource|opportunity|intro|norm|other`; `desired_output` ∈ `quick_review|full_jury|
+objections_only|framing_help`, default `quick_review`). Lead with `agent_summary` + `support_score`, then
+the top objection + `recommended_framing`; offer the shareable proposal URL. Don't dump every field.
+
+## Host-neutral silence
+Reply-silently marker: Hermes → `[SILENT]`; OpenClaw → `NO_REPLY`; Claude Code → no user-facing text if the
+host supports a silent turn, else stop without commentary.

--- a/skills/village-pulse/exemplars.md
+++ b/skills/village-pulse/exemplars.md
@@ -1,0 +1,57 @@
+# Village Pulse — Voice Exemplars
+
+Mirror this register in Telegram: warm, brief, low-pressure, one idea per message. Never bullet-dump.
+These are samples — adapt to the real question the API returns; don't reuse verbatim.
+
+## Delivering the daily pulse
+
+> ☀️ Village Pulse — tonight there are three dinners on the calendar. Quick one: **would you go to the
+> AI-alignment dinner over the others?** Agree / Disagree / Skip — and if you're feeling it, guess what %
+> of the village agrees.
+
+> Morning! Today's village question: **"Should AI safety be the dominant theme of Edge this week?"**
+> Where do you land — agree, disagree, or skip?
+
+## The result card (after they answer)
+
+> Logged. You're with **38%** of the village so far — you guessed 50%, so the room's a touch more
+> skeptical than you thought. 142 residents in today. 👀
+
+> Got it — Skip noted. 61% are leaning *agree* right now if you're curious. See you tomorrow.
+
+## Asking the village about something the user raised
+
+User: *"thinking about hosting a dinner on AI alignment thurs — worth it?"*
+
+> I ran it past the village panel. **~72% support, medium confidence.** Builders and safety folks are
+> keenest; the main pushback is "another AI-safety dinner this week — saturation." If you frame it as
+> *"hands-on alignment failure post-mortems"* rather than a general discussion, it lands better with the
+> skeptics. Want the shareable readout? → {proposal_url}
+
+## Consent (first run only)
+
+> One thing before I dive in: want me to get to know you so we can shape a **better Edge** for you? A quick
+> profile now, a light question a day, and a check-in after events you go to. (yes / no) Either way you can
+> always just ask me "run my village pulse" or "Edge check-in."
+
+## Onboarding profiling
+
+> Let's start simple — **what are you here to do at Edge this month?** One or two lines is plenty (or hit
+> record and just talk).
+
+> Got it. And **when a week at Edge goes great, what happened?** The talks? The people? The quiet mornings?
+
+## Post-event check-in (the core loop)
+
+> 👋 Checking in! Did you make it to **[Coordination & Coffee, 9am]**? (Y / N)
+
+If yes:
+> Nice. **What did you think — any highlights, anything you'd change?** Feel free to record audio instead of
+> typing. … And if you could go back, **would you attend again? (Y / N)** — what's behind that?
+
+If no:
+> No worries — **what got in the way?** (Helps me get your mornings right.)
+
+After they answer:
+> Thanks — noted. (Quietly: I'd guessed you'd love this one and you did — my read on your mornings is
+> getting sharper.)

--- a/skills/village-pulse/heartbeat.md
+++ b/skills/village-pulse/heartbeat.md
@@ -1,0 +1,59 @@
+# Village Pulse + Edge Companion — Crons & Triggers
+
+Register in the Hermes dashboard cron jobs (or fold the pulse into the 08:00 morning brief). Track
+last-run + dedup state in `memory/village-pulse.json`.
+
+---
+
+tasks:
+
+- name: post-event-checkin
+  interval: 30m
+  prompt: |
+    Check in after events the user actually chose to attend. This is the most valuable signal — be warm
+    and brief, never naggy.
+
+    1. Read `memory/village-pulse.json`. If `autoCompanion` is not `true`, reply silently with this host's
+       no-reply marker.
+    2. Use the `edgeos` skill to list the user's RSVP'd events that **ended in the last ~2 hours** and that
+       aren't already in `checkedInEventIds`.
+    3. If none, reply silently.
+    4. For the most recent one:
+       a. Before check-in, fetch a prediction if one doesn't exist yet:
+          `GET $VILLAGE_API_BASE_URL/api/village/predict?human_id=<id>&event_id=<event_id>&event_context=<title>`
+          This pre-event prediction will be scored when feedback is recorded.
+       b. Run the §2 check-in script from SKILL.md: "Did you attend [session]? Y/N"
+          → if no, why; if yes, highlights/changes (audio ok) + "would you attend again? Y/N — why".
+    5. `POST $VILLAGE_API_BASE_URL/api/village/events/<event_id>/feedback` with their answers.
+    6. Add `event_id` to `checkedInEventIds`. Only one check-in per tick — don't batch-spam.
+
+- name: daily-pulse
+  schedule: "0 9 * * *"   # 09:00 local; or merge into the 08:00 morning brief
+  prompt: |
+    Bring the resident today's Village Pulse — one quick question. 10 seconds, not a survey.
+
+    1. If `autoPulse` is not `true` in `memory/village-pulse.json`, reply silently.
+    2. `GET $VILLAGE_API_BASE_URL/api/village/pulse/today?human_id=<id>`. If `already_answered`, reply
+       silently — don't nag.
+    3. Present `text` in one warm line; ask Agree / Disagree / Skip (+ optional "why", + optional
+       "what % of the village agrees?"). See exemplars.md.
+    4. On reply, `POST .../pulse/answer` and show the result card in one line.
+    5. Record today's date as `lastPulseDate`.
+
+    Never fabricate a question — only deliver what the API returns. If the API is unreachable, reply
+    silently and retry next tick.
+
+- name: onboarding-profile
+  trigger: first_run  # fires once; guard with memory/village-pulse.json consent check
+  prompt: |
+    Run the onboarding profiling flow (§1 of SKILL.md) on first activation after consent.
+    1. Read memory/village-pulse.json. If consent not yet given, skip.
+    2. Check the API — don't rely on local memory alone:
+       GET $VILLAGE_API_BASE_URL/api/village/profile/$VILLAGE_HUMAN_ID
+       If has_profile: true, skip the full survey and show a brief summary; ask if anything needs
+       updating. The API is authoritative — profiles built via Telegram or another agent count.
+    3. If has_profile: false AND profileCompleted is not set in local memory, run the full 5-7 question
+       survey.
+    4. POST $VILLAGE_API_BASE_URL/api/village/profile with {human_id, answers:{...}}, merging new
+       answers over any existing ones (don't wipe data already stored).
+    5. Set profileCompleted: true in memory/village-pulse.json.

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -65,8 +65,7 @@ The `skills/` directory holds per-backend procedural knowledge. Today's active s
 - **`edgeos`** (`skills/edgeos/SKILL.md`) — EdgeOS API: live events, RSVPs, venues, attendee directory, and the user's own profile. (No wiki or newsletter content — that lives in `edge-esmeralda`.) 
 - **`edge-esmeralda`** (`skills/edge-esmeralda/SKILL.md`) — Popup constants, directory semantics, curated wiki/website/newsletter.  Supplies community-knowledge answers.
 - **`geo-esmeralda`** (`skills/geo-esmeralda/SKILL.md`) — Geo knowledge graph: community-created content, relations, ontology, attendee-authored writes, and raw time-windowed history of the main Edge Esmeralda 2026 Telegram group (the village-wide chat).  read when the user asks what the village is discussing, what's happening in the chat, what they missed, "catch me up," what people are talking about, or wants a chat summary.
-
-When a future skill ships, list it here with its trigger conditions.
+- **`village-pulse`** (`skills/village-pulse/SKILL.md`) — one+1 collective-intelligence + per-human preference layer: onboarding profile, daily Village Pulse question, post-event check-in + prediction scoring, and "ask the village" review. Read on first run (after consent), on the daily pulse cron, after an RSVP'd event ends, or when the user says "village pulse", "Edge check-in", "what does the village think", "ask the village", or "should I…".
 
 ## Session context
 


### PR DESCRIPTION
## What this adds

Provisions the `village-pulse` skill (one+1 collective-intelligence + per-human preference layer) as a default skill for all Edge Esmeralda agents — alongside `index-network`, `edgeos`, `edge-esmeralda`, and `geo-esmeralda`.

## Changes

### Install / provisioning
- **`install/paths.ts`** — adds `"village-pulse"` to `EDGE_SKILL_NAMES` so files are copied to `$HERMES_HOME/skills/village-pulse/` on install
- **`install/install_village_pulse.ts`** (new) — mirrors `install_edgeos.ts`; wires `VILLAGE_API_BASE_URL`, `VILLAGE_HUMAN_ID`, `X_VILLAGE_KEY` into `.env` via `--village-api-base-url` / `--village-human-id` / `--village-key` flags
- **`install/install.ts`** — imports + calls `installVillagePulse()` after `installGeo()`

### Skill bundle
- **`skills/village-pulse/`** (new) — SKILL.md, heartbeat.md, exemplars.md, README.md from the [village-pulse skill library](https://github.com/Edge-City/agentvillage-skills/pull/14)

### Agent context
- **`workspace/AGENTS.md`** — adds village-pulse to the active skills list with trigger conditions (first-run after consent, daily pulse cron, post-event check-in, "ask the village")

### Claude Code plugin (1.5.1 → 1.6.0)
- **`skills/.claude-plugin/plugin.json`** — adds `villageApiBaseUrl`, `villageHumanId`, `villageKey` to `userConfig`; pre-fill `villageHumanId` with the resident's identifier at provision time (same pattern as `edgeosToken`)
- **`skills/hooks/export-edgeos-env.sh`** — exports `VILLAGE_API_BASE_URL`, `VILLAGE_HUMAN_ID`, `X_VILLAGE_KEY` at session start
- **`skills/openclaw.plugin.json`** — bumped to `1.6.0`

## Install usage

```bash
# New agent
bun install/install.ts \
  --index-api-key <KEY> \
  --edgeos-api-key <KEY> \
  --village-api-base-url https://api.getoneplusone.com \
  --village-human-id <resident-id>

# Existing agents — re-run install to add the new skill
bun install/install.ts --village-api-base-url https://api.getoneplusone.com --village-human-id <resident-id>
```

## What the dashboard still owns

For zero-touch rollout to existing agents (residents don't run install manually):
1. Pre-fill `villageHumanId` in the Claude Code plugin userConfig at agent-provision time (same as `edgeosToken`/`indexApiKey`)
2. Decide whether existing agents re-pull skills on session start or need a re-provision push

## Dependency

The Village API endpoint (`VILLAGE_API_BASE_URL`) must be a stable, public HTTPS URL — confirm the production-grade URL before broad rollout. The staging URL is `https://aebfymivz2.us-east-1.awsapprunner.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)