### PR TITLE
fix(digest): send x-index-surface: telegram on direct MCP calls

### DIFF
--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -714,6 +714,13 @@ async function postMcpMessage(mcpUrl: string, apiKey: string, body: unknown): Pr
       "Content-Type": "application/json",
       "Accept": "application/json, text/event-stream",
       "x-api-key": apiKey,
+      // The digest is always delivered over Telegram (Hermes). Without this
+      // header the MCP server coerces the surface to "web", which stamps
+      // minted connect links with preferredSurface=web and breaks the
+      // click-time t.me deep-link redirect (links land on the web chat
+      // fallback instead of opening Telegram). Mirrors install_index.ts's
+      // buildIndexMcpHeaders.
+      "x-index-surface": "telegram",
     },
     body: JSON.stringify(body),
   });

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -595,6 +595,29 @@ describe("fetchOpportunitiesFromMcp", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("sends x-index-surface: telegram on every MCP request so minted links deep-link to t.me", async () => {
+    const originalFetch = globalThis.fetch;
+    const seenHeaders: Array<Record<string, string>> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenHeaders.push({ ...(init?.headers as Record<string, string>) });
+      const body = JSON.parse(init?.body as string ?? "{}") as { method: string };
+      if (body.method === "initialize") {
+        return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+      }
+      return Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: "" }] } });
+    }) as typeof fetch;
+    try {
+      await fetchOpportunitiesFromMcp({ apiKey: "test-key", mcpUrl: MCP_URL });
+      expect(seenHeaders.length).toBeGreaterThanOrEqual(2);
+      for (const headers of seenHeaders) {
+        expect(headers["x-index-surface"]).toBe("telegram");
+        expect(headers["x-api-key"]).toBe("test-key");
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("filterCooldownQuestions", () => {


### PR DESCRIPTION
## Problem

Clicking a connect link from the Telegram daily digest landed on the index.network web-chat fallback instead of deep-linking to Telegram (`t.me/<handle>?text=…`), even when the counterpart has a verified Telegram handle.

## Root cause

`postMcpMessage` in `skills/index-network/scripts/build-daily-brief-context.ts` calls the Index MCP server directly via JSON-RPC with only `x-api-key`. The MCP server coerces a missing `x-index-surface` header to `web`, so every connect link minted by `list_opportunities` during digest staging was stamped `preferredSurface=web`. The click-time controller only attempts the t.me redirect for telegram-stamped links.

Production data confirms the regression window: links minted via the Hermes chat path (which sends the header from `install_index.ts`) are stamped `telegram`; everything minted by this script since it shipped is stamped `web`.

## Fix

- Send `x-index-surface: telegram` on every direct MCP request — the digest is always delivered over Telegram (Hermes), mirroring `buildIndexMcpHeaders` in `install_index.ts`.
- Test asserting the header is present on both `initialize` and `tools/call` requests.

## Companion fix

`indexnetwork/index` gets a backend change so idempotent connect-link re-mints refresh `preferredSurface`, which self-heals the rows mis-stamped during the regression window on the next digest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)