### PR TITLE
feat(skills): add skill-atlas — attendees build skills for their own agents, with optional Edge Book capability registration

### DIFF
--- a/skills/.claude-plugin/marketplace.json
+++ b/skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "agentvillage",
       "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery.",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentvillage",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery skills for the Agent Village.",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "skills": "./",
   "author": {
     "name": "Edge City",

--- a/skills/.codex-plugin/plugin.json
+++ b/skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentvillage",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery.",
   "author": {
     "name": "Edge City",

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,12 +4,13 @@ Agent skills for **Edge Esmeralda 2026** (May 30 – Jun 27, Healdsburg, CA). Sh
 
 ## What you get
 
-Four skill bundles that give your agent Edge Esmeralda knowledge and live API access:
+Five skill bundles that give your agent Edge Esmeralda knowledge and live API access:
 
 - **edge-esmeralda** — popup constants (popup id, week dates, themes), attendee directory field semantics, curated wiki/website/newsletter knowledge base, and the onboarding pointer for obtaining EdgeOS tokens.
 - **edgeos** — backend-generic EdgeOS API recipes: events, RSVPs, venues, attendee directory, and your own profile lookup.
 - **geo-esmeralda** — Geo knowledge graph access through the Geo CLI package: ontology, fixed graph tools, guarded native read-only queries, and attendee-authored content/photo creation.
 - **index-network** — Index Network discovery: onboarding ritual, opportunity surfacing, voice exemplars, cron prompts for welcome/digest flows, and heartbeat tasks.
+- **skill-atlas** — lets attendees build skills for their own agents from their expertise: research-informed expert interview, Skill Atlas card with validation, and full skill-folder generation with the expert's human-in-the-loop gates preserved. Subsidiary feature: with consent, the finished skill can be advertised as a capability on the attendee's [Edge Book](https://www.npmjs.com/package/edge-book) agent (fully optional — registrations queue locally and advertise automatically once `edge-book init` has run).
 
 The skills cross-reference each other. `edge-esmeralda` supplies the popup id that `edgeos` recipes need. `geo-esmeralda` handles Geo knowledge graph-backed knowledge and attendee-authored writes, and `index-network` handles discovery and intent-based matching. Install all four together.
 

--- a/skills/openclaw.plugin.json
+++ b/skills/openclaw.plugin.json
@@ -2,6 +2,6 @@
   "id": "agentvillage-skills",
   "name": "AgentVillage Skills",
   "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, Geo knowledge graph access, and Index Network discovery.",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "skills": ["."]
 }

--- a/skills/skill-atlas/SKILL.md
+++ b/skills/skill-atlas/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: skill-atlas
+description: "Lets an attendee build skills for their own agent from their tacit expertise: a research-informed expert interview produces a Skill Atlas card, then generates the complete installable skill folder with the expert's human-in-the-loop gates preserved. Optionally, with consent, advertises the finished skill as a capability on their Edge Book agent. Use when an attendee wants to turn what they know into a skill for their agent, create a Skill Atlas card, contribute expertise to the village skill commons, or build a skill that keeps a human in the loop. Do NOT use for generic prompt writing, quick one-off advice, or editing an existing skill the attendee already has."
+version: 1.0.0
+author: Antony Evans
+tags: [edge-esmeralda, skill-atlas, expertise, human-in-the-loop, edge-book]
+required_environment_variables:
+  - name: EDGE_BOOK_CLI
+    required_for: optional — overrides how the Edge Book CLI is invoked (default `edge-book` on PATH)
+  - name: EDGE_BOOK_HOME
+    required_for: optional — selects the Edge Book agent directory (Edge Book default is ~/.openclaw/edge-book)
+---
+
+# Skill Atlas
+
+Lets an attendee build skills for their own agent from their expertise. Three phases, all human-in-the-loop: research the domain, interview the expert, then (with approval) generate the complete installable skill folder. The generated skill is the product — it works on the attendee's agent immediately, with no network or backend involved.
+
+A subsidiary feature: with explicit consent, the finished skill can also be advertised as a capability on the attendee's Edge Book agent so their friends can discover it. This is optional and deferred — if Edge Book is not installed (`npm i -g edge-book`, then `edge-book init`), the registration queues locally and completes automatically whenever it is.
+
+## Output Contract
+
+Produces:
+1. `skill-card.yaml` — the public Skill Atlas directory card.
+2. `expertise-map.md` — the private working artifact (cues, criteria, examples, limits, validation cases).
+3. On explicit approval: a complete generated skill folder (`SKILL.md` + references + evals) per `references/skill-generation.md`.
+4. On explicit consent: a capability record in the local registry, advertised on the user's Edge Book agent when available (a signed `capability_advertisement` post via `edge-book capability advertise`).
+
+Does not produce:
+- A full skill folder without explicit approval.
+- A capability advertisement without explicit consent.
+- Payment, marketplace, or reputation infrastructure.
+- Claims that a single-expert skill is broadly validated before scenario or community testing.
+
+## Workflow
+
+### Step 0: Sync Pending Registrations
+
+At the start of every run, flush any previously generated capabilities that are still waiting for Edge Book:
+
+```
+bun scripts/register_capability.ts sync
+```
+
+If the script reports newly advertised capabilities, tell the user. If it reports `pending` (Edge Book not installed or not initialized yet), continue silently.
+
+### Step 1: Classify the Request
+
+- Expert has tacit knowledge but no precise workflow: continue.
+- User wants a Skill Atlas card or community skill profile: continue.
+- User already has a complete, precise SOP: skip the interview — go straight to Step 7 (generation) using their brief.
+- User wants advice, not a reusable skill: answer normally; this skill does not apply.
+
+### Step 2: Load Prior Context
+
+Read `references/learnings.md` and summarize only the 3-5 relevant points. Then read `references/expert-elicitation.md` for the interview method and `assets/skill-atlas-card-template.yaml` for the output schema.
+
+### Step 3: Run Domain Research Before the Interview
+
+Research must happen before the human interview. Follow `references/domain-research.md`. The goal is to make the interview technically specific and give the expert concrete options to accept, reject, or adapt.
+
+Present the synthesis before the interview:
+- 3-5 nearby skill directions the expert could choose from.
+- Technical terms and tools that may matter.
+- 5-8 research-informed probes.
+- Known failure modes and novice traps to validate.
+
+### Step 4: Run the Expert Interview
+
+Use `references/expert-elicitation.md`. Ask 3-5 questions at a time. Start with a real hard case, not an abstract process description.
+
+Interview sequence:
+1. Scope the repeatable task, target user, trigger, negative trigger, and desired output.
+2. Build a 3-6 stage task diagram.
+3. Walk through one difficult real incident.
+4. Probe for cues, anomalies, discriminations, tradeoffs, and "what would change your mind."
+5. Capture good, messy, edge, negative, and novice-trap examples.
+6. Convert defensible judgment into if/then/because rules; convert fuzzy judgment into rubric dimensions; convert "the skill should not decide alone" into human review gates.
+7. Ask the expert to define 3-5 validation scenarios.
+
+### Step 5: Draft and Review the Skill Card
+
+Create `skill-card.yaml` using `assets/skill-atlas-card-template.yaml`. Mark validation status honestly:
+- `captured`: interview complete only.
+- `expert-reviewed`: expert approved the card.
+- `scenario-tested`: skill passed expert scenarios.
+- `community-tested`: at least one other user used or reviewed it.
+
+Validate the saved card:
+
+```
+bun scripts/validate_skill_card.ts path/to/skill-card.yaml
+```
+
+If Bun/Node is unavailable, manually check every required field against the template. Then ask the expert:
+
+"What is wrong, overstated, missing, or too generic in this card?"
+
+Revise once before continuing.
+
+### Step 6: Build the Expertise Map
+
+Create `expertise-map.md` using `assets/expertise-map-template.md`. Include the cognitive demands table from `assets/cognitive-demands-table.md` for the judgment-heavy step.
+
+The expertise map is the private working artifact. The skill card is the public directory artifact.
+
+### Step 7: Propose Skill Candidates and Get Approval
+
+Present 3-5 possible skills generated from the expertise map. Each option must include: skill name, user trigger, output artifact, why it is useful to the community, validation scenarios available, and one risk or known limit.
+
+Recommend one default. Ask the human to choose: stop at the Skill Atlas card, or proceed to full skill generation. Never generate without explicit approval.
+
+### Step 8: Generate the Skill
+
+On approval, follow `references/skill-generation.md` end to end. Key obligations:
+- Treat the expert's scenarios as the eval seed set.
+- Preserve every human review gate the expert defined — the generated skill must pause for the human at those points.
+- Include `skill-card.yaml` inside the generated folder.
+- Preserve validation status and known limits; do not harden fuzzy judgment into fake rules.
+- Tell the user where to install the folder for their host (Claude Code, OpenClaw, or Hermes — install paths are in `references/skill-generation.md`).
+
+### Step 9: Register the Capability
+
+Follow `references/capability-registration.md`. In short:
+
+1. Ask for consent: "Want me to advertise this skill as a capability on your Edge Book agent? It shares the skill's name, version, and a one-line summary — signed by your agent and visible to your Edge Book friends. Never the private expertise map." Proceed only on yes.
+2. Run:
+
+```
+bun scripts/register_capability.ts register path/to/skill-card.yaml
+```
+
+3. The script writes the capability to the local registry. If Edge Book is installed and initialized, it runs `edge-book capability advertise` immediately — the capability becomes a signed advertisement on the user's agent. If not, the record stays `pending` and syncs automatically later — via Step 0 of any future run, or the `heartbeat.md` task on hosts with heartbeat ticks.
+
+Tell the user which of the two outcomes happened. To withdraw a capability later: `edge-book capability deprecate <capability-id>` (the id is in the registry).
+
+### Step 10: Closing Feedback Gate
+
+Ask one question: "Did this capture your expertise accurately? Any corrections, exceptions, or examples I should learn from?"
+
+Route feedback:
+- Behavioral correction: append to `references/learnings.md`.
+- Factual exception: append to `references/edge-cases.md`.
+- "Never do X again": update `## Rules`.
+
+## Gotchas
+
+- **Symptom** — The generated card reads like a generic SOP anyone could write. **Cause** — The interview started with abstract process questions instead of a real difficult case. **Fix** — Re-run the critical incident section and probe cues, tradeoffs, and what novices missed.
+- **Symptom** — The interview asks obvious or technically naive questions. **Cause** — The research-before-interview step was skipped or too shallow. **Fix** — Pause the interview, run the `references/domain-research.md` procedure, then return with 3-5 informed skill directions and specific probes.
+- **Symptom** — The generated skill turns nuanced expert judgment into brittle thresholds. **Cause** — Fuzzy judgment was forced into fake rules. **Fix** — Move the judgment into rubric dimensions and examples unless the expert can defend the threshold with cases.
+- **Symptom** — The card looks impressive but has no proof it works. **Cause** — Expert approval was treated as validation. **Fix** — Require 3-5 expert-authored scenarios before marking anything `scenario-tested`.
+- **Symptom** — `register_capability.ts sync` keeps reporting pending forever. **Cause** — The Edge Book CLI is not installed, or `edge-book init` has not been run; the record is safely queued. **Fix** — Nothing to fix locally. Tell the user once that registration will complete after `npm i -g edge-book` and `edge-book init`; do not retry in a loop within one session.
+
+## Rules
+
+- Research must happen before the expert interview.
+- Always present adjacent options from research so the expert can choose, reject, or combine approaches.
+- Start the interview from a real hard case before asking for process.
+- Capture examples and counterexamples as first-class assets, not optional notes.
+- Never mark a single-expert card as community-tested.
+- Never generate the full skill folder without explicit user approval.
+- Never advertise a capability without explicit user consent, and never transmit the private expertise map — only the skill's name, version, and one-line summary are shared.
+- Never invent profile data, handles, or URLs for the capability record; use values verbatim from the skill card the expert approved.
+- Do not involve money, pricing, or marketplace mechanics unless the user explicitly requests it.
+- Prefer honest validation status over polished claims.

--- a/skills/skill-atlas/assets/cognitive-demands-table.md
+++ b/skills/skill-atlas/assets/cognitive-demands-table.md
@@ -1,0 +1,3 @@
+| Task stage | Hard judgment | Cues | Expert strategy | Novice trap | Failure sign | Recovery move | Eval case |
+|---|---|---|---|---|---|---|---|
+|  |  |  |  |  |  |  |  |

--- a/skills/skill-atlas/assets/expertise-map-template.md
+++ b/skills/skill-atlas/assets/expertise-map-template.md
@@ -1,0 +1,61 @@
+# Expertise Map
+
+## Domain
+
+## Expert
+
+## Expertise Basis
+
+## Community Context
+
+## Useful Tasks
+
+## Target User
+
+## Trigger
+
+## Negative Trigger
+
+## Output Contract
+
+## Task Diagram
+
+1.
+2.
+3.
+
+## Judgment-Heavy Step
+
+## Critical Incident
+
+## Key Cues
+
+## Decision Criteria
+
+## Rubric Dimensions
+
+## Human Review Points
+
+## Examples
+
+### Good
+
+### Messy
+
+### Edge
+
+### Negative
+
+### Novice Trap
+
+## Cognitive Demands Table
+
+Paste or complete `assets/cognitive-demands-table.md`.
+
+## Validation Scenarios
+
+## Known Limits
+
+## Skill Candidates
+
+## Recommended Next Step

--- a/skills/skill-atlas/assets/skill-atlas-card-template.yaml
+++ b/skills/skill-atlas/assets/skill-atlas-card-template.yaml
@@ -1,0 +1,33 @@
+title: ""
+slug: ""
+expert: ""
+expertise_basis: ""
+community_context: ""
+task: ""
+target_user: ""
+trigger: ""
+negative_trigger: ""
+output_contract: ""
+judgment_heavy_step: ""
+key_cues: []
+decision_criteria: []
+examples:
+  good: ""
+  messy: ""
+  edge: ""
+  negative: ""
+  novice_trap: ""
+novice_traps: []
+validation_cases: []
+known_limits: []
+status: "captured"
+artifacts:
+  skill_card: true
+  expertise_map: true
+  skill_folder: false
+links:
+  agent_card_url: ""
+  github_url: ""
+  contact: ""
+version: "0.1"
+updated: ""

--- a/skills/skill-atlas/evals/evals.json
+++ b/skills/skill-atlas/evals/evals.json
@@ -1,0 +1,57 @@
+[
+  {
+    "skill": "skill-atlas",
+    "query": "I know a lot about agent payments but I do not know how to turn that into a skill for my agent.",
+    "expected_behavior": [
+      "Classifies this as expert elicitation, not a ready-made SOP",
+      "Runs domain research per references/domain-research.md before interviewing the expert",
+      "Presents adjacent skill directions before asking detailed interview questions"
+    ]
+  },
+  {
+    "skill": "skill-atlas",
+    "query": "Build a skill from this complete SOP: fetch orders, normalize CSV, upload to Shopify, then email a report.",
+    "expected_behavior": [
+      "Recognizes the user already has a workflow brief",
+      "Skips the interview and proceeds to generation per references/skill-generation.md",
+      "Still requires explicit approval of the design summary before writing files"
+    ]
+  },
+  {
+    "skill": "skill-atlas",
+    "query": "Create a public Skill Atlas card for my biosecurity expertise, but do not build the full skill yet.",
+    "expected_behavior": [
+      "Produces a skill-card.yaml artifact and validates it",
+      "Does not generate a full SKILL.md folder",
+      "Marks validation status no higher than expert-reviewed unless scenarios have been tested"
+    ]
+  },
+  {
+    "skill": "skill-atlas",
+    "query": "Interview me about my expertise and make a skill from it.",
+    "expected_behavior": [
+      "Starts from research-informed options, not generic process questions",
+      "Asks for a difficult real incident",
+      "Captures validation scenarios before recommending full skill generation",
+      "Preserves the expert's human review gates as hard pauses in the generated skill"
+    ]
+  },
+  {
+    "skill": "skill-atlas",
+    "query": "The skill is generated. Add it to my profile.",
+    "expected_behavior": [
+      "Asks for explicit consent naming exactly what is advertised (name, version, one-line summary) before registering",
+      "Runs scripts/register_capability.ts register with the skill card path",
+      "If Edge Book is not installed or not initialized, reports the capability is queued and will advertise automatically once edge-book init has run",
+      "Never transmits the expertise map or example content"
+    ]
+  },
+  {
+    "skill": "skill-atlas",
+    "query": "What's the weather at Edge Esmeralda today?",
+    "expected_behavior": [
+      "Does not activate skill-atlas",
+      "Answers normally or routes to the appropriate skill"
+    ]
+  }
+]

--- a/skills/skill-atlas/heartbeat.md
+++ b/skills/skill-atlas/heartbeat.md
@@ -1,0 +1,22 @@
+# Skill Atlas — Heartbeat Tasks
+
+For hosts with a heartbeat tick (OpenClaw, Hermes). Hosts without one get the same behavior from Step 0 of every skill-atlas run.
+
+## Task: edge-book-capability-sync
+
+**Cadence:** at most once per day. Skip silently on every other tick.
+
+**Condition:** run only when BOTH are true:
+1. `~/.agentvillage/capability-registry.json` exists and contains at least one record with `"registration": "pending"`.
+2. The Edge Book CLI is available — `edge-book capability list` exits 0 (or `EDGE_BOOK_CLI` is set and works).
+
+**Action:**
+
+```
+bun scripts/register_capability.ts sync
+```
+
+**Reporting:**
+- If the sync advertised one or more capabilities: send the user one short message naming which skills are now advertised on their Edge Book agent.
+- If everything is still pending or there was nothing to do: reply silently per the host's silent-turn convention. Do not message the user about pending records — they have already been told once at generation time.
+- Never loop or retry within a single tick; the next tick is the retry.

--- a/skills/skill-atlas/references/capability-registration.md
+++ b/skills/skill-atlas/references/capability-registration.md
@@ -1,0 +1,68 @@
+# Capability Registration — Edge Book
+
+How a generated skill becomes an advertised capability on the attendee's Edge Book agent — immediately if Edge Book is installed and initialized, or automatically later when it is.
+
+**Edge Book** (`npm i -g edge-book`, Node 20+) is the permissioned agent-to-agent network: each agent holds a signed Agent Card, friends connect by explicit mutual consent, and everything — relationships, grants, posts — is cryptographically signed and stored on the user's own machine. Its post taxonomy includes capability advertisements natively:
+
+```
+edge-book capability advertise --name <slug> --version <v> --summary <s>   # → Capability cap_…
+edge-book capability list
+edge-book capability deprecate <capability-id>
+```
+
+An advertisement is a signed `capability_advertisement` post (schema `edge-book/capability/0.1`) bound to the agent's DID, governed by Edge Book's grant model — so "added to the user's profile" means: their agent now verifiably advertises the capability to the friends they have chosen.
+
+## Design
+
+Registration is **local-first with deferred sync**:
+
+1. Every registered capability is a record in the local registry, regardless of Edge Book availability. The registry is the source of truth for what skills this user has minted.
+2. If Edge Book is installed and the identity is initialized, the capability is advertised immediately and marked `registered` (the `cap_…` id is kept for a future `capability deprecate`).
+3. If not, the record stays `pending` and is advertised by the next `sync` — which runs at Step 0 of every skill-atlas session and, on hosts with heartbeat ticks, via this skill's `heartbeat.md` task. Nothing is lost if the user installs Edge Book weeks later.
+
+## Local Registry
+
+- **Path:** `~/.agentvillage/capability-registry.json` (created on first use; shared across hosts so a capability minted in Claude Code still syncs from OpenClaw).
+- **Record fields:** `slug`, `title`, `version`, `summary`, `card_status`, `skill_card_path`, `created_at`, `registration` (`pending` | `registered` | `failed`), `registered_at`, `capability_id`.
+- `failed` means Edge Book was reachable but rejected the advertise — the payload needs human attention; re-run `register` after fixing the card. `pending` records retry automatically.
+
+## Edge Book Detection
+
+The script probes `edge-book capability list`:
+
+- Command not found → Edge Book not installed → queue (`pending`).
+- Non-zero exit → CLI present but identity not initialized (`edge-book init` not yet run) → queue (`pending`).
+- Exit 0 → ready → advertise.
+
+Environment overrides (both optional):
+
+- `EDGE_BOOK_CLI` — command used to invoke the CLI (default `edge-book` on PATH; multi-word values like `node /path/dist/edge-book.js` work).
+- `EDGE_BOOK_HOME` — passed through to the CLI; selects the agent directory (Edge Book's own default is `~/.openclaw/edge-book`).
+
+## What Is Shared
+
+Exactly three values, all derived from the expert-approved skill card:
+
+| Advertisement field | Source |
+| --- | --- |
+| `--name` | card `slug` |
+| `--version` | card `version` (default `1.0.0`) |
+| `--summary` | `"{title}: {task}"`, truncated to 200 chars |
+
+The expertise map, examples, validation scenarios, cues, and decision criteria never leave the machine. Visibility of the advertisement itself follows Edge Book's grant model — friends the user has explicitly accepted.
+
+## Consent and Privacy
+
+- Ask for explicit consent before the first `register` call for each skill, naming exactly what is advertised: the skill's name, version, and one-line summary, signed by their agent and visible to their Edge Book friends. Never register on inference.
+- If the user later wants the capability withdrawn: `edge-book capability deprecate <capability-id>` (the id is in the registry), then delete the registry record.
+- Do not fabricate any field — every value comes verbatim from the expert-approved skill card.
+
+## Script Commands
+
+```
+bun scripts/register_capability.ts register path/to/skill-card.yaml   # add to registry + advertise if Edge Book is ready
+bun scripts/register_capability.ts sync                               # advertise all pending records
+bun scripts/register_capability.ts status                             # print the registry as JSON
+```
+
+Runs on Bun or Node 22.18+ (native TypeScript). If neither runtime is available, run the `edge-book capability advertise` command directly with the three fields above and note it in the registry manually.

--- a/skills/skill-atlas/references/domain-research.md
+++ b/skills/skill-atlas/references/domain-research.md
@@ -1,0 +1,47 @@
+# Domain Research Procedure
+
+Run this before every expert interview. The interviewer must know the domain language, nearby methods, and likely failure modes before asking the expert anything. This procedure is host-neutral: it uses whatever research tools the host provides and degrades gracefully when one is missing.
+
+## Research Modes
+
+Run every mode the host supports. Skip a mode silently if the host lacks the tool.
+
+### Mode 1: Skill marketplace prior art
+
+Search existing skill directories for skills that solve the same or an adjacent problem. Extract structural patterns, not content.
+
+- `https://skills.sh/?q=[keyword]` — most curated; check install counts.
+- `https://skillsmp.com/search?q=[keyword]` — largest raw index; favor higher-starred results.
+- `https://github.com/anthropics/skills` — official reference patterns.
+
+These directories have intermittent availability. If a fetch fails, skip the source and note it — do not retry more than once.
+
+For each relevant hit (up to 3): note its process structure, human-in-the-loop design, output format, and guardrails. Do not copy skill content verbatim.
+
+### Mode 2: Deep web research
+
+Use the host's web search and fetch tools to find: best practices, established frameworks, standard terminology, common failure modes, and expert opinions in the domain. Favor practitioner sources over marketing content.
+
+### Mode 3: Community knowledge
+
+If the `geo-esmeralda` or `edgeos` skills are installed, query them for village-local context: attendees with related expertise, prior community content on the topic, and events where the skill could be tested. This grounds the skill in what the community actually needs.
+
+### Mode 4: Local synthesis
+
+Search the agent's local workspace and memory for prior notes on the topic. Synthesize across files: key themes, contradictions, gaps.
+
+## Required Synthesis Output
+
+Consolidate all modes into one synthesis with exactly these sections:
+
+1. **Domain map** — the 5-10 concepts, tools, and methods that structure this domain.
+2. **Adjacent skill options** — 3-5 distinct directions the expert's skill could take, each one sentence.
+3. **Technical probes** — 5-8 specific, research-informed questions for the interview.
+4. **Likely validation scenarios** — 2-3 candidate test cases the expert can refine.
+5. **Known anti-patterns** — failure modes and novice traps documented in the domain.
+
+## Quality Bar
+
+- If the synthesis could have been written without doing the research, it is too shallow — redo Modes 1-2 with narrower queries.
+- Distinguish high-confidence findings from inference. Flag gaps rather than filling them with speculation.
+- Ground claims in what sources actually say; cite specifics (numbers, named examples) where possible.

--- a/skills/skill-atlas/references/edge-cases.md
+++ b/skills/skill-atlas/references/edge-cases.md
@@ -1,0 +1,3 @@
+# Edge Cases
+
+- No edge cases recorded yet.

--- a/skills/skill-atlas/references/expert-elicitation.md
+++ b/skills/skill-atlas/references/expert-elicitation.md
@@ -1,0 +1,134 @@
+# Expert Elicitation Method
+
+Use this reference during the expert interview. The goal is to extract tacit judgment, not to document an obvious SOP.
+
+## Principles
+
+- Research first. The interviewer should know the domain language, nearby methods, and likely failure modes before asking the expert questions.
+- Incident first. A real difficult case reveals cues and tradeoffs that abstract questions hide.
+- Cues before rules. Experts often know what matters before they can explain the rule.
+- Examples are assets. Good, bad, messy, edge, and negative examples become skill assets and evals.
+- Validation requires scenarios. "Looks good" is weak evidence.
+
+## 50-Minute Interview Flow
+
+### 1. Frame and Scope
+
+Ask:
+- What repeatable task do you do better than a competent novice?
+- Who would use this skill?
+- What input would they give it?
+- What should the skill produce?
+- What should this skill refuse or hand off?
+
+Output: target user, task, trigger, negative trigger, output contract.
+
+### 2. Task Diagram
+
+Ask the expert to break the work into 3-6 stages.
+
+For each stage ask:
+- What is happening here?
+- What makes this stage hard?
+- Which stage requires the most judgment?
+- Where do novices most often go wrong?
+
+Output: task stages and judgment-heavy step.
+
+### 3. Critical Incident
+
+Ask for one difficult recent case. Walk through it from start to finish.
+
+Probe:
+- What was the first cue that this was not routine?
+- What information did you seek?
+- What information did you ignore?
+- What tradeoff mattered most?
+- What options did you consider?
+- What would have changed your mind?
+- What did someone less experienced miss?
+- How did you know the final answer was good enough?
+
+Output: cues, discriminations, decision points, uncertainty, recovery moves.
+
+### 4. Knowledge Audit
+
+Probe categories:
+- Anomaly detection: what looks off before it is obvious?
+- Typicality: how do you know whether this is a normal case?
+- Big picture: what larger context changes the answer?
+- Tricks of the trade: what shortcut or heuristic do you use?
+- Mental simulation: what future consequence do you imagine?
+- Recovery: what do you do when the first approach fails?
+- Novice trap: what plausible answer is wrong?
+- Stop condition: when should the agent ask a human?
+
+Output: cognitive demands and novice traps.
+
+### 5. Examples and Counterexamples
+
+Capture:
+- Good input with good output.
+- Messy real-world input.
+- Edge case.
+- Negative trigger.
+- Bad output the skill must avoid.
+- Novice-trap case.
+
+Output: assets and eval seed cases.
+
+### 6. Decision Criteria
+
+For each judgment, choose one:
+- If/then/because rule: use only when the expert can defend the rule with examples.
+- Rubric dimension: use for fuzzy judgment.
+- Human review point: use when the skill should not decide alone.
+
+Output: rules, rubric dimensions, human review gates.
+
+### 7. Validation Plan
+
+Ask:
+- What 3-5 scenarios would prove this skill is useful?
+- What must a good answer include?
+- What would make you reject the skill?
+- Which scenario is the novice trap?
+
+Output: validation scenarios.
+
+## Cognitive Demands Table
+
+Use the template in `assets/cognitive-demands-table.md`.
+
+Each row should capture:
+- Task stage.
+- Hard judgment.
+- Cues.
+- Expert strategy.
+- Novice trap.
+- Failure sign.
+- Recovery move.
+- Eval case.
+
+## Research-Informed Option Crafting
+
+Before the interview, the research synthesis should give the expert options such as:
+- Alternative skill scopes.
+- Adjacent methodologies.
+- Tool or platform choices.
+- Possible output formats.
+- Validation methods.
+
+Ask the expert to react:
+- Which option is closest?
+- Which is wrong for this domain?
+- Which two should be combined?
+- What is missing from all of them?
+
+## Anti-Patterns
+
+- Asking "describe your process" before a real case.
+- Accepting generic answers without drilling into cues.
+- Treating expert confidence as validation.
+- Hiding uncertainty or known limits in the public card.
+- Letting directory polish outrun actual skill quality.

--- a/skills/skill-atlas/references/learnings.md
+++ b/skills/skill-atlas/references/learnings.md
@@ -1,0 +1,18 @@
+# Learnings
+
+## What Has Worked
+
+- No observations yet.
+
+## What Has Failed
+
+- No observations yet.
+
+## Patterns and Preferences
+
+- Research should precede the expert interview so questions are technically relevant and can present adjacent options for the expert to shape.
+
+## Open Questions
+
+- Which Skill Atlas card fields should be public by default versus private to the contributor?
+- What is the right cadence for re-validating a registered capability whose underlying skill has changed?

--- a/skills/skill-atlas/references/skill-generation.md
+++ b/skills/skill-atlas/references/skill-generation.md
@@ -1,0 +1,92 @@
+# Skill Generation Procedure
+
+Generates a complete, installable skill folder from an approved expertise map and skill card. Run only after the user explicitly approves a candidate in Step 7 of SKILL.md.
+
+## Contents
+
+1. Design before building
+2. Folder structure
+3. SKILL.md rules
+4. Human-in-the-loop design (mandatory)
+5. References, scripts, assets, evals
+6. Validation checklist
+7. Install paths per host
+
+## 1. Design Before Building
+
+Most intake is already done — the expertise map holds the task, trigger, negative trigger, output contract, judgment-heavy step, examples, and validation scenarios. Before writing files, present a short design summary and get a nod:
+
+- **Name** — lowercase, hyphens, ≤64 chars, matches the folder name. Prefer gerund form (`reviewing-contracts`) or a clear noun.
+- **Description** — the highest-leverage element; spend real effort here. It is a routing signal for agents, not a label for humans. Must contain, in one single-line string: capabilities (the artifacts it produces), trigger scenarios (the outcome language a user or agent would actually use), and negative triggers (similar-looking cases that must NOT activate it). Never use YAML folded syntax (`description: >`); if the line wraps, the skill silently breaks on some hosts.
+- **Output contract** — what it produces, what it does not produce, and who consumes the output next.
+- **Process steps** — for each step: what the agent does and *why* (the reasoning principle, so it generalizes to unseen cases), which reference file it loads, whether a human is involved, and the artifact produced.
+- **Gotchas inventory** — at least 2 predicted failure modes, each as Symptom / Cause / Fix.
+
+## 2. Folder Structure
+
+```
+skill-name/
+├── SKILL.md              # SOP only — includes ## Gotchas (mandatory)
+├── skill-card.yaml       # the approved Skill Atlas card, included verbatim
+├── references/           # domain knowledge, style guides, dense rules
+│   ├── learnings.md      # starts empty — grows with use (mandatory)
+│   └── edge-cases.md     # starts empty — factual exceptions (mandatory)
+├── scripts/              # deterministic execute steps (optional)
+├── assets/               # templates and output examples (optional)
+└── evals/
+    └── evals.json        # 3+ test cases seeded from the expert's scenarios
+```
+
+No README.md, CHANGELOG.md, or library code inside the folder.
+
+## 3. SKILL.md Rules
+
+- Frontmatter: `name`, single-line `description`, `version: 1.0.0`, `author` (the expert's name, with their permission), `tags`. If the skill needs credentials, declare them under `required_environment_variables` with a `required_for` note each.
+- Under 500 lines hard limit; aim for under 150 in the body. SKILL.md is a routing layer — push all reference material into `references/`.
+- Numbered steps, third-person imperative ("Extract the…"), one word per concept, forward slashes in all paths.
+- Host-neutral language: never assume a specific host's subagents, slash commands, or UI. Where a host capability is optional (web search, heartbeat), say what to do when it is absent.
+- Mandatory `## Gotchas` section (≥2 entries, Symptom/Cause/Fix) immediately above `## Rules`.
+- `## Rules` section: include "reference files are required, not optional", the human review gates from §4, and an explicit approval gate before any irreversible action (send, publish, delete, pay).
+
+## 4. Human-in-the-Loop Design (mandatory)
+
+Every review gate the expert defined in the interview becomes a hard pause in the generated skill. For each gate:
+
+- State exactly what the agent presents to the human (prefer 3-5 options over a single output — this is the single highest-impact design decision).
+- State what counts as approval and what the agent does on rejection.
+- The agent never proceeds past a gate on silence, timeout, or its own judgment.
+
+Additionally, every judgment the expert classified as "the skill should not decide alone" must route to the human, and every fuzzy judgment becomes a rubric dimension with examples — never a fake threshold.
+
+## 5. References, Scripts, Assets, Evals
+
+- **References** — one level deep only. Files over 100 lines get a table of contents. Move the expertise map's cues, decision criteria, and rubric dimensions into a domain reference the skill reads at the judgment-heavy step.
+- **Scripts** — any step that makes an HTTP call, transforms files in a repeatable format, loops over many items, validates against a schema, or produces exact-format output ships as a script, not prose. Prefer TypeScript run with `bun` (the village runtime default); small and single-purpose; explicit error messages that tell the agent what to try next.
+- **Assets** — concrete templates of the output, not prose descriptions of it. Include the expert's good/messy/edge examples.
+- **Evals** — `evals/evals.json` with at least 3 cases: the happy path, one edge case, and one negative trigger. Each case has a `query` and verifiable `expected_behavior` assertions. Seed directly from the expert's validation scenarios; the novice-trap scenario is mandatory.
+
+## 6. Validation Checklist
+
+Before declaring the skill ready, verify:
+
+- [ ] Description is a single line and contains capabilities + triggers + negative triggers.
+- [ ] `## Gotchas` present with ≥2 grounded entries.
+- [ ] `references/learnings.md` and `references/edge-cases.md` exist.
+- [ ] Every expert-defined human gate appears as an explicit pause.
+- [ ] `evals/evals.json` has ≥3 cases including the novice trap.
+- [ ] `skill-card.yaml` is inside the folder, status and known limits unchanged.
+- [ ] No host-specific assumptions without a documented fallback.
+
+Then suggest a fresh-session test: install the skill, run the expert's 3-5 validation scenarios in a new conversation, and bring failures back as learnings. Only after those scenarios pass may the card's status move to `scenario-tested`.
+
+## 7. Install Paths Per Host
+
+Tell the user where to put the generated folder:
+
+| Host | Path |
+| --- | --- |
+| Claude Code | `~/.claude/skills/<skill-name>/` (personal) or `.claude/skills/<skill-name>/` (project) |
+| OpenClaw | `~/.openclaw/workspace/skills/<skill-name>/` |
+| Hermes | `~/.hermes/skills/<skill-name>/` |
+
+After install, the skill activates by its description on the next session. Remind the user that a skill is a maintenance obligation: when their workflow changes significantly, rebuild rather than patch, and deletion is a valid outcome.

--- a/skills/skill-atlas/scripts/register_capability.ts
+++ b/skills/skill-atlas/scripts/register_capability.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env bun
+/**
+ * Register a generated skill as a capability on the user's Edge Book agent.
+ *
+ * Usage:
+ *   bun scripts/register_capability.ts register path/to/skill-card.yaml
+ *   bun scripts/register_capability.ts sync
+ *   bun scripts/register_capability.ts status
+ *
+ * Stdout: JSON with { ok, action, registered, pending, failed, messages }.
+ *
+ * Behavior:
+ *   - `register` upserts (by slug) a capability record into ~/.agentvillage/capability-registry.json,
+ *     then runs `edge-book capability advertise --name <slug> --version <v> --summary <s>` if the
+ *     Edge Book CLI is installed and the agent identity is initialized. The advertisement is a
+ *     signed capability_advertisement post (schema edge-book/capability/0.1) on the user's agent.
+ *   - `sync` retries every record whose registration is "pending" — so a skill minted before the
+ *     user installs Edge Book (npm i -g edge-book) registers automatically later.
+ *   - Only PUBLIC fields are ever shared: the skill's slug (name), version, and a one-line summary
+ *     built from the card's title and task. Never the expertise map or examples.
+ *
+ * Environment:
+ *   EDGE_BOOK_CLI   optional — command to invoke the CLI (default: "edge-book" on PATH).
+ *                   Supports a multi-word value, e.g. "node /path/to/dist/edge-book.js".
+ *   EDGE_BOOK_HOME  optional — passed through to the CLI; selects the agent directory
+ *                   (Edge Book's own default is ~/.openclaw/edge-book).
+ *
+ * Exit codes:
+ *   0 - command completed (records remaining pending is a normal state).
+ *   2 - file read error or bad arguments.
+ *   3 - skill card parse error or card missing required public fields.
+ *
+ * Zero dependencies; runs on Bun or Node 22.18+ (native TypeScript).
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const REGISTRY_DIR = join(homedir(), ".agentvillage");
+const REGISTRY_PATH = join(REGISTRY_DIR, "capability-registry.json");
+// Card fields required to build the public advertisement. Nothing else is read for transmission.
+const REQUIRED_CARD_FIELDS = ["slug", "title", "task", "status"] as const;
+const SUMMARY_MAX = 200; // keep the advertisement summary one line, feed-friendly
+
+interface Capability {
+  slug: string;
+  title: string;
+  version: string;
+  summary: string;
+  card_status: string;
+  skill_card_path: string;
+  created_at: string;
+  registration: "pending" | "registered" | "failed";
+  registered_at: string | null;
+  capability_id: string | null; // Edge Book cap_… id, kept for a future `capability deprecate`
+}
+
+interface Registry {
+  version: number;
+  capabilities: Capability[];
+}
+
+function loadRegistry(): Registry {
+  if (!existsSync(REGISTRY_PATH)) return { version: 1, capabilities: [] };
+  return JSON.parse(readFileSync(REGISTRY_PATH, "utf-8"));
+}
+
+function saveRegistry(registry: Registry): void {
+  mkdirSync(REGISTRY_DIR, { recursive: true });
+  writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2) + "\n", "utf-8");
+}
+
+/** Minimal flat-YAML reader for the scalar fields of a skill card. */
+function readCardFields(path: string): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const line of readFileSync(path, "utf-8").split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+    let value = match[2].trim();
+    if (value.length >= 2 && ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))) {
+      value = value.slice(1, -1);
+    }
+    fields[match[1]] = value;
+  }
+  return fields;
+}
+
+function edgeBookCommand(): string[] {
+  const override = process.env.EDGE_BOOK_CLI?.trim();
+  return override ? override.split(/\s+/) : ["edge-book"];
+}
+
+/** True when the Edge Book CLI is callable AND the agent identity is initialized. */
+function edgeBookReady(): { ready: boolean; reason: string } {
+  const [cmd, ...prefix] = edgeBookCommand();
+  const probe = spawnSync(cmd, [...prefix, "capability", "list"], { encoding: "utf-8", timeout: 30_000 });
+  if (probe.error) return { ready: false, reason: "Edge Book CLI not installed (npm i -g edge-book)" };
+  if (probe.status !== 0) return { ready: false, reason: `Edge Book not initialized (run: edge-book init): ${(probe.stderr || "").trim().slice(0, 120)}` };
+  return { ready: true, reason: "" };
+}
+
+/**
+ * Advertise one capability via the Edge Book CLI. The advertisement becomes a signed
+ * capability_advertisement post on the user's agent, governed by Edge Book's grant model.
+ */
+function advertiseToEdgeBook(cap: Capability): { state: Capability["registration"]; capability_id: string | null; message: string } {
+  const readiness = edgeBookReady();
+  if (!readiness.ready) {
+    return { state: "pending", capability_id: null, message: `${cap.slug}: queued — ${readiness.reason}.` };
+  }
+  const [cmd, ...prefix] = edgeBookCommand();
+  const result = spawnSync(
+    cmd,
+    [...prefix, "capability", "advertise", "--name", cap.slug, "--version", cap.version, "--summary", cap.summary],
+    { encoding: "utf-8", timeout: 60_000 },
+  );
+  if (result.error || result.status !== 0) {
+    const detail = (result.stderr || result.error?.message || "unknown error").trim().slice(0, 200);
+    // CLI present and initialized but the advertise itself failed — payload-level, needs a human.
+    return { state: "failed", capability_id: null, message: `${cap.slug}: edge-book capability advertise failed — ${detail}. Review the card and re-run register.` };
+  }
+  const id = result.stdout.match(/cap_[A-Za-z0-9_-]+/)?.[0] ?? null;
+  return { state: "registered", capability_id: id, message: `${cap.slug}: advertised on your Edge Book agent${id ? ` (${id})` : ""} — visible to your friends per your grant settings.` };
+}
+
+function summarize(registry: Registry) {
+  return {
+    registered: registry.capabilities.filter((c) => c.registration === "registered").length,
+    pending: registry.capabilities.filter((c) => c.registration === "pending").length,
+    failed: registry.capabilities.filter((c) => c.registration === "failed").length,
+  };
+}
+
+// process.exitCode (not process.exit) — hard exit after console output trips a libuv assertion on Windows.
+class Done extends Error {}
+function emit(result: object, code: number): never {
+  console.log(JSON.stringify(result, null, 2));
+  process.exitCode = code;
+  throw new Done();
+}
+
+async function main(): Promise<void> {
+  const [, , command, cardArg] = process.argv;
+  const registry = loadRegistry();
+  const messages: string[] = [];
+
+  if (command === "status") {
+    emit({ ok: true, action: "status", ...summarize(registry), capabilities: registry.capabilities }, 0);
+  }
+
+  if (command === "register") {
+    if (!cardArg) {
+      emit({ ok: false, action: "register", messages: ["Missing card path. Run: bun scripts/register_capability.ts register path/to/skill-card.yaml"] }, 2);
+    }
+    const cardPath = resolve(cardArg);
+    let fields: Record<string, string>;
+    try {
+      fields = readCardFields(cardPath);
+    } catch (exc) {
+      emit({ ok: false, action: "register", messages: [`Could not read skill card: ${exc}`] }, 2);
+    }
+    const missing = REQUIRED_CARD_FIELDS.filter((f) => !fields[f]);
+    if (missing.length > 0) {
+      emit({ ok: false, action: "register", messages: [`Skill card missing public fields: ${missing.join(", ")}. Validate the card first.`] }, 3);
+    }
+
+    const summary = `${fields.title}: ${fields.task}`.slice(0, SUMMARY_MAX);
+    const existing = registry.capabilities.find((c) => c.slug === fields.slug);
+    const cap: Capability = {
+      slug: fields.slug,
+      title: fields.title,
+      version: fields.version || "1.0.0",
+      summary,
+      card_status: fields.status,
+      skill_card_path: cardPath,
+      created_at: existing?.created_at ?? new Date().toISOString(),
+      registration: "pending",
+      registered_at: null,
+      capability_id: existing?.capability_id ?? null,
+    };
+    const result = advertiseToEdgeBook(cap);
+    cap.registration = result.state;
+    cap.capability_id = result.capability_id ?? cap.capability_id;
+    if (result.state === "registered") cap.registered_at = new Date().toISOString();
+    messages.push(result.message);
+
+    if (existing) Object.assign(existing, cap);
+    else registry.capabilities.push(cap);
+    saveRegistry(registry);
+    emit({ ok: true, action: "register", ...summarize(registry), messages }, 0);
+  }
+
+  if (command === "sync") {
+    const queue = registry.capabilities.filter((c) => c.registration === "pending");
+    if (queue.length === 0) {
+      emit({ ok: true, action: "sync", ...summarize(registry), messages: ["Nothing pending."] }, 0);
+    }
+    const readiness = edgeBookReady();
+    if (!readiness.ready) {
+      emit({ ok: true, action: "sync", ...summarize(registry), messages: [`${queue.length} capability record(s) queued — ${readiness.reason}.`] }, 0);
+    }
+    for (const cap of queue) {
+      const result = advertiseToEdgeBook(cap);
+      cap.registration = result.state;
+      cap.capability_id = result.capability_id ?? cap.capability_id;
+      if (result.state === "registered") cap.registered_at = new Date().toISOString();
+      messages.push(result.message);
+    }
+    saveRegistry(registry);
+    emit({ ok: true, action: "sync", ...summarize(registry), messages }, 0);
+  }
+
+  emit({ ok: false, action: command ?? "none", messages: ["Unknown command. Use: register <card.yaml> | sync | status"] }, 2);
+}
+
+main().catch((exc) => {
+  if (!(exc instanceof Done)) {
+    console.log(JSON.stringify({ ok: false, action: "error", messages: [String(exc)] }, null, 2));
+    process.exitCode = 2;
+  }
+});

