### PR TITLE
feat(agentvillage): daily brief question injection via read_pending_questions MCP tool

### DIFF
--- a/skills/edge-esmeralda/prompts/prepare.md
+++ b/skills/edge-esmeralda/prompts/prepare.md
@@ -14,6 +14,7 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 - Edge Esmeralda popup id for EdgeOS calendar calls: `43746fd0-bce2-472b-93e4-a438177b2dff`.
 - Build deterministic non-prose context with `skills/index-network/scripts/build-daily-brief-context.ts`. The script fetches admin announcements from the AgentVillage control plane, pulls the user's RSVPs for today (`rsvped_only=true`), pulls today's EdgeOS calendar and selects highlighted plus interest-fill events (RSVPed events are de-duplicated out of that discovery list by the composer), calls the Index MCP server directly for opportunities, and writes structured JSON. All event times are rendered from each event's `timePacific` value (America/Los_Angeles). Do not manually re-fetch announcements, RSVPs, calendar, or opportunities outside this script.
 - Index people sections are fetched directly by the script from the Index MCP server using `INDEX_API_KEY` — you never need to call `list_opportunities` or write `memory/digest-opportunities.txt` yourself. Use `profileUrl` and `acceptUrl` exactly as provided in the script's output — never construct, shorten, or modify them.
+- The optional closing question ("**One for you:**") is fetched by the same script from the Index MCP server's `read_pending_questions` tool. The script renders at most one question, only when the digest has verified content, and skips any question delivered within the last 3 days (tracked under `questionDelivery` in `memory/heartbeat-state.json`). Render the prompt exactly as the script provides it; never invent or rephrase questions.
 - Organizer announcements come only from the context builder's `announcements` array. Do not fill this section from chat, stale wiki/newsletter copy, generic community facts, or ordinary attendee chatter.
 - For user interests, rely on the context builder's `diagnostics.interestTags` and selected `interestEvents`. Do not import new private EdgeOS directory/profile data here.
 
@@ -25,7 +26,7 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
    bun skills/index-network/scripts/stage-daily-brief.ts --state-file memory/heartbeat-state.json --context-out memory/daily-brief-context.json
    ```
 
-   The script resolves the America/Los_Angeles date, fetches opportunities from the Index MCP server, builds structured context, composes the markdown body, runs the URL guard, creates the Kanban task with argv-safe `--body`, blocks it for review, and records `prepared.taskId` in `memory/heartbeat-state.json`. Its JSON stdout is for diagnostics only; do not expose it.
+   The script resolves the America/Los_Angeles date, fetches opportunities and pending questions from the Index MCP server, builds structured context, composes the markdown body (including the optional closing question postscript), runs the URL guard, creates the Kanban task with argv-safe `--body`, blocks it for review, and records `prepared.taskId` in `memory/heartbeat-state.json`. Its JSON stdout is for diagnostics only; do not expose it.
 
    If the script exits with a non-zero code, end your turn immediately with the host-specific no-reply marker. Do not diagnose the failure, retry the script, or attempt alternative staging paths. One attempt only.
 
@@ -37,6 +38,7 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 - One attempt at the staging script. If it fails, end immediately with the no-reply marker — no retries, no diagnosis, no alternative paths.
 - Always stage the brief **blocked** (held for review) and record its `taskId`; it ships only if a human unblocks (approves) it before the send pass. Never assign it or move it to **Ready**.
 - Calendar failures must not block launch: ship people-only plus the one-line calendar pointer, or the pointer-only fallback if there is nothing else.
+- The question postscript is sanctioned: when the digest has verified content and a pending question exists, the body ends with `---` followed by a single `**One for you:**` question after the sign-off line. The pointer-only fallback digest never carries a question. The hidden `digest-question` marker beside it is delivery bookkeeping — like opportunity markers, it is stripped before the user sees the brief; do not remove or edit it.
 - Never confirm delivery here. Never write `deliveredToday` here.
 - The staged body is what the user receives in the morning after internal digest markers are stripped — make the visible prose complete and final.
 - Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in visible prose.

--- a/skills/edge-esmeralda/prompts/send.md
+++ b/skills/edge-esmeralda/prompts/send.md
@@ -12,7 +12,7 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
    bun skills/index-network/scripts/send-daily-brief.ts
    ```
 
-   Do not write Python, shell pipelines, or replacement delivery logic. The script resolves today's America/Los_Angeles date, reads `memory/heartbeat-state.json`, checks the Kanban approval gate, writes `memory/digest-outgoing.md`, extracts digest opportunity markers, updates delivery state, marks the task complete, strips unsafe URLs/internal metadata, and prints either `[SILENT]` or one JSON object.
+   Do not write Python, shell pipelines, or replacement delivery logic. The script resolves today's America/Los_Angeles date, reads `memory/heartbeat-state.json`, checks the Kanban approval gate, writes `memory/digest-outgoing.md`, extracts digest opportunity and question markers, updates delivery state (today's opportunity ids plus the per-question 3-day re-delivery cooldown under `questionDelivery`), marks the task complete, strips unsafe URLs/internal metadata, and prints either `[SILENT]` or one JSON object.
 
    If the script exits with a non-zero code, end your turn immediately with `[SILENT]`. Do not diagnose, retry, or attempt alternatives. One attempt only.
 
@@ -21,10 +21,10 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
 3. **If stdout is JSON, parse it.** It has this shape:
 
    ```json
-   { "taskId": "...", "opportunityIds": ["..."], "finalBrief": "..." }
+   { "taskId": "...", "opportunityIds": ["..."], "questionIds": ["..."], "finalBrief": "..." }
    ```
 
