### PR TITLE
fix(digest): stagger per-tenant cron schedules to avoid shared rate-limit bursts

### DIFF
--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -3,11 +3,17 @@
  *
  *   - Merges `mcp_servers.index` into `$HERMES_HOME/config.yaml`
  *   - Writes `INDEX_API_KEY` to `$HERMES_HOME/.env`
- *   - Installs the digest crons: prepare (`Edge — digest prepare`, 02:00) and
- *     send (`Edge — daily digest`, 08:00) — both host-local; times overridable
+ *   - Installs the digest crons: prepare (`Edge — digest prepare`, ~02:00) and
+ *     send (`Edge — daily digest`, ~08:00) — both host-local; times overridable
  *     via --digest-prepare-cron / --digest-send-cron (or DIGEST_PREPARE_CRON /
- *     DIGEST_SEND_CRON). New installs create enabled crons; reconcile updates
- *     prompt bodies only and preserves each job's schedule and pause state.
+ *     DIGEST_SEND_CRON). To avoid the whole fleet hitting the LLM provider in
+ *     the same minute (OpenRouter caps gemini-flash at 300 req/min account-wide),
+ *     each tenant gets a deterministic minute offset derived from its
+ *     INDEX_API_KEY: prepare spreads over 02:00–02:49, send over 08:00–08:24.
+ *     New installs create enabled crons; reconcile updates prompt bodies,
+ *     migrates jobs still on the old synchronized defaults (0 2 / 0 8) to their
+ *     staggered slot, and otherwise preserves each job's schedule and pause
+ *     state (user-customized schedules are never touched).
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -112,6 +118,14 @@ interface StoredCronJob {
   id: string;
   name: string;
   prompt?: string;
+  schedule?: { expr?: string } | string;
+  schedule_display?: string;
+}
+
+/** Extract the cron expression a stored Hermes job currently runs on. */
+export function storedSchedule(job: StoredCronJob): string {
+  if (typeof job.schedule === "string") return job.schedule.trim();
+  return (job.schedule?.expr ?? job.schedule_display ?? "").trim();
 }
 
 function readCronJobs(): StoredCronJob[] {
@@ -128,6 +142,8 @@ function readCronJobs(): StoredCronJob[] {
 export interface DigestCronSpec {
   /** Default cron schedule (overridable at install time). */
   schedule: string;
+  /** Width of the per-tenant stagger window, in minutes from the default hour. */
+  staggerWindowMinutes: number;
   /** Prompt file under skills/edge-esmeralda/prompts/. */
   promptFile: string;
   /** Full Hermes cron name (kept under the CRON_NAME_PREFIX). */
@@ -144,6 +160,7 @@ export interface DigestCronSpec {
 export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
   {
     schedule: "0 2 * * *",
+    staggerWindowMinutes: 50,
     promptFile: "prepare.md",
     name: "Edge — digest prepare",
     deliver: false,
@@ -152,6 +169,7 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
   },
   {
     schedule: "0 8 * * *",
+    staggerWindowMinutes: 25,
     promptFile: "send.md",
     name: "Edge — daily digest",
     deliver: true,
@@ -159,6 +177,28 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     overrideEnv: "DIGEST_SEND_CRON",
   },
 ];
+
+/** FNV-1a 32-bit hash — deterministic, dependency-free. */
+export function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Per-tenant staggered schedule: replace the minute field of the spec default
+ * with a deterministic offset in [0, staggerWindowMinutes) derived from a
+ * stable tenant seed. Spreads the fleet so simultaneous digest runs don't
+ * blow through the shared OpenRouter per-model rate limit.
+ */
+export function staggeredSchedule(spec: DigestCronSpec, seed: string): string {
+  const fields = spec.schedule.trim().split(/\s+/);
+  const minute = fnv1a(`${seed}:${spec.name}`) % Math.max(1, spec.staggerWindowMinutes);
+  return [String(minute), ...fields.slice(1)].join(" ");
+}
 
 /** Build the argv for `hermes cron create` from a spec + resolved prompt body. */
 export function cronCreateArgs(spec: DigestCronSpec, promptBody: string, home: string): string[] {
@@ -168,9 +208,15 @@ export function cronCreateArgs(spec: DigestCronSpec, promptBody: string, home: s
   return args;
 }
 
-/** Build the argv for `hermes cron edit` — prompt only; schedule/pause unchanged. */
-export function cronEditPromptArgs(jobId: string, promptBody: string): string[] {
-  return ["cron", "edit", jobId, "--prompt", promptBody];
+/** Build the argv for `hermes cron edit` — only the provided fields; pause state unchanged. */
+export function cronEditArgs(
+  jobId: string,
+  { prompt, schedule }: { prompt?: string; schedule?: string },
+): string[] {
+  const args = ["cron", "edit", jobId];
+  if (schedule !== undefined) args.push("--schedule", schedule);
+  if (prompt !== undefined) args.push("--prompt", prompt);
+  return args;
 }
 
 /** True for a standard 5-field cron expression (minute hour day-of-month month day-of-week). */
@@ -181,24 +227,27 @@ export function isValidCron(expr: string): boolean {
 
 /**
  * Resolve a spec's cron schedule, honoring an optional install-time override.
- * Precedence: CLI flag (`<overrideFlag> <expr>`) > env var (`overrideEnv`) > the
- * spec default. An override that is not a valid 5-field cron expression is
- * ignored (with a warning) and the default is used.
+ * Precedence: CLI flag (`<overrideFlag> <expr>`) > env var (`overrideEnv`) >
+ * per-tenant staggered default (when `staggerSeed` is provided) > the spec
+ * default. An override that is not a valid 5-field cron expression is ignored
+ * (with a warning) and the staggered/spec default is used.
  */
 export function resolveCronSchedule(
   spec: DigestCronSpec,
   argv: string[] = process.argv,
   env: NodeJS.ProcessEnv = process.env,
+  staggerSeed = "",
 ): string {
+  const fallback = staggerSeed ? staggeredSchedule(spec, staggerSeed) : spec.schedule;
   const flagIdx = argv.indexOf(spec.overrideFlag);
   const fromFlag = flagIdx >= 0 ? argv[flagIdx + 1]?.trim() : undefined;
   const override = fromFlag || env[spec.overrideEnv]?.trim();
-  if (!override) return spec.schedule;
+  if (!override) return fallback;
   if (!isValidCron(override)) {
     console.warn(
-      `  warning: ignoring invalid cron override for "${spec.name}" ("${override}") — using default "${spec.schedule}"`,
+      `  warning: ignoring invalid cron override for "${spec.name}" ("${override}") — using default "${fallback}"`,
     );
-    return spec.schedule;
+    return fallback;
   }
   return override;
 }
@@ -230,6 +279,9 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
 
   const existing = readCronJobs();
   const specNames = new Set(DIGEST_CRON_SPECS.map((s) => s.name));
+  // Stable per-tenant seed for schedule staggering. The tenant's own Index
+  // API key never changes across reinstalls, so the derived minute is stable.
+  const staggerSeed = process.env.INDEX_API_KEY?.trim() || readPersistedEnvVar("INDEX_API_KEY");
 
   for (const job of existing) {
     if (!job.name.startsWith(CRON_NAME_PREFIX) || specNames.has(job.name)) continue;
@@ -256,27 +308,40 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
     }
     const promptBody = readFileSync(promptPath, "utf8");
     const job = existing.find((entry) => entry.name === spec.name);
+    const schedule = resolveCronSchedule(spec, process.argv, process.env, staggerSeed);
 
     if (job) {
-      if (job.prompt === promptBody) {
-        console.log(`→ cron "${spec.name}" prompt up to date`);
+      const promptStale = job.prompt !== promptBody;
+      // Migrate only jobs still sitting on the old synchronized default
+      // (e.g. "0 8 * * *") to their staggered slot. Anything else is a
+      // deliberate per-tenant schedule and is preserved.
+      const scheduleStale = storedSchedule(job) === spec.schedule && schedule !== spec.schedule;
+      if (!promptStale && !scheduleStale) {
+        console.log(`→ cron "${spec.name}" up to date`);
         continue;
       }
-      console.log(`→ updating cron "${spec.name}" prompt`);
+      const parts = [
+        ...(promptStale ? ["prompt"] : []),
+        ...(scheduleStale ? [`schedule → ${schedule}`] : []),
+      ];
+      console.log(`→ updating cron "${spec.name}" (${parts.join(", ")})`);
       try {
-        execFileSync(bin, cronEditPromptArgs(job.id, promptBody), {
-          stdio: ["ignore", "ignore", "inherit"],
-          env,
-        });
+        execFileSync(
+          bin,
+          cronEditArgs(job.id, {
+            ...(promptStale ? { prompt: promptBody } : {}),
+            ...(scheduleStale ? { schedule } : {}),
+          }),
+          { stdio: ["ignore", "ignore", "inherit"], env },
+        );
       } catch {
         console.warn(`  warning: could not update cron "${spec.name}" — gateway may still run`);
       }
       continue;
     }
 
-    const schedule = resolveCronSchedule(spec);
     const resolved = { ...spec, schedule };
-    const suffix = schedule === spec.schedule ? "" : " [overridden]";
+    const suffix = schedule === spec.schedule ? "" : " [staggered/overridden]";
     console.log(`→ installing cron "${spec.name}" (${schedule})${suffix}`);
     try {
       execFileSync(bin, cronCreateArgs(resolved, promptBody, home), {

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -320,22 +320,30 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
         console.log(`→ cron "${spec.name}" up to date`);
         continue;
       }
-      const parts = [
-        ...(promptStale ? ["prompt"] : []),
-        ...(scheduleStale ? [`schedule → ${schedule}`] : []),
-      ];
-      console.log(`→ updating cron "${spec.name}" (${parts.join(", ")})`);
-      try {
-        execFileSync(
-          bin,
-          cronEditArgs(job.id, {
-            ...(promptStale ? { prompt: promptBody } : {}),
-            ...(scheduleStale ? { schedule } : {}),
-          }),
-          { stdio: ["ignore", "ignore", "inherit"], env },
-        );
-      } catch {
-        console.warn(`  warning: could not update cron "${spec.name}" — gateway may still run`);
+      // Prompt and schedule are updated in separate `cron edit` calls so a
+      // failure of one (e.g. an older Hermes without --schedule) cannot take
+      // down the other. Prompt first — it's the critical update.
+      if (promptStale) {
+        console.log(`→ updating cron "${spec.name}" prompt`);
+        try {
+          execFileSync(bin, cronEditArgs(job.id, { prompt: promptBody }), {
+            stdio: ["ignore", "ignore", "inherit"],
+            env,
+          });
+        } catch {
+          console.warn(`  warning: could not update cron "${spec.name}" prompt — gateway may still run`);
+        }
+      }
+      if (scheduleStale) {
+        console.log(`→ migrating cron "${spec.name}" schedule → ${schedule}`);
+        try {
+          execFileSync(bin, cronEditArgs(job.id, { schedule }), {
+            stdio: ["ignore", "ignore", "inherit"],
+            env,
+          });
+        } catch {
+          console.warn(`  warning: could not migrate cron "${spec.name}" schedule — still on "${spec.schedule}"`);
+        }
       }
       continue;
     }

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -4,9 +4,12 @@ import {
   DIGEST_CRON_SPECS,
   buildIndexMcpHeaders,
   cronCreateArgs,
-  cronEditPromptArgs,
+  cronEditArgs,
+  fnv1a,
   isValidCron,
   resolveCronSchedule,
+  staggeredSchedule,
+  storedSchedule,
 } from "../install_index";
 
 test("two digest cron specs: prepare (02:00, no deliver) then send (08:00, deliver telegram)", () => {
@@ -37,10 +40,46 @@ test("prepare cron args omit --deliver; send cron args include --deliver telegra
   ]);
 });
 
-test("cronEditPromptArgs updates prompt only", () => {
-  expect(cronEditPromptArgs("abc123", "NEW_BODY")).toEqual([
+test("cronEditArgs includes only the provided fields", () => {
+  expect(cronEditArgs("abc123", { prompt: "NEW_BODY" })).toEqual([
     "cron", "edit", "abc123", "--prompt", "NEW_BODY",
   ]);
+  expect(cronEditArgs("abc123", { schedule: "7 8 * * *" })).toEqual([
+    "cron", "edit", "abc123", "--schedule", "7 8 * * *",
+  ]);
+  expect(cronEditArgs("abc123", { prompt: "P", schedule: "7 8 * * *" })).toEqual([
+    "cron", "edit", "abc123", "--schedule", "7 8 * * *", "--prompt", "P",
+  ]);
+});
+
+test("staggeredSchedule derives a deterministic minute inside the spec's window", () => {
+  const [prepare, send] = DIGEST_CRON_SPECS;
+
+  for (const spec of [prepare, send]) {
+    const schedule = staggeredSchedule(spec, "ix_tenant_key");
+    expect(staggeredSchedule(spec, "ix_tenant_key")).toBe(schedule); // deterministic
+    const [minute, ...rest] = schedule.split(" ");
+    expect(Number(minute)).toBeGreaterThanOrEqual(0);
+    expect(Number(minute)).toBeLessThan(spec.staggerWindowMinutes);
+    expect(rest.join(" ")).toBe(spec.schedule.split(" ").slice(1).join(" "));
+    expect(isValidCron(schedule)).toBe(true);
+  }
+
+  // Different specs hash independently for the same tenant seed.
+  expect(fnv1a(`seed:${prepare.name}`)).not.toBe(fnv1a(`seed:${send.name}`));
+});
+
+test("staggered windows keep prepare within 02:00–02:49 and send within 08:00–08:24", () => {
+  const [prepare, send] = DIGEST_CRON_SPECS;
+  expect(prepare.staggerWindowMinutes).toBe(50);
+  expect(send.staggerWindowMinutes).toBe(25);
+});
+
+test("storedSchedule reads hermes jobs.json shapes", () => {
+  expect(storedSchedule({ id: "a", name: "x", schedule: { expr: "0 8 * * *" } })).toBe("0 8 * * *");
+  expect(storedSchedule({ id: "a", name: "x", schedule_display: "5 8 * * *" })).toBe("5 8 * * *");
+  expect(storedSchedule({ id: "a", name: "x", schedule: "1 2 * * *" })).toBe("1 2 * * *");
+  expect(storedSchedule({ id: "a", name: "x" })).toBe("");
 });
 
 test("index MCP headers include telegram surface and optional handle", () => {
@@ -77,6 +116,20 @@ test("isValidCron accepts 5-field expressions and rejects malformed ones", () =>
 test("resolveCronSchedule returns the default when no override is set", () => {
   const [prepare] = DIGEST_CRON_SPECS;
   expect(resolveCronSchedule(prepare, [], {})).toBe("0 2 * * *");
+});
+
+test("resolveCronSchedule staggers from the seed when no override is set, but override wins", () => {
+  const [prepare, send] = DIGEST_CRON_SPECS;
+  const seed = "ix_tenant_key";
+
+  expect(resolveCronSchedule(prepare, [], {}, seed)).toBe(staggeredSchedule(prepare, seed));
+  expect(resolveCronSchedule(send, [], {}, seed)).toBe(staggeredSchedule(send, seed));
+
+  // Explicit override beats the staggered default; invalid override falls back to it.
+  expect(resolveCronSchedule(send, [], { DIGEST_SEND_CRON: "0 9 * * *" }, seed)).toBe("0 9 * * *");
+  expect(resolveCronSchedule(send, [], { DIGEST_SEND_CRON: "garbage" }, seed)).toBe(
+    staggeredSchedule(send, seed),
+  );
 });
 
 test("resolveCronSchedule honors flag, then env, with flag winning over env", () => {

--- a/install/tests/reconcile_digest_crons.test.ts
+++ b/install/tests/reconcile_digest_crons.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration tests for reconcileDigestCronJobs: run the real reconcile loop
+ * against a stub `hermes` binary (records every invocation to a log file) and
+ * a temp HERMES_HOME, covering the create / prompt-edit / schedule-migrate /
+ * preserve paths end-to-end.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  DIGEST_CRON_SPECS,
+  reconcileDigestCronJobs,
+  staggeredSchedule,
+} from "../install_index";
+
+const SEED = "ix_integration_seed";
+const [PREPARE, SEND] = DIGEST_CRON_SPECS;
+
+let home: string;
+let stubLog: string;
+let savedEnv: Record<string, string | undefined>;
+
+function writeStubHermes(dir: string, { rejectScheduleFlag = false } = {}): string {
+  const bin = join(dir, "hermes");
+  const rejectBlock = rejectScheduleFlag
+    ? `for arg in "$@"; do if [ "$arg" = "--schedule" ]; then exit 2; fi; done\n`
+    : "";
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "stub 0.0.0"; exit 0; fi
+${rejectBlock}printf '%s\\n' "$(printf '%s\\x1f' "$@")" >> "${join(dir, "calls.log")}"
+exit 0
+`,
+  );
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
+/** Parse the stub's call log into argv arrays (one per invocation). */
+function stubCalls(): string[][] {
+  let raw: string;
+  try {
+    raw = readFileSync(stubLog, "utf8");
+  } catch {
+    return [];
+  }
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\x1f").filter((part) => part !== ""));
+}
+
+function cronCalls(): string[][] {
+  return stubCalls().filter((argv) => argv[0] === "cron");
+}
+
+function writePrompts(): void {
+  const prompts = join(home, "skills/edge-esmeralda/prompts");
+  mkdirSync(prompts, { recursive: true });
+  writeFileSync(join(prompts, PREPARE.promptFile), "PREPARE_BODY");
+  writeFileSync(join(prompts, SEND.promptFile), "SEND_BODY");
+}
+
+function writeJobs(jobs: unknown[]): void {
+  mkdirSync(join(home, "cron"), { recursive: true });
+  writeFileSync(join(home, "cron", "jobs.json"), JSON.stringify({ jobs }));
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "edge-reconcile-"));
+  stubLog = join(home, "calls.log");
+  savedEnv = {
+    HERMES_HOME: process.env.HERMES_HOME,
+    HERMES_BIN: process.env.HERMES_BIN,
+    INDEX_API_KEY: process.env.INDEX_API_KEY,
+    DIGEST_PREPARE_CRON: process.env.DIGEST_PREPARE_CRON,
+    DIGEST_SEND_CRON: process.env.DIGEST_SEND_CRON,
+  };
+  process.env.HERMES_HOME = home;
+  process.env.HERMES_BIN = writeStubHermes(home);
+  process.env.INDEX_API_KEY = SEED;
+  delete process.env.DIGEST_PREPARE_CRON;
+  delete process.env.DIGEST_SEND_CRON;
+  writePrompts();
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(home, { recursive: true, force: true });
+});
+
+test("fresh install creates both crons on their staggered schedules", () => {
+  reconcileDigestCronJobs({ ...process.env });
+
+  const creates = cronCalls().filter((argv) => argv[1] === "create");
+  expect(creates).toHaveLength(2);
+
+  const prepare = creates.find((argv) => argv.includes(PREPARE.name))!;
+  const send = creates.find((argv) => argv.includes(SEND.name))!;
+  expect(prepare[2]).toBe(staggeredSchedule(PREPARE, SEED));
+  expect(prepare[3]).toBe("PREPARE_BODY");
+  expect(send[2]).toBe(staggeredSchedule(SEND, SEED));
+  expect(send[3]).toBe("SEND_BODY");
+  expect(send).toContain("--deliver");
+  expect(prepare).not.toContain("--deliver");
+});
+
+test("job still on the old synchronized default gets a schedule-only migration", () => {
+  writeJobs([
+    { id: "p1", name: PREPARE.name, prompt: "PREPARE_BODY", schedule: { expr: PREPARE.schedule } },
+    { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: SEND.schedule } },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const calls = cronCalls();
+  expect(calls).toEqual([
+    ["cron", "edit", "p1", "--schedule", staggeredSchedule(PREPARE, SEED)],
+    ["cron", "edit", "s1", "--schedule", staggeredSchedule(SEND, SEED)],
+  ]);
+});
+
+test("custom schedule is preserved; stale prompt gets a prompt-only edit", () => {
+  writeJobs([
+    { id: "p1", name: PREPARE.name, prompt: "OLD_BODY", schedule: { expr: "30 4 * * *" } },
+    { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: "15 9 * * *" } },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  expect(cronCalls()).toEqual([
+    ["cron", "edit", "p1", "--prompt", "PREPARE_BODY"],
+  ]);
+});
+
+test("stale prompt + old default schedule produce two independent edit calls", () => {
+  writeJobs([
+    { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const sendEdits = cronCalls().filter((argv) => argv[2] === "s1");
+  expect(sendEdits).toEqual([
+    ["cron", "edit", "s1", "--prompt", "SEND_BODY"],
+    ["cron", "edit", "s1", "--schedule", staggeredSchedule(SEND, SEED)],
+  ]);
+});
+
+test("up-to-date jobs (staggered schedule + current prompt) trigger no cron calls", () => {
+  writeJobs([
+    {
+      id: "p1",
+      name: PREPARE.name,
+      prompt: "PREPARE_BODY",
+      schedule: { expr: staggeredSchedule(PREPARE, SEED) },
+    },
+    {
+      id: "s1",
+      name: SEND.name,
+      prompt: "SEND_BODY",
+      schedule: { expr: staggeredSchedule(SEND, SEED) },
+    },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  expect(cronCalls()).toEqual([]);
+});
+
+test("retired Edge-prefixed crons are removed; foreign crons are untouched", () => {
+  writeJobs([
+    { id: "old1", name: "Edge — heartbeat", prompt: "X", schedule: { expr: "0 6 * * *" } },
+    { id: "user1", name: "my own job", prompt: "Y", schedule: { expr: "0 7 * * *" } },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const removes = cronCalls().filter((argv) => argv[1] === "remove");
+  expect(removes).toEqual([["cron", "remove", "old1"]]);
+});
+
+test("a Hermes that rejects --schedule still gets the prompt update (degraded migration)", () => {
+  process.env.HERMES_BIN = writeStubHermes(home, { rejectScheduleFlag: true });
+  writeJobs([
+    {
+      id: "p1",
+      name: PREPARE.name,
+      prompt: "PREPARE_BODY",
+      schedule: { expr: staggeredSchedule(PREPARE, SEED) },
+    },
+    { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  // The schedule edit died (exit 2, never logged) but the prompt edit landed.
+  expect(cronCalls()).toEqual([
+    ["cron", "edit", "s1", "--prompt", "SEND_BODY"],
+  ]);
+});
+
+test("DIGEST_SEND_CRON override beats the staggered default on create", () => {
+  process.env.DIGEST_SEND_CRON = "45 7 * * *";
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const send = cronCalls().find((argv) => argv[1] === "create" && argv.includes(SEND.name))!;
+  expect(send[2]).toBe("45 7 * * *");
+});


### PR DESCRIPTION
## Why

Today's `Edge — daily digest` cron failed fleet-wide with:

> RuntimeError: HTTP 429: Rate limit exceeded: limit_rpm/google/gemini-3.5-flash-…. High demand for google/gemini-3.5-flash on OpenRouter - limited to 300 requests per minute.

Every tenant runs **prepare at exactly 02:00** and **send at exactly 08:00**, and all tenant keys hang off one OpenRouter account whose high-demand cap on `google/gemini-3.5-flash` is **300 req/min account-wide**. N tenants × several LLM calls in the same minute blows through it, Hermes doesn't retry on 429, and that day's digest is silently dropped for the failed tenants.

## What

- **Deterministic per-tenant stagger**: derive a minute offset from the tenant's stable `INDEX_API_KEY` (FNV-1a). Prepare spreads over **02:00–02:49**, send over **08:00–08:24**. Same tenant always gets the same slot.
- **Override precedence unchanged**: `--digest-prepare-cron` / `--digest-send-cron` flags and `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON` env still win over the staggered default.
- **Existing-tenant migration**: reconcile now moves jobs still sitting on the old synchronized defaults (`0 2 * * *` / `0 8 * * *`) to their staggered slot via `hermes cron edit --schedule`. Any other schedule is treated as deliberately customized and preserved, as is pause state.

## Tests

`bun test install/` — 18 pass (new coverage for `staggeredSchedule`, `storedSchedule`, `cronEditArgs`, and seed-aware `resolveCronSchedule`).

Companion control-plane PR throttles the `send-ready` trigger dispatch: Edge-City/agentvillage-controlplane (same branch name).