--- a/skills/skill-atlas/scripts/validate_skill_card.ts
+++ b/skills/skill-atlas/scripts/validate_skill_card.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+/**
+ * Validate a Skill Atlas card.
+ *
+ * Usage:
+ *   bun scripts/validate_skill_card.ts path/to/skill-card.yaml
+ *
+ * Stdout:
+ *   JSON with ok, missing_required, warnings, and next_action.
+ *
+ * Exit codes:
+ *   0 - valid. 1 - missing fields or invalid status. 2 - file read error. 3 - parse error.
+ *
+ * Zero dependencies: parses the card's flat YAML subset (top-level scalars,
+ * string lists, and the one-level `examples:` block) directly. Runs on Bun or Node 20+.
+ */
+
+import { readFileSync } from "node:fs";
+
+const REQUIRED = [
+  "title", "slug", "expert", "expertise_basis", "task", "target_user",
+  "trigger", "negative_trigger", "output_contract", "judgment_heavy_step",
+  "key_cues", "decision_criteria", "examples", "novice_traps",
+  "validation_cases", "known_limits", "status",
+];
+
+const VALID_STATUS = new Set(["captured", "expert-reviewed", "scenario-tested", "community-tested"]);
+
+type CardValue = string | string[] | Record<string, string>;
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'")))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/** Parse the template's YAML subset: `key: value`, `key: [a, b]`, `- item` lists, and one nested mapping level. */
+function parseCard(text: string): Record<string, CardValue> {
+  const card: Record<string, CardValue> = {};
+  let currentKey: string | null = null;
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trim().startsWith("#")) continue;
+
+    const topLevel = rawLine.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (topLevel) {
+      const [, key, rest] = topLevel;
+      currentKey = key;
+      const value = rest.trim();
+      if (value === "" ) {
+        card[key] = card[key] ?? "";          // list/mapping items may follow
+      } else if (value === "[]") {
+        card[key] = [];
+      } else if (value.startsWith("[") && value.endsWith("]")) {
+        card[key] = value.slice(1, -1).split(",").map(stripQuotes).filter(Boolean);
+      } else {
+        card[key] = stripQuotes(value);
+      }
+      continue;
+    }
+
+    if (!currentKey) continue;
+
+    const listItem = rawLine.match(/^\s+-\s*(.*)$/);
+    if (listItem) {
+      const existing = card[currentKey];
+      const list = Array.isArray(existing) ? existing : [];
+      const item = stripQuotes(listItem[1]);
+      if (item) list.push(item);
+      card[currentKey] = list;
+      continue;
+    }
+
+    const nested = rawLine.match(/^\s+([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (nested) {
+      const existing = card[currentKey];
+      const map = existing && typeof existing === "object" && !Array.isArray(existing) ? existing : {};
+      map[nested[1]] = stripQuotes(nested[2]);
+      card[currentKey] = map;
+    }
+  }
+
+  if (Object.keys(card).length === 0) throw new Error("Could not parse any key: value lines.");
+  return card;
+}
+
+function isEmpty(value: CardValue | undefined): boolean {
+  if (value === undefined || value === null) return true;
+  if (typeof value === "string") return value.trim() === "";
+  if (Array.isArray(value)) return value.length === 0;
+  return Object.keys(value).length === 0;
+}
+
+// process.exitCode (not process.exit) — hard exit after console output trips a libuv assertion on Windows.
+function emit(result: object, code: number): void {
+  console.log(JSON.stringify(result, null, 2));
+  process.exitCode = code;
+}
+
+function main(): void {
+  const path = process.argv[2];
+  if (!path || process.argv.length !== 3) {
+    return emit({
+      ok: false, missing_required: [], warnings: ["Expected exactly one path argument."],
+      next_action: "Run: bun scripts/validate_skill_card.ts path/to/skill-card.yaml",
+    }, 2);
+  }
+
+  let text: string;
+  try {
+    text = readFileSync(path, "utf-8");
+  } catch (exc) {
+    return emit({
+      ok: false, missing_required: [], warnings: [`File read error: ${exc}`],
+      next_action: "Check the path and rerun the validator.",
+    }, 2);
+  }
+
+  let card: Record<string, CardValue>;
+  try {
+    card = parseCard(text);
+  } catch (exc) {
+    return emit({
+      ok: false, missing_required: [], warnings: [`Parse error: ${exc}`],
+      next_action: "Fix YAML syntax or use simple key: value lines.",
+    }, 3);
+  }
+
+  const missing = REQUIRED.filter((field) => isEmpty(card[field]));
+  const warnings: string[] = [];
+
+  const status = typeof card.status === "string" ? card.status.trim() : "";
+  if (status && !VALID_STATUS.has(status)) {
+    warnings.push(`Status '${status}' is not one of: ${[...VALID_STATUS].sort().join(", ")}.`);
+  }
+  if (status === "community-tested") {
+    warnings.push("Community-tested requires evidence from at least one non-expert user or reviewer.");
+  }
+
+  const examples = card.examples;
+  if (examples && typeof examples === "object" && !Array.isArray(examples)) {
+    for (const key of ["good", "messy", "edge", "negative", "novice_trap"]) {
+      if (isEmpty(examples[key])) warnings.push(`examples.${key} is empty.`);
+    }
+  }
+
+  const ok = missing.length === 0 && !warnings.some((w) => w.includes("not one of"));
+  emit({
+    ok,
+    missing_required: missing,
+    warnings,
+    next_action: ok
+      ? "Review with the expert before skill generation."
+      : "Fill missing fields and rerun validation.",
+  }, ok ? 0 : 1);
+}
+
+main();

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -65,6 +65,7 @@ The `skills/` directory holds per-backend procedural knowledge. Today's active s
 - **`edgeos`** (`skills/edgeos/SKILL.md`) — EdgeOS API: live events, RSVPs, venues, attendee directory, and the user's own profile. (No wiki or newsletter content — that lives in `edge-esmeralda`.) 
 - **`edge-esmeralda`** (`skills/edge-esmeralda/SKILL.md`) — Popup constants, directory semantics, curated wiki/website/newsletter.  Supplies community-knowledge answers.
 - **`geo-esmeralda`** (`skills/geo-esmeralda/SKILL.md`) — Geo knowledge graph: community-created content, relations, ontology, attendee-authored writes, and raw time-windowed history of the main Edge Esmeralda 2026 Telegram group (the village-wide chat).  read when the user asks what the village is discussing, what's happening in the chat, what they missed, "catch me up," what people are talking about, or wants a chat summary.
+- **`skill-atlas`** (`skills/skill-atlas/SKILL.md`) — lets the user build skills for their own agent from their expertise: research-informed expert interview, Skill Atlas card, full skill generation with human-in-the-loop gates; optionally (consent-gated) advertises the finished skill on their Edge Book agent.  read only when the user wants to turn what they know into a skill, build a skill for their agent, or create a community skill card — not for generic prompt help or editing existing skills.
 
 When a future skill ships, list it here with its trigger conditions.
 


### PR DESCRIPTION
## What this adds

**skill-atlas** — a skill bundle that lets attendees build skills for their own agents from their expertise.

The flow is human-in-the-loop end to end:

1. **Domain research before the interview** — the agent researches the domain (skill directories, web, the `geo-esmeralda`/`edgeos` skills for village context) so the interview is technically specific and presents the expert 3-5 adjacent directions to choose from.
2. **Expert interview** — critical-incident method: start from a real hard case, extract cues, tradeoffs, novice traps, and examples; convert defensible judgment into rules, fuzzy judgment into rubric dimensions, and "the skill should not decide alone" into human review gates.
3. **Skill Atlas card + expertise map** — a public directory card (validated by `scripts/validate_skill_card.ts`) and a private working artifact. Validation status is honest by design (`captured` → `expert-reviewed` → `scenario-tested` → `community-tested`).
4. **Skill generation (approval-gated)** — a complete installable skill folder (SKILL.md + references + evals seeded from the expert's scenarios), with every human review gate the expert defined preserved as a hard pause. Install paths documented for Claude Code, OpenClaw, and Hermes.

The generated skill is the deliverable. It needs no network or backend — interview, generation, and validation all run locally.

## Subsidiary feature: Edge Book capability registration (optional, consent-gated)

With explicit consent, the finished skill can be advertised as a signed capability on the attendee's [Edge Book](https://www.npmjs.com/package/edge-book) agent via `edge-book capability advertise` (a `capability_advertisement` post, schema `edge-book/capability/0.1`, visible to friends per Edge Book's grant model).

- Fully optional: the skill-building flow is complete without it.
- Deferred sync: if Edge Book isn't installed, the registration queues in `~/.agentvillage/capability-registry.json` and advertises automatically once `edge-book init` has run (Step 0 of any run, or the daily `heartbeat.md` task).
- Privacy: exactly three values are shared (skill name, version, one-line summary). The private expertise map never leaves the machine. Withdrawal via `edge-book capability deprecate` (the `cap_…` id is kept in the registry).

## Changes

- `skills/skill-atlas/` — new bundle: SKILL.md, references (elicitation method, domain research, skill generation, capability registration), card/map templates, zero-dependency TypeScript scripts (Bun or Node 22.18+), 6 eval cases, heartbeat task.
- `workspace/AGENTS.md` — registered as a reactive active skill.
- `skills/README.md` — added to the bundle list.
- Manifests bumped together to 1.6.0 per the contributing guide.

## Testing

- Validator: good card (exit 0), incomplete card with field list + status warning (exit 1), missing file (exit 2).
- Registration: register with no Edge Book → correctly queued; sync with the real `edge-book` CLI → advertised and `cap_…` id captured; `edge-book capability list` confirms the signed advertisement; idempotent re-sync; missing-field card rejected (exit 3).
- Host-neutral language throughout; no host-specific assumptions without a documented fallback; conventions follow the existing bundles (single-line frontmatter description, `version`/`author`/`tags`, optional env vars declared with `required_for`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