-4. **Confirm delivery only for returned opportunity ids.** For every `opportunityIds[]` value, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. If the array is empty, skip this step.
+4. **Confirm delivery only for returned opportunity ids.** For every `opportunityIds[]` value, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. If the array is empty, skip this step. Never call any MCP tool for `questionIds[]` — question delivery bookkeeping is handled entirely by the script's state file; there is no question confirmation tool.
 
 5. **Deliver the final brief.** Your final assistant reply must be `finalBrief` verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting. Hermes delivers it. End your turn.
 

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -166,6 +166,14 @@ export interface DailyBriefContext {
 const HIGHLIGHTED_EVENT_LIMIT = 6;
 const DISCOVERY_EVENT_TARGET = 6;
 const RSVP_EVENT_LIMIT = 6;
+/** How many pending questions to fetch per digest run (tool caps at 10). */
+const QUESTION_FETCH_LIMIT = 5;
+/** Hard cap on a question prompt interpolated into the digest body. */
+const QUESTION_PROMPT_MAX_LENGTH = 300;
+/** Marker-safe question id shape — ids are interpolated into <!-- digest-question:id=… --> markers. */
+const QUESTION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+/** Days a delivered question stays out of the digest before being re-offered. */
+export const QUESTION_COOLDOWN_DAYS = 3;
 
 type EdgeEvent = Record<string, unknown> & {
   id?: string;
@@ -438,6 +446,55 @@ async function readDeliveredIds(stateFile: string, date: string): Promise<Set<st
     // missing/malformed state should not block the brief
   }
   return new Set();
+}
+
+/** Whole days from `earlier` to `later` (both YYYY-MM-DD); negative when `earlier` is after `later`. */
+function daysBetween(earlier: string, later: string): number {
+  const a = parseDateParts(earlier);
+  const b = parseDateParts(later);
+  const ms = Date.UTC(b.year, b.month - 1, b.day) - Date.UTC(a.year, a.month - 1, a.day);
+  return Math.floor(ms / 86_400_000);
+}
+
+/**
+ * Read the cross-day question delivery log (`questionDelivery`:
+ * `{ [questionId]: "YYYY-MM-DD" }`) from heartbeat state. Unlike
+ * `deliveredToday`, entries persist across days — a question stays pending on
+ * Index until answered, so dedup must outlive a single date. Defensive like
+ * readDeliveredIds: missing/malformed state never blocks the brief.
+ */
+async function readQuestionDelivery(stateFile: string): Promise<Record<string, string>> {
+  try {
+    const raw = await Bun.file(stateFile).text();
+    const parsed = JSON.parse(raw) as { questionDelivery?: unknown };
+    if (parsed.questionDelivery && typeof parsed.questionDelivery === "object" && !Array.isArray(parsed.questionDelivery)) {
+      return Object.fromEntries(
+        Object.entries(parsed.questionDelivery as Record<string, unknown>)
+          .filter((entry): entry is [string, string] =>
+            Boolean(entry[0]) && typeof entry[1] === "string" && /^\d{4}-\d{2}-\d{2}$/.test(entry[1])),
+      );
+    }
+  } catch {
+    // missing/malformed state should not block the brief
+  }
+  return {};
+}
+
+/**
+ * Drop questions delivered within the last QUESTION_COOLDOWN_DAYS days.
+ * A question with a future-dated delivery entry (clock skew) is also dropped —
+ * never re-spam on ambiguity. Undelivered questions always pass.
+ */
+export function filterCooldownQuestions(
+  questions: BriefQuestion[],
+  delivery: Record<string, string>,
+  date: string,
+): BriefQuestion[] {
+  return questions.filter((q) => {
+    const deliveredOn = delivery[q.id];
+    if (!deliveredOn) return true;
+    return daysBetween(deliveredOn, date) >= QUESTION_COOLDOWN_DAYS;
+  });
 }
 
 async function fetchOpenMeteoWeather(date: string): Promise<DailyBriefWeather> {
@@ -725,17 +782,34 @@ export async function fetchOpportunitiesFromMcp(opts: {
 }
 
 /**
- * Fetch the first pending question by calling the Index MCP server directly
- * via JSON-RPC with read_pending_questions. Mirrors fetchOpportunitiesFromMcp.
+ * Sanitize an MCP-sourced question prompt before it is interpolated into the
+ * digest body: drop HTML-comment sequences (so a hostile prompt cannot forge
+ * digest-opportunity/digest-question markers), collapse all whitespace to a
+ * single line (so it cannot inject section headers), and cap the length.
+ */
+function sanitizeQuestionPrompt(raw: string): string {
+  const collapsed = raw
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<!--|-->/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (collapsed.length <= QUESTION_PROMPT_MAX_LENGTH) return collapsed;
+  return `${collapsed.slice(0, QUESTION_PROMPT_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
+/**
+ * Fetch pending questions by calling the Index MCP server directly via
+ * JSON-RPC with read_pending_questions. Mirrors fetchOpportunitiesFromMcp.
  *
  * NEVER throws — all errors are caught internally.
- * Returns `{ questions, source }` so callers can distinguish a successful
- * (possibly-empty) fetch from a silent failure.
+ * Returns `{ questions, source, reason? }`: `source: "mcp"` is reserved for
+ * genuinely successful fetches (possibly empty); every failure path returns
+ * `source: "unavailable"` with a `reason` for the diagnostics warning.
  */
 export async function fetchPendingQuestionsFromMcp(opts: {
   apiKey: string;
   mcpUrl: string;
-}): Promise<{ questions: BriefQuestion[]; source: "mcp" | "unavailable" }> {
+}): Promise<{ questions: BriefQuestion[]; source: "mcp" | "unavailable"; reason?: string }> {
   try {
     const initResp = await postMcpMessage(opts.mcpUrl, opts.apiKey, {
       jsonrpc: "2.0",
@@ -747,34 +821,42 @@ export async function fetchPendingQuestionsFromMcp(opts: {
         clientInfo: { name: "agentvillage-digest", version: "1.0.0" },
       },
     });
-    if (initResp.error) return { questions: [], source: "unavailable" };
+    if (initResp.error) {
+      return { questions: [], source: "unavailable", reason: `MCP initialize: ${initResp.error.message}` };
+    }
 
     const toolResp = await postMcpMessage(opts.mcpUrl, opts.apiKey, {
       jsonrpc: "2.0",
       id: 2,
       method: "tools/call",
-      params: { name: "read_pending_questions", arguments: { limit: 1 } },
+      params: { name: "read_pending_questions", arguments: { limit: QUESTION_FETCH_LIMIT } },
     });
-    if (toolResp.error) return { questions: [], source: "unavailable" };
+    if (toolResp.error) {
+      return { questions: [], source: "unavailable", reason: `MCP read_pending_questions: ${toolResp.error.message}` };
+    }
 
     const result = toolResp.result as McpToolResult | undefined;
     const text = result?.content?.find((c) => c.type === "text")?.text ?? "";
     if (!text.trim()) return { questions: [], source: "mcp" };
 
-    const parsed = JSON.parse(text) as { success?: boolean; data?: { questions?: unknown[] } };
+    const parsed = JSON.parse(text) as { success?: boolean; error?: unknown; data?: { questions?: unknown[] } };
+    if (parsed.success === false) {
+      const detail = typeof parsed.error === "string" && parsed.error.trim() ? parsed.error : "tool reported failure";
+      return { questions: [], source: "unavailable", reason: `read_pending_questions: ${detail}` };
+    }
     if (!parsed.data?.questions || !Array.isArray(parsed.data.questions)) return { questions: [], source: "mcp" };
     const questions = parsed.data.questions
       .filter((q): q is Record<string, unknown> => q !== null && typeof q === "object")
       .map((q) => ({
         id: String(q.id ?? ""),
         title: String(q.title ?? ""),
-        prompt: String(q.prompt ?? ""),
+        prompt: sanitizeQuestionPrompt(String(q.prompt ?? "")),
         mode: String(q.mode ?? ""),
       }))
-      .filter((q) => q.id && q.prompt);
+      .filter((q) => QUESTION_ID_PATTERN.test(q.id) && q.prompt);
     return { questions, source: "mcp" };
-  } catch {
-    return { questions: [], source: "unavailable" };
+  } catch (err) {
+    return { questions: [], source: "unavailable", reason: err instanceof Error ? err.message : String(err) };
   }
 }
 
@@ -826,10 +908,11 @@ export async function buildDailyBriefContext(options: {
 
   if (apiKey) {
     const questionResult = await fetchPendingQuestionsFromMcp({ apiKey, mcpUrl });
-    questions = questionResult.questions;
+    const questionDelivery = await readQuestionDelivery(options.stateFile ?? "memory/heartbeat-state.json");
+    questions = filterCooldownQuestions(questionResult.questions, questionDelivery, date);
     questionSource = questionResult.source;
     if (questionResult.source === "unavailable") {
-      warnings.push("questions MCP unavailable");
+      warnings.push(`questions MCP unavailable: ${questionResult.reason ?? "unknown"}`);
     }
   }
 

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -120,6 +120,13 @@ export interface BriefEvent {
   reasonHint: string;
 }
 
+export interface BriefQuestion {
+  id: string;
+  title: string;
+  prompt: string;
+  mode: string;
+}
+
 export interface BriefOpportunity {
   name: string;
   mainText?: string;
@@ -143,11 +150,13 @@ export interface DailyBriefContext {
   connectionOpportunities: BriefOpportunity[];
   communityOpportunities: BriefOpportunity[];
   weather?: DailyBriefWeather;
+  questions?: BriefQuestion[];
   diagnostics: {
     announcementsSource: "control-plane" | "unavailable";
     calendarSource: "edgeos" | "unavailable";
     rsvpSource: "edgeos" | "unavailable";
     opportunitySource: "mcp" | "file" | "unavailable";
+    questionSource?: "mcp" | "unavailable";
     weatherSource?: "open-meteo" | "nws" | "unavailable";
     warnings: string[];
     interestTags: string[];
@@ -715,6 +724,60 @@ export async function fetchOpportunitiesFromMcp(opts: {
   return parseOpportunityTranscript(text);
 }
 
+/**
+ * Fetch the first pending question by calling the Index MCP server directly
+ * via JSON-RPC with read_pending_questions. Mirrors fetchOpportunitiesFromMcp.
+ *
+ * NEVER throws — all errors are caught internally.
+ * Returns `{ questions, source }` so callers can distinguish a successful
+ * (possibly-empty) fetch from a silent failure.
+ */
+export async function fetchPendingQuestionsFromMcp(opts: {
+  apiKey: string;
+  mcpUrl: string;
+}): Promise<{ questions: BriefQuestion[]; source: "mcp" | "unavailable" }> {
+  try {
+    const initResp = await postMcpMessage(opts.mcpUrl, opts.apiKey, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "agentvillage-digest", version: "1.0.0" },
+      },
+    });
+    if (initResp.error) return { questions: [], source: "unavailable" };
+
+    const toolResp = await postMcpMessage(opts.mcpUrl, opts.apiKey, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "read_pending_questions", arguments: { limit: 1 } },
+    });
+    if (toolResp.error) return { questions: [], source: "unavailable" };
+
+    const result = toolResp.result as McpToolResult | undefined;
+    const text = result?.content?.find((c) => c.type === "text")?.text ?? "";
+    if (!text.trim()) return { questions: [], source: "mcp" };
+
+    const parsed = JSON.parse(text) as { success?: boolean; data?: { questions?: unknown[] } };
+    if (!parsed.data?.questions || !Array.isArray(parsed.data.questions)) return { questions: [], source: "mcp" };
+    const questions = parsed.data.questions
+      .filter((q): q is Record<string, unknown> => q !== null && typeof q === "object")
+      .map((q) => ({
+        id: String(q.id ?? ""),
+        title: String(q.title ?? ""),
+        prompt: String(q.prompt ?? ""),
+        mode: String(q.mode ?? ""),
+      }))
+      .filter((q) => q.id && q.prompt);
+    return { questions, source: "mcp" };
+  } catch {
+    return { questions: [], source: "unavailable" };
+  }
+}
+
 export async function buildDailyBriefContext(options: {
   date?: string;
   stateFile?: string;
@@ -758,6 +821,18 @@ export async function buildDailyBriefContext(options: {
     }
   }
 
+  let questions: BriefQuestion[] = [];
+  let questionSource: "mcp" | "unavailable" = "unavailable";
+
+  if (apiKey) {
+    const questionResult = await fetchPendingQuestionsFromMcp({ apiKey, mcpUrl });
+    questions = questionResult.questions;
+    questionSource = questionResult.source;
+    if (questionResult.source === "unavailable") {
+      warnings.push("questions MCP unavailable");
+    }
+  }
+
   return {
     date,
     displayDate: displayDate(date),
@@ -770,11 +845,13 @@ export async function buildDailyBriefContext(options: {
     connectionOpportunities: opportunities.filter((opp) => opp.feedCategory === "connection"),
     communityOpportunities: opportunities.filter((opp) => opp.feedCategory === "connector-flow"),
     weather: weather.source !== "unavailable" ? weather : undefined,
+    questions,
     diagnostics: {
       announcementsSource: announcementResult.source,
       calendarSource: eventResult.source,
       rsvpSource: rsvpResult.source,
       opportunitySource,
+      questionSource,
       weatherSource: weather.source,
       warnings,
       interestTags,

--- a/skills/index-network/scripts/send-daily-brief.ts
+++ b/skills/index-network/scripts/send-daily-brief.ts
@@ -13,11 +13,13 @@
 import { existsSync } from "node:fs";
 import { access } from "node:fs/promises";
 
-import { extractDigestOpportunityIds, sanitizeDigestUrls } from "./validate-digest-urls";
+import { QUESTION_COOLDOWN_DAYS } from "./build-daily-brief-context";
+import { extractDigestOpportunityIds, extractDigestQuestionIds, sanitizeDigestUrls } from "./validate-digest-urls";
 
 interface SendResult {
   taskId: string;
   opportunityIds: string[];
+  questionIds: string[];
   finalBrief: string;
 }
 
@@ -48,6 +50,20 @@ function pacificDate(): string {
   }).formatToParts(new Date());
   const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
   return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+/**
+ * Whether a question delivery entry is still inside the re-delivery cooldown.
+ * Future-dated entries (clock skew) count as within cooldown — never re-spam
+ * on ambiguity, matching filterCooldownQuestions in build-daily-brief-context.
+ */
+function withinQuestionCooldown(deliveredOn: string, today: string): boolean {
+  const toUtc = (d: string) => {
+    const [year, month, day] = d.split("-").map(Number);
+    return Date.UTC(year, month - 1, day);
+  };
+  const elapsedDays = Math.floor((toUtc(today) - toUtc(deliveredOn)) / 86_400_000);
+  return elapsedDays < QUESTION_COOLDOWN_DAYS;
 }
 
 async function readJsonObject(path: string): Promise<Record<string, unknown>> {
@@ -143,6 +159,7 @@ export async function sendDailyBrief(options: {
 
   await Bun.write(outgoingFile, body);
   const opportunityIds = extractDigestOpportunityIds(body);
+  const questionIds = extractDigestQuestionIds(body);
 
   const deliveredToday = state.deliveredToday && typeof state.deliveredToday === "object" && !Array.isArray(state.deliveredToday)
     ? state.deliveredToday as Record<string, unknown>
@@ -152,12 +169,27 @@ export async function sendDailyBrief(options: {
     date,
     ids: Array.from(new Set([...currentIds, ...opportunityIds])),
   };
+
+  // Cross-day question delivery log: record today's delivered question ids and
+  // prune entries past the cooldown (they no longer affect filtering, so the
+  // prune is lossless and keeps the state file bounded).
+  const questionDelivery = state.questionDelivery && typeof state.questionDelivery === "object" && !Array.isArray(state.questionDelivery)
+    ? { ...(state.questionDelivery as Record<string, unknown>) }
+    : {};
+  for (const [id, deliveredOn] of Object.entries(questionDelivery)) {
+    if (typeof deliveredOn !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(deliveredOn) || !withinQuestionCooldown(deliveredOn, date)) {
+      delete questionDelivery[id];
+    }
+  }
+  for (const id of questionIds) questionDelivery[id] = date;
+  state.questionDelivery = questionDelivery;
+
   await writeJson(stateFile, state);
 
   await hermes(["kanban", "complete", taskId, "--summary", "delivered"]);
 
   const { output: finalBrief } = sanitizeDigestUrls(body, { stripDigestMetadata: true });
-  return { taskId, opportunityIds, finalBrief };
+  return { taskId, opportunityIds, questionIds, finalBrief };
 }
 
 async function main(): Promise<void> {

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -171,6 +171,16 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
 
   lines.push("That's it for now. You can always ask me for more detail, or any other questions you have!");
 
+  const pendingQuestions = context.questions ?? [];
+  if (pendingQuestions.length > 0) {
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+    lines.push(`**One for you:** ${pendingQuestions[0].prompt}`);
+    lines.push("");
+    lines.push("Reply to me anytime!");
+  }
+
   return { body: lines.join("\n").replace(/\n{3,}/g, "\n\n"), opportunityIds };
 }
 

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -84,7 +84,7 @@ function opportunityReason(
   return linkifyOpportunityName(reason, opp);
 }
 
-export function composeDailyBrief(context: DailyBriefContext): { body: string; opportunityIds: string[] } {
+export function composeDailyBrief(context: DailyBriefContext): { body: string; opportunityIds: string[]; questionIds: string[] } {
   const greetingParts = [`🌞 Good morning from Edge Esmeralda. It is ${context.displayDate}`];
   if (context.weather?.source !== "unavailable" && context.weather?.forecast) {
     greetingParts.push(`${context.weather.emoji} ${context.weather.forecast}`);
@@ -97,6 +97,7 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
     "",
   ];
   const opportunityIds: string[] = [];
+  const questionIds: string[] = [];
   let hasVerifiedContent = false;
 
   if (context.announcements.length > 0) {
@@ -171,17 +172,24 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
 
   lines.push("That's it for now. You can always ask me for more detail, or any other questions you have!");
 
+  // "One for you" postscript: deliberately placed after the sign-off as a P.S.
+  // (sanctioned in prepare.md). Gated on hasVerifiedContent so the pointer-only
+  // fallback digest stays pointer-only. The digest-question marker mirrors the
+  // opportunity marker: it survives human Kanban edits and lets the send pass
+  // record exactly which question actually shipped.
   const pendingQuestions = context.questions ?? [];
-  if (pendingQuestions.length > 0) {
+  const question = hasVerifiedContent ? pendingQuestions[0] : undefined;
+  if (question) {
+    questionIds.push(question.id);
     lines.push("");
     lines.push("---");
     lines.push("");
-    lines.push(`**One for you:** ${pendingQuestions[0].prompt}`);
+    lines.push(`<!-- digest-question:id=${question.id} -->**One for you:** ${question.prompt}`);
     lines.push("");
     lines.push("Reply to me anytime!");
   }
 
-  return { body: lines.join("\n").replace(/\n{3,}/g, "\n\n"), opportunityIds };
+  return { body: lines.join("\n").replace(/\n{3,}/g, "\n\n"), opportunityIds, questionIds };
 }
 
 async function readJsonObject(path: string): Promise<Record<string, unknown>> {
@@ -247,7 +255,7 @@ export async function stageDailyBrief(options: {
   opportunitiesFile?: string;
   stateFile?: string;
   contextOut?: string;
-} = {}): Promise<{ taskId: string; body: string; opportunityIds: string[] }> {
+} = {}): Promise<{ taskId: string; body: string; opportunityIds: string[]; questionIds: string[] }> {
   const date = options.date ?? pacificDate();
   const opportunitiesFile = options.opportunitiesFile ?? "memory/digest-opportunities.txt";
   const stateFile = options.stateFile ?? "memory/heartbeat-state.json";
@@ -256,7 +264,7 @@ export async function stageDailyBrief(options: {
   const context = await buildDailyBriefContext({ date, opportunitiesFile, stateFile });
   await writeJson(contextOut, context);
 
-  const { body, opportunityIds } = composeDailyBrief(context);
+  const { body, opportunityIds, questionIds } = composeDailyBrief(context);
   const { output: sanitizedBody } = sanitizeDigestUrls(body);
   await Bun.write("memory/digest-draft.md", `${sanitizedBody}\n`);
 
@@ -280,12 +288,13 @@ export async function stageDailyBrief(options: {
     taskId,
     taskTitle: `Morning digest — ${date}`,
     opportunityIds,
+    questionIds,
   };
   await writeJson(stateFile, state);
 
   rmSync("memory/digest-draft.md", { force: true });
 
-  return { taskId, body: sanitizedBody, opportunityIds };
+  return { taskId, body: sanitizedBody, opportunityIds, questionIds };
 }
 
 async function main(): Promise<void> {
@@ -296,7 +305,7 @@ async function main(): Promise<void> {
     stateFile: argValue(args, "--state-file"),
     contextOut: argValue(args, "--context-out"),
   });
-  process.stdout.write(`${JSON.stringify({ taskId: result.taskId, opportunityIds: result.opportunityIds })}\n`);
+  process.stdout.write(`${JSON.stringify({ taskId: result.taskId, opportunityIds: result.opportunityIds, questionIds: result.questionIds })}\n`);
 }
 
 if (import.meta.main) {

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -4,6 +4,7 @@ import {
   buildDailyBriefContext,
   extractInterestTags,
   fetchOpportunitiesFromMcp,
+  fetchPendingQuestionsFromMcp,
   filterDedupedOpportunities,
   formatPacificTime,
   pacificDayBounds,
@@ -212,6 +213,14 @@ describe("build-daily-brief-context helpers", () => {
           return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
         }
         if (body.method === "tools/call") {
+          const params = (body as { params?: { name?: string } }).params;
+          if (params?.name === "read_pending_questions") {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: 2,
+              result: { content: [{ type: "text", text: JSON.stringify({ success: true, data: { questions: [] } }) }] },
+            });
+          }
           return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: opportunityText }] } });
         }
       }
@@ -386,6 +395,70 @@ describe("fetchOpportunitiesFromMcp", () => {
     );
     try {
       await expect(fetchOpportunitiesFromMcp({ apiKey: "test-key", mcpUrl: MCP_URL })).rejects.toThrow("Method not found");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("fetchPendingQuestionsFromMcp", () => {
+  const MCP_URL = "https://test.mcp.com/mcp";
+
+  test("returns questions and source mcp on success", async () => {
+    const originalFetch = globalThis.fetch;
+    const mockQuestion = {
+      id: "q-0001",
+      title: "Collaboration focus",
+      prompt: "What kind of collaboration are you most open to right now?",
+      mode: "profile",
+    };
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === MCP_URL) {
+        const body = JSON.parse(init?.body as string ?? "{}") as { method: string };
+        if (body.method === "initialize") {
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+        }
+        if (body.method === "tools/call") {
+          return Response.json({
+            jsonrpc: "2.0",
+            id: 2,
+            result: { content: [{ type: "text", text: JSON.stringify({ success: true, data: { questions: [mockQuestion] } }) }] },
+          });
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const result = await fetchPendingQuestionsFromMcp({ apiKey: "test-key", mcpUrl: MCP_URL });
+      expect(result.source).toBe("mcp");
+      expect(result.questions).toHaveLength(1);
+      expect(result.questions[0].id).toBe("q-0001");
+      expect(result.questions[0].prompt).toBe("What kind of collaboration are you most open to right now?");
+      expect(result.questions[0].mode).toBe("profile");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns source unavailable when response body is malformed", async () => {
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async () => {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { content: [{ type: "text", text: "not json {{{{" }] },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await fetchPendingQuestionsFromMcp({ apiKey: "test-key", mcpUrl: MCP_URL });
+      // Malformed JSON triggers the catch block—source is unavailable
+      expect(result.source).toBe("unavailable");
+      expect(result.questions).toEqual([]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   buildDailyBriefContext,
   extractInterestTags,
   fetchOpportunitiesFromMcp,
   fetchPendingQuestionsFromMcp,
+  filterCooldownQuestions,
   filterDedupedOpportunities,
   formatPacificTime,
   pacificDayBounds,
@@ -233,8 +237,200 @@ describe("build-daily-brief-context helpers", () => {
       expect(context.opportunities).toHaveLength(1);
       expect(context.opportunities[0].name).toBe("Nathan Price");
       expect(context.opportunities[0].opportunityId).toBe("opp-mcp-1");
+      expect(context.questions).toEqual([]);
+      expect(context.diagnostics.questionSource).toBe("mcp");
     } finally {
       globalThis.fetch = originalFetch;
+      if (originalApiKey === undefined) delete process.env.INDEX_API_KEY;
+      else process.env.INDEX_API_KEY = originalApiKey;
+      if (originalMcpUrl === undefined) delete process.env.INDEX_MCP_URL;
+      else process.env.INDEX_MCP_URL = originalMcpUrl;
+      if (originalEdgeosKey === undefined) delete process.env.EDGEOS_API_KEY;
+      else process.env.EDGEOS_API_KEY = originalEdgeosKey;
+      if (originalControlPlaneUrl === undefined) delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+      else process.env.EDGE_AGENT_CONTROL_PLANE_URL = originalControlPlaneUrl;
+      if (originalAdminToken === undefined) delete process.env.ADMIN_TOKEN;
+      else process.env.ADMIN_TOKEN = originalAdminToken;
+    }
+  });
+
+  test("buildDailyBriefContext populates questions and questionSource from MCP", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.INDEX_API_KEY;
+    const originalMcpUrl = process.env.INDEX_MCP_URL;
+    const originalEdgeosKey = process.env.EDGEOS_API_KEY;
+    const originalControlPlaneUrl = process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    const originalAdminToken = process.env.ADMIN_TOKEN;
+    delete process.env.EDGEOS_API_KEY;
+    delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    delete process.env.ADMIN_TOKEN;
+    process.env.INDEX_API_KEY = "test-key";
+    process.env.INDEX_MCP_URL = "https://test.example.com/mcp";
+
+    const mockQuestion = {
+      id: "q-0001",
+      title: "Collaboration focus",
+      prompt: "What kind of collaboration are you most open to right now?",
+      mode: "profile",
+    };
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("open-meteo") || url.includes("weather.gov")) {
+        return new Response("unavailable", { status: 503, statusText: "Service Unavailable" });
+      }
+      if (url === "https://test.example.com/mcp") {
+        const body = JSON.parse(init?.body as string ?? "{}") as { method: string; params?: { name?: string } };
+        if (body.method === "initialize") {
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+        }
+        if (body.method === "tools/call") {
+          if (body.params?.name === "read_pending_questions") {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: 2,
+              result: { content: [{ type: "text", text: JSON.stringify({ success: true, data: { questions: [mockQuestion] } }) }] },
+            });
+          }
+          return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: "" }] } });
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const context = await buildDailyBriefContext({ date: "2026-06-10", userFiles: [] });
+      expect(context.questions).toEqual([mockQuestion]);
+      expect(context.diagnostics.questionSource).toBe("mcp");
+      expect(context.diagnostics.warnings.some((w) => w.startsWith("questions MCP unavailable"))).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalApiKey === undefined) delete process.env.INDEX_API_KEY;
+      else process.env.INDEX_API_KEY = originalApiKey;
+      if (originalMcpUrl === undefined) delete process.env.INDEX_MCP_URL;
+      else process.env.INDEX_MCP_URL = originalMcpUrl;
+      if (originalEdgeosKey === undefined) delete process.env.EDGEOS_API_KEY;
+      else process.env.EDGEOS_API_KEY = originalEdgeosKey;
+      if (originalControlPlaneUrl === undefined) delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+      else process.env.EDGE_AGENT_CONTROL_PLANE_URL = originalControlPlaneUrl;
+      if (originalAdminToken === undefined) delete process.env.ADMIN_TOKEN;
+      else process.env.ADMIN_TOKEN = originalAdminToken;
+    }
+  });
+
+  test("buildDailyBriefContext marks questionSource unavailable with a detailed warning on success:false", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.INDEX_API_KEY;
+    const originalMcpUrl = process.env.INDEX_MCP_URL;
+    const originalEdgeosKey = process.env.EDGEOS_API_KEY;
+    const originalControlPlaneUrl = process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    const originalAdminToken = process.env.ADMIN_TOKEN;
+    delete process.env.EDGEOS_API_KEY;
+    delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    delete process.env.ADMIN_TOKEN;
+    process.env.INDEX_API_KEY = "test-key";
+    process.env.INDEX_MCP_URL = "https://test.example.com/mcp";
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("open-meteo") || url.includes("weather.gov")) {
+        return new Response("unavailable", { status: 503, statusText: "Service Unavailable" });
+      }
+      if (url === "https://test.example.com/mcp") {
+        const body = JSON.parse(init?.body as string ?? "{}") as { method: string; params?: { name?: string } };
+        if (body.method === "initialize") {
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+        }
+        if (body.method === "tools/call") {
+          if (body.params?.name === "read_pending_questions") {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: 2,
+              result: { content: [{ type: "text", text: JSON.stringify({ success: false, error: "boom" }) }] },
+            });
+          }
+          return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: "" }] } });
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const context = await buildDailyBriefContext({ date: "2026-06-10", userFiles: [] });
+      expect(context.questions).toEqual([]);
+      expect(context.diagnostics.questionSource).toBe("unavailable");
+      expect(context.diagnostics.warnings).toContain("questions MCP unavailable: read_pending_questions: boom");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalApiKey === undefined) delete process.env.INDEX_API_KEY;
+      else process.env.INDEX_API_KEY = originalApiKey;
+      if (originalMcpUrl === undefined) delete process.env.INDEX_MCP_URL;
+      else process.env.INDEX_MCP_URL = originalMcpUrl;
+      if (originalEdgeosKey === undefined) delete process.env.EDGEOS_API_KEY;
+      else process.env.EDGEOS_API_KEY = originalEdgeosKey;
+      if (originalControlPlaneUrl === undefined) delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+      else process.env.EDGE_AGENT_CONTROL_PLANE_URL = originalControlPlaneUrl;
+      if (originalAdminToken === undefined) delete process.env.ADMIN_TOKEN;
+      else process.env.ADMIN_TOKEN = originalAdminToken;
+    }
+  });
+
+  test("buildDailyBriefContext filters questions in cooldown and falls through to the next pending one", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.INDEX_API_KEY;
+    const originalMcpUrl = process.env.INDEX_MCP_URL;
+    const originalEdgeosKey = process.env.EDGEOS_API_KEY;
+    const originalControlPlaneUrl = process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    const originalAdminToken = process.env.ADMIN_TOKEN;
+    delete process.env.EDGEOS_API_KEY;
+    delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    delete process.env.ADMIN_TOKEN;
+    process.env.INDEX_API_KEY = "test-key";
+    process.env.INDEX_MCP_URL = "https://test.example.com/mcp";
+
+    const dir = mkdtempSync(join(tmpdir(), "brief-questions-"));
+    const stateFile = join(dir, "state.json");
+    await Bun.write(stateFile, JSON.stringify({
+      prepared: { date: "2026-06-09", taskId: "t_x" },
+      questionDelivery: { "q-recent": "2026-06-09", "q-stale": "2026-06-01" },
+    }));
+
+    const questions = [
+      { id: "q-recent", title: "A", prompt: "Recently asked?", mode: "profile" },
+      { id: "q-stale", title: "B", prompt: "Asked long ago?", mode: "intent" },
+    ];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("open-meteo") || url.includes("weather.gov")) {
+        return new Response("unavailable", { status: 503, statusText: "Service Unavailable" });
+      }
+      if (url === "https://test.example.com/mcp") {
+        const body = JSON.parse(init?.body as string ?? "{}") as { method: string; params?: { name?: string } };
+        if (body.method === "initialize") {
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+        }
+        if (body.method === "tools/call") {
+          if (body.params?.name === "read_pending_questions") {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: 2,
+              result: { content: [{ type: "text", text: JSON.stringify({ success: true, data: { questions } }) }] },
+            });
+          }
+          return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: "" }] } });
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const context = await buildDailyBriefContext({ date: "2026-06-10", userFiles: [], stateFile });
+      expect(context.questions.map((q) => q.id)).toEqual(["q-stale"]);
+      expect(context.diagnostics.questionSource).toBe("mcp");
+    } finally {
+      globalThis.fetch = originalFetch;
+      rmSync(dir, { recursive: true, force: true });
       if (originalApiKey === undefined) delete process.env.INDEX_API_KEY;
       else process.env.INDEX_API_KEY = originalApiKey;
       if (originalMcpUrl === undefined) delete process.env.INDEX_MCP_URL;
@@ -401,6 +597,24 @@ describe("fetchOpportunitiesFromMcp", () => {
   });
 });
 
+describe("filterCooldownQuestions", () => {
+  const q = (id: string) => ({ id, title: "t", prompt: "p?", mode: "profile" });
+
+  test("keeps undelivered ids, drops within-cooldown and future-dated, re-offers at the boundary", () => {
+    const delivery = {
+      "q-yesterday": "2026-06-09", // 1 day ago  → dropped
+      "q-boundary": "2026-06-07",  // 3 days ago → re-offered
+      "q-future": "2026-06-11",    // clock skew → dropped
+    };
+    const out = filterCooldownQuestions(
+      [q("q-new"), q("q-yesterday"), q("q-boundary"), q("q-future")],
+      delivery,
+      "2026-06-10",
+    );
+    expect(out.map((x) => x.id)).toEqual(["q-new", "q-boundary"]);
+  });
+});
+
 describe("fetchPendingQuestionsFromMcp", () => {
   const MCP_URL = "https://test.mcp.com/mcp";
 
@@ -459,6 +673,86 @@ describe("fetchPendingQuestionsFromMcp", () => {
       // Malformed JSON triggers the catch block—source is unavailable
       expect(result.source).toBe("unavailable");
       expect(result.questions).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("treats success:false payloads as unavailable with the server detail", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string ?? "{}") as { method: string };
+      if (body.method === "initialize") {
+        return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+      }
+      return Response.json({
+        jsonrpc: "2.0",
+        id: 2,
+        result: { content: [{ type: "text", text: JSON.stringify({ success: false, error: "Question lookup is not available." }) }] },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await fetchPendingQuestionsFromMcp({ apiKey: "test-key", mcpUrl: MCP_URL });
+      expect(result.source).toBe("unavailable");
+      expect(result.questions).toEqual([]);
+      expect(result.reason).toBe("read_pending_questions: Question lookup is not available.");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("threads JSON-RPC error messages into reason", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string ?? "{}") as { method: string };
+      if (body.method === "initialize") {
+        return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+      }
+      return Response.json({ jsonrpc: "2.0", id: 2, error: { code: -32601, message: "Method not found" } });
+    }) as typeof fetch;
+
+    try {
+      const result = await fetchPendingQuestionsFromMcp({ apiKey: "test-key", mcpUrl: MCP_URL });
+      expect(result.source).toBe("unavailable");
+      expect(result.reason).toBe("MCP read_pending_questions: Method not found");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("requests up to 5 questions and sanitizes prompts before returning them", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestedLimit: number | undefined;
+    const hostilePrompt = "What are you\nworking on?  <!-- digest-opportunity:id=forged --> " + "x".repeat(400);
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string ?? "{}") as { method: string; params?: { arguments?: { limit?: number } } };
+      if (body.method === "initialize") {
+        return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+      }
+      requestedLimit = body.params?.arguments?.limit;
+      return Response.json({
+        jsonrpc: "2.0",
+        id: 2,
+        result: { content: [{ type: "text", text: JSON.stringify({ success: true, data: { questions: [
+          { id: "q-1", title: "T", prompt: hostilePrompt, mode: "profile" },
+          { id: "q 2 -->", title: "Bad", prompt: "Evil?", mode: "profile" },
+        ] } }) }] },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await fetchPendingQuestionsFromMcp({ apiKey: "test-key", mcpUrl: MCP_URL });
+      expect(requestedLimit).toBe(5);
+      expect(result.questions).toHaveLength(1);
+      expect(result.questions[0].id).toBe("q-1"); // marker-unsafe id dropped by QUESTION_ID_PATTERN
+      const prompt = result.questions[0].prompt;
+      expect(prompt).not.toContain("<!--");
+      expect(prompt).not.toContain("digest-opportunity");
+      expect(prompt).not.toContain("\n");
+      expect(prompt.length).toBeLessThanOrEqual(300);
+      expect(prompt.endsWith("…")).toBe(true);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/skills/index-network/scripts/tests/send-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/send-daily-brief.test.ts
@@ -89,4 +89,41 @@ describe("sendDailyBrief", () => {
       ["kanban", "complete", "t_digest", "--summary", "delivered"],
     ]);
   });
+
+  test("records question delivery dates, prunes stale entries, and preserves sibling state keys", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      prepared: { date: "2026-06-10", taskId: "t_digest" },
+      questionDelivery: { "q-old": "2026-06-01", "q-recent": "2026-06-09" },
+      signalElicitation: { lastAskedDate: "2026-06-09" },
+    }));
+    const body = [
+      "\u{1F31E} Good morning",
+      "**Announcements**",
+      "- Town hall at 5pm.",
+      "<!-- digest-question:id=q-0001 -->**One for you:** What are you building?",
+    ].join("\n");
+
+    const result = await sendDailyBrief({
+      date: "2026-06-10",
+      stateFile: "state.json",
+      outgoingFile: "outgoing.md",
+      hermes: (args) => {
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest", status: "ready", body } });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+    });
+
+    expect("silent" in result).toBe(false);
+    if ("silent" in result) throw new Error("unexpected silent result");
+    expect(result.questionIds).toEqual(["q-0001"]);
+    expect(result.finalBrief).not.toContain("digest-question");
+    expect(result.finalBrief).toContain("**One for you:** What are you building?");
+
+    const state = JSON.parse(await Bun.file("state.json").text());
+    // q-old (9 days ago, past the 3-day cooldown) pruned; q-recent kept; q-0001 recorded today.
+    expect(state.questionDelivery).toEqual({ "q-recent": "2026-06-09", "q-0001": "2026-06-10" });
+    expect(state.signalElicitation).toEqual({ lastAskedDate: "2026-06-09" });
+  });
 });

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -271,9 +271,10 @@ describe("composeDailyBrief", () => {
     expect(body).not.toContain("Low");
   });
 
-  test("renders a One for you section when questions are pending", () => {
-    const { body } = composeDailyBrief({
+  test("renders a gated One for you postscript with a digest-question marker", () => {
+    const { body, questionIds } = composeDailyBrief({
       ...baseContext,
+      announcements: [{ body: "Town hall at 5pm." }],
       questions: [
         {
           id: "q-0001",
@@ -283,8 +284,21 @@ describe("composeDailyBrief", () => {
         },
       ],
     });
-    expect(body).toContain("**One for you:** What kind of collaboration are you most open to right now?");
+    expect(questionIds).toEqual(["q-0001"]);
+    expect(body).toContain("<!-- digest-question:id=q-0001 -->**One for you:** What kind of collaboration are you most open to right now?");
     expect(body).toContain("Reply to me anytime!");
+    expect(body.indexOf("That's it for now")).toBeLessThan(body.indexOf("**One for you:**"));
+  });
+
+  test("omits the question postscript from the pointer-only fallback digest", () => {
+    const { body, questionIds } = composeDailyBrief({
+      ...baseContext,
+      questions: [{ id: "q-0001", title: "T", prompt: "Anything new?", mode: "profile" }],
+    });
+    expect(questionIds).toEqual([]);
+    expect(body).toContain("I couldn't check the live calendar this morning");
+    expect(body).not.toContain("**One for you:**");
+    expect(body).not.toContain("digest-question");
   });
 
   test("does not render a One for you section when questions are absent", () => {

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -271,6 +271,33 @@ describe("composeDailyBrief", () => {
     expect(body).not.toContain("Low");
   });
 
+  test("renders a One for you section when questions are pending", () => {
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      questions: [
+        {
+          id: "q-0001",
+          title: "Collaboration focus",
+          prompt: "What kind of collaboration are you most open to right now?",
+          mode: "profile",
+        },
+      ],
+    });
+    expect(body).toContain("**One for you:** What kind of collaboration are you most open to right now?");
+    expect(body).toContain("Reply to me anytime!");
+  });
+
+  test("does not render a One for you section when questions are absent", () => {
+    const { body } = composeDailyBrief({ ...baseContext });
+    expect(body).not.toContain("**One for you:**");
+    expect(body).not.toContain("Reply to me anytime!");
+  });
+
+  test("does not render a One for you section when questions array is empty", () => {
+    const { body } = composeDailyBrief({ ...baseContext, questions: [] });
+    expect(body).not.toContain("**One for you:**");
+  });
+
   test("greeting includes weather when available and omits trailing period without weather", () => {
     // Without weather — should match exemplar (no trailing period)
     const { body: noWeather } = composeDailyBrief(baseContext);

--- a/skills/index-network/scripts/tests/validate-digest-urls.test.ts
+++ b/skills/index-network/scripts/tests/validate-digest-urls.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 
 import {
   extractDigestOpportunityIds,
+  extractDigestQuestionIds,
   sanitizeDigestUrls,
   stripDigestMetadata,
 } from "../validate-digest-urls";
@@ -152,5 +153,34 @@ describe("sanitizeDigestUrls", () => {
     const md = "<!-- keep-me -->\n- <!-- digest-opportunity:id=opp-1 -->Maya";
 
     expect(stripDigestMetadata(md)).toBe("<!-- keep-me -->\n- Maya");
+  });
+
+  test("extracts unique question ids in order, ignoring opportunity markers", () => {
+    const md = [
+      "- <!-- digest-opportunity:id=opp-1 -->Maya — relevant",
+      "<!-- digest-question:id=q-1 -->**One for you:** What are you building?",
+      "<!-- digest-question:id=q-1 -->duplicate",
+      "<!-- digest-question:id=q-2 -->**One for you:** Something else?",
+    ].join("\n");
+
+    expect(extractDigestQuestionIds(md)).toEqual(["q-1", "q-2"]);
+    expect(extractDigestOpportunityIds(md)).toEqual(["opp-1"]);
+  });
+
+  test("stripDigestMetadata removes question markers as well as opportunity markers", () => {
+    const md = "<!-- keep-me -->\n- <!-- digest-opportunity:id=opp-1 -->Maya\n<!-- digest-question:id=q-1 -->**One for you:** What are you building?";
+
+    const stripped = stripDigestMetadata(md);
+
+    expect(stripped).toBe("<!-- keep-me -->\n- Maya\n**One for you:** What are you building?");
+    expect(stripped).not.toContain("digest-opportunity");
+    expect(stripped).not.toContain("digest-question");
+  });
+
+  test("sanitizeDigestUrls strips question markers on final delivery and preserves them by default", () => {
+    const md = "<!-- digest-question:id=q-1 -->**One for you:** Anything new?";
+
+    expect(sanitizeDigestUrls(md).output).toBe(md);
+    expect(sanitizeDigestUrls(md, { stripDigestMetadata: true }).output).toBe("**One for you:** Anything new?");
   });
 });

--- a/skills/index-network/scripts/validate-digest-urls.ts
+++ b/skills/index-network/scripts/validate-digest-urls.ts
@@ -45,6 +45,10 @@ const MARKDOWN_LINK = /\[([^\]]*)\]\(([^)]*)\)/g;
 
 /** Hidden marker that ties an editable digest fragment to the opportunity it represents. */
 const DIGEST_OPPORTUNITY_MARKER = /<!--\s*digest-opportunity:id=([^\s>]+)\s*-->/g;
+/** Hidden marker that ties a digest question fragment to the question it represents. */
+const DIGEST_QUESTION_MARKER = /<!--\s*digest-question:id=([^\s>]+)\s*-->/g;
+/** Any internal digest metadata marker (opportunity or question) — the strip set. */
+const DIGEST_METADATA_MARKER = /<!--\s*digest-(?:opportunity|question):id=[^\s>]+\s*-->/g;
 
 export interface SanitizeDigestOptions {
   /** Strip internal digest metadata comments before user-facing delivery. */
@@ -98,13 +102,33 @@ export function extractDigestOpportunityIds(markdown: string): string[] {
 }
 
 /**
+ * Extract question ids from digest question markers that remain in the edited body.
+ *
+ * @param markdown - the editable digest body
+ * @returns unique question ids in first-seen order
+ */
+export function extractDigestQuestionIds(markdown: string): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of markdown.matchAll(DIGEST_QUESTION_MARKER)) {
+    const id = match[1];
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+/**
  * Remove internal digest metadata comments from user-facing output.
  *
  * @param markdown - the digest body
- * @returns markdown without digest opportunity markers
+ * @returns markdown without digest opportunity/question markers
  */
 export function stripDigestMetadata(markdown: string): string {
-  return markdown.replace(DIGEST_OPPORTUNITY_MARKER, "");
+  return markdown.replace(DIGEST_METADATA_MARKER, "");
 }
 
 export function sanitizeDigestUrls(


### PR DESCRIPTION
## New Features

- **`read_pending_questions` MCP tool** — exposes pending questions from the QuestionerAgent DB via a new `questioner.tools.ts` file; registered in `tool.registry.ts` after `createPremiseTools`
- **`fetchPendingQuestionsFromMcp()`** — new function in `build-daily-brief-context.ts` that fetches the first pending question via JSON-RPC (initialize → tools/call), fail-closed; returns `{ questions, source }`
- **`BriefQuestion` type and `DailyBriefContext.questions`** — new optional fields propagating question data through the context pipeline
- **Brief composition** — `composeDailyBrief()` in `stage-daily-brief.ts` appends a `**One for you:** {prompt}` / `Reply to me anytime!` section after the closing line when questions are present

## Tests

- 4 new unit tests for `read_pending_questions` tool (success, empty, absent dep, limit)
- 2 new tests for `fetchPendingQuestionsFromMcp` (success path, malformed JSON → unavailable)
- 3 new tests for `composeDailyBrief` question section (present, absent, empty array)

## Notes

- Questions fetched in the **prepare step** (02:00 AM cron); `send.md` is unchanged — delivers verbatim
- Fail-closed: any fetch failure yields `source: "unavailable"` + empty questions; brief delivers without a question
- Only the first pending question is included per brief (`limit: 1`)