### PR TITLE
fix(install): verify INDEX_API_KEY identity before writing to disk

### DIFF
--- a/install/install.ts
+++ b/install/install.ts
@@ -30,7 +30,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
 
-import { installIndex } from "./install_index";
+import { installIndex, preflightIndexIdentity } from "./install_index";
 import { installEdgeos } from "./install_edgeos";
 import { installGeo } from "./install_geo";
 import { setTerminalCwd } from "./config";
@@ -183,6 +183,11 @@ function restartGateway(): void {
 async function main(): Promise<void> {
   ensureHermesAvailable();
 
+  // Pre-flight: verify Index credentials before any HERMES_HOME mutations.
+  // Throws IdentityVerificationError on rejected key or handle mismatch,
+  // which propagates to main().catch → exit 1.
+  await preflightIndexIdentity();
+
   const wipeUser = process.argv.includes("--wipe-user");
 
   console.log("Edge Hermes installer");
@@ -196,7 +201,7 @@ async function main(): Promise<void> {
   copySkillFiles();
   setTerminalCwd();
 
-  await installIndex();
+  installIndex();
   installEdgeos();
   installGeo();
 

--- a/install/install.ts
+++ b/install/install.ts
@@ -180,7 +180,7 @@ function restartGateway(): void {
   }
 }
 
-function main(): void {
+async function main(): Promise<void> {
   ensureHermesAvailable();
 
   const wipeUser = process.argv.includes("--wipe-user");
@@ -196,7 +196,7 @@ function main(): void {
   copySkillFiles();
   setTerminalCwd();
 
-  installIndex();
+  await installIndex();
   installEdgeos();
   installGeo();
 
@@ -211,4 +211,4 @@ function main(): void {
   console.log("next: message your Telegram bot — gateway uses terminal.cwd above");
 }
 
-main();
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -57,6 +57,111 @@ export function buildIndexMcpHeaders(apiKey: string, telegramHandle = ""): Recor
   return headers;
 }
 
+/**
+ * Normalize a Telegram handle to a bare lowercase handle.
+ * Strips leading @, URL prefix (t.me/, https://t.me/, telegram.me/), and
+ * everything after the first /, ?, or # — matching the SQL normalization
+ * in database.adapter.ts:4483.
+ */
+export function normalizeTelegramHandle(value: string): string {
+  let v = value.trim().toLowerCase();
+  v = v.replace(/^(https?:\/\/)?(t\.me|telegram\.me)\//, "");
+  v = v.replace(/^@/, "");
+  v = v.replace(/[/?#].*$/, "");
+  return v;
+}
+
+/**
+ * Verify that the given API key resolves to the expected resident on Index Network.
+ * Calls GET /api/auth/me with the key and compares the profile telegram handle against
+ * the expected handle (if provided).
+ *
+ * Exit codes:
+ *   - HTTP 401/403: key is invalid/expired → exit 1
+ *   - telegram handle mismatch: wrong key for this resident → exit 1
+ *   - network error / missing profile handle: warn + continue
+ */
+async function verifyIndexIdentity(apiKey: string, telegramHandle: string): Promise<void> {
+  const baseUrl = PROTOCOL_MCP_URL.replace(/\/mcp$/, "");
+  console.log("  verifying Index Network identity...");
+
+  type MeUser = {
+    id: string;
+    name: string;
+    email: string | null;
+    socials?: Array<{ label: string; value: string }>;
+  };
+
+  let identity: MeUser | null = null;
+
+  try {
+    const resp = await fetch(`${baseUrl}/api/auth/me`, {
+      headers: { "x-api-key": apiKey },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (resp.status === 401 || resp.status === 403) {
+      console.error(
+        `error: API key rejected by Index Network (HTTP ${resp.status}) — invalid or expired key`,
+      );
+      process.exit(1);
+    }
+
+    if (!resp.ok) {
+      console.warn(
+        `  warning: identity check unavailable (HTTP ${resp.status}) — proceeding without verification`,
+      );
+      return;
+    }
+
+    const json = (await resp.json()) as { user?: MeUser };
+    identity = json.user ?? null;
+  } catch (err) {
+    const reason = err instanceof Error && err.name === "TimeoutError"
+      ? "timeout after 10 s"
+      : "network error";
+    console.warn(
+      `  warning: identity check unavailable (${reason}) — proceeding without verification`,
+    );
+    return;
+  }
+
+  if (!identity) {
+    console.warn(
+      "  warning: identity check returned empty user — proceeding without verification",
+    );
+    return;
+  }
+
+  const displayName = `${identity.name}${identity.email ? ` (${identity.email})` : ""}`;
+
+  if (!telegramHandle) {
+    console.log(`  authenticated as ${displayName}`);
+    return;
+  }
+
+  const telegramSocial = identity.socials?.find((s) => s.label === "telegram");
+
+  if (!telegramSocial) {
+    console.warn(
+      `  warning: authenticated as ${displayName} — no telegram handle on profile, cannot verify @${telegramHandle}`,
+    );
+    return;
+  }
+
+  const profileHandle = normalizeTelegramHandle(telegramSocial.value);
+  const expectedHandle = normalizeTelegramHandle(telegramHandle);
+
+  if (profileHandle !== expectedHandle) {
+    console.error(
+      `error: API key authenticates as @${profileHandle}, expected @${expectedHandle} — wrong key for this resident`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`  authenticated as ${displayName} — telegram: @${profileHandle} ✓`);
+}
+
 function writeMcpServerEntry(apiKey: string, telegramHandle: string): void {
   const configPath = join(hermesHome(), "config.yaml");
   let doc: Record<string, unknown> = {};
@@ -289,12 +394,13 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
   }
 }
 
-export function installIndex(): void {
+export async function installIndex(): Promise<void> {
   const apiKey = readApiKey();
   const telegramHandle = readTelegramHandle();
   console.log(
     `→ index network: target=${IS_DEV ? "dev" : "production"} (${PROTOCOL_MCP_URL})`,
   );
+  await verifyIndexIdentity(apiKey, telegramHandle);
   upsertEnvVar("INDEX_API_KEY", apiKey);
   if (telegramHandle) upsertEnvVar("INDEX_TELEGRAM_HANDLE", telegramHandle);
   writeMcpServerEntry(apiKey, telegramHandle);

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -72,16 +72,29 @@ export function normalizeTelegramHandle(value: string): string {
 }
 
 /**
+ * Typed error for identity verification failures.
+ * `kind` distinguishes a rejected key (401/403) from a telegram handle mismatch.
+ * Thrown by `verifyIndexIdentity`; `main().catch` maps it to exit 1.
+ */
+export class IdentityVerificationError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: "rejected" | "mismatch",
+  ) {
+    super(message);
+    this.name = "IdentityVerificationError";
+  }
+}
+
+/**
  * Verify that the given API key resolves to the expected resident on Index Network.
  * Calls GET /api/auth/me with the key and compares the profile telegram handle against
  * the expected handle (if provided).
  *
- * Exit codes:
- *   - HTTP 401/403: key is invalid/expired → exit 1
- *   - telegram handle mismatch: wrong key for this resident → exit 1
- *   - network error / missing profile handle: warn + continue
+ * @throws {IdentityVerificationError} kind='rejected' when HTTP 401/403 (invalid/expired key)
+ * @throws {IdentityVerificationError} kind='mismatch' when telegram handle does not match
  */
-async function verifyIndexIdentity(apiKey: string, telegramHandle: string): Promise<void> {
+export async function verifyIndexIdentity(apiKey: string, telegramHandle: string): Promise<void> {
   const baseUrl = PROTOCOL_MCP_URL.replace(/\/mcp$/, "");
   console.log("  verifying Index Network identity...");
 
@@ -101,10 +114,10 @@ async function verifyIndexIdentity(apiKey: string, telegramHandle: string): Prom
     });
 
     if (resp.status === 401 || resp.status === 403) {
-      console.error(
-        `error: API key rejected by Index Network (HTTP ${resp.status}) — invalid or expired key`,
+      throw new IdentityVerificationError(
+        `API key rejected by Index Network (HTTP ${resp.status}) — invalid or expired key`,
+        "rejected",
       );
-      process.exit(1);
     }
 
     if (!resp.ok) {
@@ -117,6 +130,7 @@ async function verifyIndexIdentity(apiKey: string, telegramHandle: string): Prom
     const json = (await resp.json()) as { user?: MeUser };
     identity = json.user ?? null;
   } catch (err) {
+    if (err instanceof IdentityVerificationError) throw err;
     const reason = err instanceof Error && err.name === "TimeoutError"
       ? "timeout after 10 s"
       : "network error";
@@ -153,10 +167,10 @@ async function verifyIndexIdentity(apiKey: string, telegramHandle: string): Prom
   const expectedHandle = normalizeTelegramHandle(telegramHandle);
 
   if (profileHandle !== expectedHandle) {
-    console.error(
-      `error: API key authenticates as @${profileHandle}, expected @${expectedHandle} — wrong key for this resident`,
+    throw new IdentityVerificationError(
+      `API key authenticates as @${profileHandle}, expected @${expectedHandle} — wrong key for this resident`,
+      "mismatch",
     );
-    process.exit(1);
   }
 
   console.log(`  authenticated as ${displayName} — telegram: @${profileHandle} ✓`);
@@ -394,13 +408,27 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
   }
 }
 
-export async function installIndex(): Promise<void> {
+/**
+ * Pre-flight identity verification. Reads the API key and telegram handle from
+ * CLI flags / env, then calls `verifyIndexIdentity`.
+ *
+ * Call this in `main()` *before* any HERMES_HOME mutations so a credential
+ * failure aborts a pristine install.
+ *
+ * @throws {IdentityVerificationError} on rejected key or handle mismatch
+ */
+export async function preflightIndexIdentity(): Promise<void> {
   const apiKey = readApiKey();
   const telegramHandle = readTelegramHandle();
   console.log(
     `→ index network: target=${IS_DEV ? "dev" : "production"} (${PROTOCOL_MCP_URL})`,
   );
   await verifyIndexIdentity(apiKey, telegramHandle);
+}
+
+export function installIndex(): void {
+  const apiKey = readApiKey();
+  const telegramHandle = readTelegramHandle();
   upsertEnvVar("INDEX_API_KEY", apiKey);
   if (telegramHandle) upsertEnvVar("INDEX_TELEGRAM_HANDLE", telegramHandle);
   writeMcpServerEntry(apiKey, telegramHandle);

--- a/install/tests/verify_identity.test.ts
+++ b/install/tests/verify_identity.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  IdentityVerificationError,
+  normalizeTelegramHandle,
+  verifyIndexIdentity,
+} from "../install_index";
+
+// ---------------------------------------------------------------------------
+// normalizeTelegramHandle
+// ---------------------------------------------------------------------------
+
+describe("normalizeTelegramHandle", () => {
+  test("strips leading @", () => {
+    expect(normalizeTelegramHandle("@alice")).toBe("alice");
+  });
+
+  test("strips https://t.me/ prefix", () => {
+    expect(normalizeTelegramHandle("https://t.me/alice")).toBe("alice");
+  });
+
+  test("strips http://t.me/ prefix", () => {
+    expect(normalizeTelegramHandle("http://t.me/bob")).toBe("bob");
+  });
+
+  test("strips telegram.me prefix", () => {
+    expect(normalizeTelegramHandle("https://telegram.me/carol")).toBe("carol");
+  });
+
+  test("lowercases the handle", () => {
+    expect(normalizeTelegramHandle("@AlIcE")).toBe("alice");
+  });
+
+  test("strips trailing path/query/hash", () => {
+    expect(normalizeTelegramHandle("https://t.me/alice/extra?q=1#foo")).toBe("alice");
+  });
+
+  test("trims whitespace", () => {
+    expect(normalizeTelegramHandle("  @alice  ")).toBe("alice");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(normalizeTelegramHandle("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyIndexIdentity — five branches
+// ---------------------------------------------------------------------------
+
+describe("verifyIndexIdentity", () => {
+  const ME_USER = {
+    id: "u1",
+    name: "Alice",
+    email: "alice@example.com",
+    socials: [{ label: "telegram", value: "@alice" }],
+  };
+
+  function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) =>
+      handler(String(input), init)) as typeof fetch;
+    return () => { globalThis.fetch = original; };
+  }
+
+  // Branch 1: HTTP 401/403 → IdentityVerificationError kind='rejected'
+  test("throws rejected error on HTTP 401", async () => {
+    const restore = mockFetch(() => new Response("Unauthorized", { status: 401 }));
+    try {
+      await expect(verifyIndexIdentity("bad-key", "alice")).rejects.toThrow(IdentityVerificationError);
+      await expect(verifyIndexIdentity("bad-key", "alice")).rejects.toMatchObject({ kind: "rejected" });
+    } finally {
+      restore();
+    }
+  });
+
+  test("throws rejected error on HTTP 403", async () => {
+    const restore = mockFetch(() => new Response("Forbidden", { status: 403 }));
+    try {
+      await expect(verifyIndexIdentity("bad-key", "alice")).rejects.toThrow(IdentityVerificationError);
+      await expect(verifyIndexIdentity("bad-key", "alice")).rejects.toMatchObject({ kind: "rejected" });
+    } finally {
+      restore();
+    }
+  });
+
+  // Branch 2: HTTP 5xx → warn-continue (no throw)
+  test("resolves on HTTP 503 (warn-continue)", async () => {
+    const restore = mockFetch(() => new Response("Service Unavailable", { status: 503 }));
+    try {
+      await expect(verifyIndexIdentity("key", "alice")).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  // Branch 3: network/timeout error → warn-continue (no throw)
+  test("resolves on network error (warn-continue)", async () => {
+    const restore = mockFetch(() => { throw new Error("ECONNREFUSED"); });
+    try {
+      await expect(verifyIndexIdentity("key", "alice")).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("resolves on timeout error (warn-continue)", async () => {
+    const restore = mockFetch(() => { throw Object.assign(new Error("timeout"), { name: "TimeoutError" }); });
+    try {
+      await expect(verifyIndexIdentity("key", "alice")).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  // Branch 4: missing telegram social on profile → warn-continue
+  test("resolves when profile has no telegram social", async () => {
+    const restore = mockFetch(() => Response.json({
+      user: { id: "u1", name: "Alice", email: null, socials: [] },
+    }));
+    try {
+      await expect(verifyIndexIdentity("key", "alice")).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  // Branch 5: telegram handle mismatch → IdentityVerificationError kind='mismatch'
+  test("throws mismatch error when handles differ", async () => {
+    const restore = mockFetch(() => Response.json({ user: ME_USER }));
+    try {
+      await expect(verifyIndexIdentity("key", "bob")).rejects.toThrow(IdentityVerificationError);
+      await expect(verifyIndexIdentity("key", "bob")).rejects.toMatchObject({ kind: "mismatch" });
+    } finally {
+      restore();
+    }
+  });
+
+  // Happy path: matching handle → resolves
+  test("resolves when handle matches", async () => {
+    const restore = mockFetch(() => Response.json({ user: ME_USER }));
+    try {
+      await expect(verifyIndexIdentity("key", "alice")).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  // Happy path: no expected handle → resolves (no comparison)
+  test("resolves when no expected handle is provided", async () => {
+    const restore = mockFetch(() => Response.json({ user: ME_USER }));
+    try {
+      await expect(verifyIndexIdentity("key", "")).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  // Empty user response → warn-continue
+  test("resolves when /me returns empty user", async () => {
+    const restore = mockFetch(() => Response.json({}));
+    try {
+      await expect(verifyIndexIdentity("key", "alice")).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -708,7 +708,10 @@ export async function buildDailyBriefContext(options: {
     // Best-effort identity log before each MCP session. Never blocks digest.
     try {
       const baseUrl = mcpUrl.replace(/\/mcp$/, "");
-      const meResp = await fetch(`${baseUrl}/api/auth/me`, { headers: { "x-api-key": apiKey } });
+      const meResp = await fetch(`${baseUrl}/api/auth/me`, {
+        headers: { "x-api-key": apiKey },
+        signal: AbortSignal.timeout(10_000),
+      });
       if (meResp.ok) {
         const meJson = (await meResp.json()) as {
           user?: { id: string; name: string; email: string | null };
@@ -720,9 +723,14 @@ export async function buildDailyBriefContext(options: {
             email: meJson.user.email,
           });
         }
+      } else {
+        warnings.push(`identity check failed: HTTP ${meResp.status}`);
       }
-    } catch {
-      // best-effort; never propagate
+    } catch (err) {
+      const reason = err instanceof Error && err.name === "TimeoutError"
+        ? "timeout after 10 s"
+        : err instanceof Error ? err.message : String(err);
+      warnings.push(`identity check failed: ${reason}`);
     }
     try {
       const deliveredIds = await readDeliveredIds(options.stateFile ?? "memory/heartbeat-state.json", date);

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -705,6 +705,25 @@ export async function buildDailyBriefContext(options: {
   const mcpUrl = process.env.INDEX_MCP_URL?.trim() || "https://protocol.index.network/mcp";
 
   if (apiKey) {
+    // Best-effort identity log before each MCP session. Never blocks digest.
+    try {
+      const baseUrl = mcpUrl.replace(/\/mcp$/, "");
+      const meResp = await fetch(`${baseUrl}/api/auth/me`, { headers: { "x-api-key": apiKey } });
+      if (meResp.ok) {
+        const meJson = (await meResp.json()) as {
+          user?: { id: string; name: string; email: string | null };
+        };
+        if (meJson.user) {
+          console.log("[build-daily-brief-context] authenticatedAs:", {
+            id: meJson.user.id,
+            name: meJson.user.name,
+            email: meJson.user.email,
+          });
+        }
+      }
+    } catch {
+      // best-effort; never propagate
+    }
     try {
       const deliveredIds = await readDeliveredIds(options.stateFile ?? "memory/heartbeat-state.json", date);
       const fetched = await fetchOpportunitiesFromMcp({ apiKey, mcpUrl });

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -239,6 +239,171 @@ describe("build-daily-brief-context helpers", () => {
     }
   });
 
+  test("buildDailyBriefContext identity check success does not add warnings", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.INDEX_API_KEY;
+    const originalMcpUrl = process.env.INDEX_MCP_URL;
+    const originalEdgeosKey = process.env.EDGEOS_API_KEY;
+    const originalControlPlaneUrl = process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    const originalAdminToken = process.env.ADMIN_TOKEN;
+    delete process.env.EDGEOS_API_KEY;
+    delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    delete process.env.ADMIN_TOKEN;
+    process.env.INDEX_API_KEY = "test-key";
+    process.env.INDEX_MCP_URL = "https://test.example.com/mcp";
+
+    const opportunityText = "1. Nathan Price\n   <!-- digest-opportunity:id=opp-mcp-1 -->\n   builds AI agents\n   status: pending\n   profileUrl: https://index.network/u/abc\n   acceptUrl: https://index.network/c/xyz\n   feedCategory: connection";
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("open-meteo") || url.includes("weather.gov")) {
+        return new Response("unavailable", { status: 503, statusText: "Service Unavailable" });
+      }
+      if (url === "https://test.example.com/api/auth/me") {
+        return Response.json({ user: { id: "u1", name: "Alice", email: "alice@test.com" } });
+      }
+      if (url === "https://test.example.com/mcp") {
+        const body = JSON.parse(init?.body as string ?? "{}") as { method: string };
+        if (body.method === "initialize") {
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+        }
+        if (body.method === "tools/call") {
+          return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: opportunityText }] } });
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const context = await buildDailyBriefContext({ date: "2026-06-10", userFiles: [] });
+      // Identity check succeeded — no identity-related warnings
+      const identityWarnings = context.diagnostics.warnings.filter((w: string) => w.startsWith("identity check"));
+      expect(identityWarnings).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalApiKey === undefined) delete process.env.INDEX_API_KEY;
+      else process.env.INDEX_API_KEY = originalApiKey;
+      if (originalMcpUrl === undefined) delete process.env.INDEX_MCP_URL;
+      else process.env.INDEX_MCP_URL = originalMcpUrl;
+      if (originalEdgeosKey === undefined) delete process.env.EDGEOS_API_KEY;
+      else process.env.EDGEOS_API_KEY = originalEdgeosKey;
+      if (originalControlPlaneUrl === undefined) delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+      else process.env.EDGE_AGENT_CONTROL_PLANE_URL = originalControlPlaneUrl;
+      if (originalAdminToken === undefined) delete process.env.ADMIN_TOKEN;
+      else process.env.ADMIN_TOKEN = originalAdminToken;
+    }
+  });
+
+  test("buildDailyBriefContext identity check non-ok pushes warning", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.INDEX_API_KEY;
+    const originalMcpUrl = process.env.INDEX_MCP_URL;
+    const originalEdgeosKey = process.env.EDGEOS_API_KEY;
+    const originalControlPlaneUrl = process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    const originalAdminToken = process.env.ADMIN_TOKEN;
+    delete process.env.EDGEOS_API_KEY;
+    delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    delete process.env.ADMIN_TOKEN;
+    process.env.INDEX_API_KEY = "test-key";
+    process.env.INDEX_MCP_URL = "https://test.example.com/mcp";
+
+    const opportunityText = "1. Nathan Price\n   <!-- digest-opportunity:id=opp-mcp-1 -->\n   builds AI agents\n   status: pending\n   profileUrl: https://index.network/u/abc\n   acceptUrl: https://index.network/c/xyz\n   feedCategory: connection";
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("open-meteo") || url.includes("weather.gov")) {
+        return new Response("unavailable", { status: 503, statusText: "Service Unavailable" });
+      }
+      // Return 503 from /me endpoint
+      if (url === "https://test.example.com/api/auth/me") {
+        return new Response("Service Unavailable", { status: 503 });
+      }
+      if (url === "https://test.example.com/mcp") {
+        const body = JSON.parse(init?.body as string ?? "{}") as { method: string };
+        if (body.method === "initialize") {
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+        }
+        if (body.method === "tools/call") {
+          return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: opportunityText }] } });
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const context = await buildDailyBriefContext({ date: "2026-06-10", userFiles: [] });
+      expect(context.diagnostics.warnings).toContain("identity check failed: HTTP 503");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalApiKey === undefined) delete process.env.INDEX_API_KEY;
+      else process.env.INDEX_API_KEY = originalApiKey;
+      if (originalMcpUrl === undefined) delete process.env.INDEX_MCP_URL;
+      else process.env.INDEX_MCP_URL = originalMcpUrl;
+      if (originalEdgeosKey === undefined) delete process.env.EDGEOS_API_KEY;
+      else process.env.EDGEOS_API_KEY = originalEdgeosKey;
+      if (originalControlPlaneUrl === undefined) delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+      else process.env.EDGE_AGENT_CONTROL_PLANE_URL = originalControlPlaneUrl;
+      if (originalAdminToken === undefined) delete process.env.ADMIN_TOKEN;
+      else process.env.ADMIN_TOKEN = originalAdminToken;
+    }
+  });
+
+  test("buildDailyBriefContext identity check fetch error pushes warning", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.INDEX_API_KEY;
+    const originalMcpUrl = process.env.INDEX_MCP_URL;
+    const originalEdgeosKey = process.env.EDGEOS_API_KEY;
+    const originalControlPlaneUrl = process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    const originalAdminToken = process.env.ADMIN_TOKEN;
+    delete process.env.EDGEOS_API_KEY;
+    delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+    delete process.env.ADMIN_TOKEN;
+    process.env.INDEX_API_KEY = "test-key";
+    process.env.INDEX_MCP_URL = "https://test.example.com/mcp";
+
+    const opportunityText = "1. Nathan Price\n   <!-- digest-opportunity:id=opp-mcp-1 -->\n   builds AI agents\n   status: pending\n   profileUrl: https://index.network/u/abc\n   acceptUrl: https://index.network/c/xyz\n   feedCategory: connection";
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("open-meteo") || url.includes("weather.gov")) {
+        return new Response("unavailable", { status: 503, statusText: "Service Unavailable" });
+      }
+      // Throw network error from /me endpoint
+      if (url === "https://test.example.com/api/auth/me") {
+        throw new Error("ECONNREFUSED");
+      }
+      if (url === "https://test.example.com/mcp") {
+        const body = JSON.parse(init?.body as string ?? "{}") as { method: string };
+        if (body.method === "initialize") {
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+        }
+        if (body.method === "tools/call") {
+          return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: opportunityText }] } });
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const context = await buildDailyBriefContext({ date: "2026-06-10", userFiles: [] });
+      expect(context.diagnostics.warnings).toContain("identity check failed: ECONNREFUSED");
+      // Digest still completes — never-throw contract preserved
+      expect(context.diagnostics.opportunitySource).toBe("mcp");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalApiKey === undefined) delete process.env.INDEX_API_KEY;
+      else process.env.INDEX_API_KEY = originalApiKey;
+      if (originalMcpUrl === undefined) delete process.env.INDEX_MCP_URL;
+      else process.env.INDEX_MCP_URL = originalMcpUrl;
+      if (originalEdgeosKey === undefined) delete process.env.EDGEOS_API_KEY;
+      else process.env.EDGEOS_API_KEY = originalEdgeosKey;
+      if (originalControlPlaneUrl === undefined) delete process.env.EDGE_AGENT_CONTROL_PLANE_URL;
+      else process.env.EDGE_AGENT_CONTROL_PLANE_URL = originalControlPlaneUrl;
+      if (originalAdminToken === undefined) delete process.env.ADMIN_TOKEN;
+      else process.env.ADMIN_TOKEN = originalAdminToken;
+    }
+  });
+
   test("buildDailyBriefContext falls back to NWS when Open-Meteo rate limits", async () => {
     const originalFetch = globalThis.fetch;
     const originalEdgeosKey = process.env.EDGEOS_API_KEY;


### PR DESCRIPTION
## Summary

Root-cause fix for the AgentVillage daily digest bug where User C received User A's opportunities because User C's `HERMES_HOME` had User A's `INDEX_API_KEY` stored.

## Bug

`stage-daily-brief.ts` reads `INDEX_API_KEY` from `$HERMES_HOME/.env` and uses it to authenticate the MCP session. If the wrong key is stored, the digest pipeline authenticates as the wrong user, fetches that user's opportunities, mints their connect links, and stages them into the wrong person's Kanban board.

## Fix

### 1. Install-time identity verification (`install_index.ts`)
- Add `normalizeTelegramHandle()` — strips `@`, `t.me/` URL prefix, lowercases; matches SQL normalization in `database.adapter.ts:4483`
- Add `verifyIndexIdentity()` — calls `GET /api/auth/me` with the key before any disk write:
  - HTTP 401/403 → `exit 1` (invalid/expired key)
  - Telegram handle mismatch → `exit 1` (wrong key for this resident)
  - Network error / timeout (10 s) → warn + continue
  - Missing telegram social on profile → warn + continue
  - No `--telegram-handle` flag → log identity only, skip comparison
- Make `installIndex()` async; `await verifyIndexIdentity()` before first `upsertEnvVar`

### 2. Async wiring (`install.ts`)
- `async function main(): Promise<void>`
- `await installIndex()`
- `main().catch((err) => { console.error(err); process.exit(1); })`

### 3. Digest runtime logging (`build-daily-brief-context.ts`)
- Best-effort `GET /api/auth/me` call before `fetchOpportunitiesFromMcp`; logs `authenticatedAs: { id, name, email }`
- Always caught, never propagates — digest run never blocked

## Testing

Backend tests (in companion PR on indexnetwork/index): `backend/tests/auth-me-apikey.spec.ts` — 4 tests, 4 pass:
- API key resolves correctly on `GET /api/auth/me`
- Two API keys resolve to two distinct users (cross-resolution regression test)
- Invalid key → guard throws
- Missing auth → guard throws

## Related

Companion backend PR: indexnetwork/index — guard swap on `GET /api/auth/me` (`AuthGuard` → `AuthOrApiKeyGuard`)