### PR TITLE
feat(digest): deterministic ledger confirm in send script + 'Still open' re-show framing

### DIFF
--- a/skills/edge-esmeralda/prompts/send.md
+++ b/skills/edge-esmeralda/prompts/send.md
@@ -12,7 +12,7 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
    bun skills/index-network/scripts/send-daily-brief.ts
    ```
 
-   Do not write Python, shell pipelines, or replacement delivery logic. The script resolves today's America/Los_Angeles date, reads `memory/heartbeat-state.json`, checks the Kanban approval gate, writes `memory/digest-outgoing.md`, extracts digest opportunity and question markers, updates delivery state (today's opportunity ids plus the per-question 3-day re-delivery cooldown under `questionDelivery`), marks the task complete, strips unsafe URLs/internal metadata, and prints either `[SILENT]` or one JSON object.
+   Do not write Python, shell pipelines, or replacement delivery logic. The script resolves today's America/Los_Angeles date, reads `memory/heartbeat-state.json`, checks the Kanban approval gate, writes `memory/digest-outgoing.md`, extracts digest opportunity and question markers, updates delivery state (today's opportunity ids plus the per-question 3-day re-delivery cooldown under `questionDelivery`), marks the task complete, confirms digest delivery for every extracted opportunity id directly on the Index ledger, strips unsafe URLs/internal metadata, and prints either `[SILENT]` or one JSON object.
 
    If the script exits with a non-zero code, end your turn immediately with `[SILENT]`. Do not diagnose, retry, or attempt alternatives. One attempt only.
 
@@ -21,10 +21,10 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
 3. **If stdout is JSON, parse it.** It has this shape:
 
    ```json
-   { "taskId": "...", "opportunityIds": ["..."], "questionIds": ["..."], "finalBrief": "..." }
+   { "taskId": "...", "opportunityIds": ["..."], "questionIds": ["..."], "finalBrief": "...", "confirmedOpportunityIds": ["..."], "confirmFailed": [] }
    ```
 
-4. **Confirm delivery only for returned opportunity ids.** For every `opportunityIds[]` value, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. If the array is empty, skip this step. Never call any MCP tool for `questionIds[]` — question delivery bookkeeping is handled entirely by the script's state file; there is no question confirmation tool.
+4. **Do not confirm delivery yourself.** The script already calls `confirm_opportunity_delivery(trigger="digest")` on the Index ledger for every extracted opportunity id — `confirmedOpportunityIds` and `confirmFailed` are diagnostics only. Never call `confirm_opportunity_delivery` or any other MCP tool in this pass, for opportunities or for `questionIds[]`.
 
 5. **Deliver the final brief.** Your final assistant reply must be `finalBrief` verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting. Hermes delivers it. End your turn.
 
@@ -33,6 +33,6 @@ Deliver the staged morning brief verbatim from Kanban, then reconcile delivery b
 - Never reimplement the send flow in generated code. Always call `bun skills/index-network/scripts/send-daily-brief.ts` exactly once.
 - One attempt at the send script. If it fails, end immediately with `[SILENT]` — no retries, no diagnosis, no alternative paths.
 - Deliver only a brief a human has approved by unblocking it (status `ready` or `todo`, depending on Hermes version). A still-`blocked` task means no approval yet — stay silent; the next prepare pass can try again.
-- Confirm delivery only for opportunity ids returned by the deterministic script.
+- Never call MCP tools in this pass — the script owns all ledger confirmation.
 - Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in the reply.
 - Never construct URLs yourself. The URL guard strips anything except approved connect, profile, and Edge Esmeralda event links.

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -136,6 +136,8 @@ export interface BriefOpportunity {
   feedCategory?: string;
   opportunityId?: string;
   confidence?: number;
+  /** Cooldown re-show — the user has already seen this card in a previous digest. */
+  redelivery?: boolean;
 }
 
 export interface DailyBriefContext {
@@ -402,12 +404,14 @@ export function parseOpportunityTranscript(text: string): BriefOpportunity[] {
       continue;
     }
 
-    const field = line.trim().match(/^(status|profileUrl|acceptUrl|feedCategory|opportunityId|confidence):\s*(.+)$/);
+    const field = line.trim().match(/^(status|profileUrl|acceptUrl|feedCategory|opportunityId|confidence|redelivery):\s*(.+)$/);
     if (field) {
       const key = field[1] as keyof BriefOpportunity;
       if (key === "confidence") {
         const val = parseFloat(field[2].trim());
         if (!isNaN(val)) current[key] = val;
+      } else if (key === "redelivery") {
+        current.redelivery = field[2].trim() === "true";
       } else {
         current[key] = field[2].trim();
       }
@@ -786,6 +790,87 @@ export async function fetchOpportunitiesFromMcp(opts: {
   if (!text.trim()) return [];
 
   return parseOpportunityTranscript(text);
+}
+
+/**
+ * Confirm digest delivery for a set of opportunity ids by calling the Index
+ * MCP server's `confirm_opportunity_delivery` tool directly via JSON-RPC.
+ *
+ * Owned by the deterministic send script (not the LLM prompt) so the delivery
+ * ledger is written reliably — a skipped confirm means the same opportunity
+ * reappears in later digests. Each id is confirmed independently with one
+ * retry; failures never throw, they are reported back for diagnostics.
+ *
+ * @returns per-id outcome: `confirmed` (includes already_delivered) or `failed` with reason.
+ */
+export async function confirmOpportunityDeliveriesViaMcp(opts: {
+  apiKey: string;
+  mcpUrl: string;
+  opportunityIds: string[];
+}): Promise<{ confirmed: string[]; failed: Array<{ opportunityId: string; reason: string }> }> {
+  const confirmed: string[] = [];
+  const failed: Array<{ opportunityId: string; reason: string }> = [];
+  if (opts.opportunityIds.length === 0) return { confirmed, failed };
+
+  try {
+    const initResp = await postMcpMessage(opts.mcpUrl, opts.apiKey, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "agentvillage-digest", version: "1.0.0" },
+      },
+    });
+    if (initResp.error) throw new Error(`MCP initialize: ${initResp.error.message}`);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { confirmed, failed: opts.opportunityIds.map((opportunityId) => ({ opportunityId, reason })) };
+  }
+
+  let rpcId = 2;
+  for (const opportunityId of opts.opportunityIds) {
+    let lastReason = "unknown";
+    let ok = false;
+    for (let attempt = 0; attempt < 2 && !ok; attempt++) {
+      try {
+        const resp = await postMcpMessage(opts.mcpUrl, opts.apiKey, {
+          jsonrpc: "2.0",
+          id: rpcId++,
+          method: "tools/call",
+          params: {
+            name: "confirm_opportunity_delivery",
+            arguments: { opportunityId, trigger: "digest" },
+          },
+        });
+        if (resp.error) {
+          lastReason = resp.error.message;
+          continue;
+        }
+        const result = resp.result as McpToolResult | undefined;
+        const text = result?.content?.find((c) => c.type === "text")?.text ?? "";
+        // The tool returns a success/error envelope; treat an explicit
+        // success:false as failure so we don't silently drop ledger writes.
+        try {
+          const parsed = JSON.parse(text) as { success?: boolean; error?: unknown };
+          if (parsed.success === false) {
+            lastReason = typeof parsed.error === "string" ? parsed.error : "tool reported failure";
+            continue;
+          }
+        } catch {
+          // Non-JSON tool text — the call itself succeeded; accept it.
+        }
+        ok = true;
+      } catch (err) {
+        lastReason = err instanceof Error ? err.message : String(err);
+      }
+    }
+    if (ok) confirmed.push(opportunityId);
+    else failed.push({ opportunityId, reason: lastReason });
+  }
+
+  return { confirmed, failed };
 }
 
 /**

--- a/skills/index-network/scripts/send-daily-brief.ts
+++ b/skills/index-network/scripts/send-daily-brief.ts
@@ -13,7 +13,7 @@
 import { existsSync } from "node:fs";
 import { access } from "node:fs/promises";
 
-import { QUESTION_COOLDOWN_DAYS } from "./build-daily-brief-context";
+import { QUESTION_COOLDOWN_DAYS, confirmOpportunityDeliveriesViaMcp, resolveIndexApiKey } from "./build-daily-brief-context";
 import { extractDigestOpportunityIds, extractDigestQuestionIds, sanitizeDigestUrls } from "./validate-digest-urls";
 
 interface SendResult {
@@ -21,7 +21,34 @@ interface SendResult {
   opportunityIds: string[];
   questionIds: string[];
   finalBrief: string;
+  /** Opportunity ids whose digest delivery was confirmed on the Index ledger by this script. */
+  confirmedOpportunityIds: string[];
+  /** Opportunity ids whose ledger confirm failed (diagnostics only — delivery still proceeds). */
+  confirmFailed: Array<{ opportunityId: string; reason: string }>;
 }
+
+type DeliveryConfirmer = (opportunityIds: string[]) => Promise<{
+  confirmed: string[];
+  failed: Array<{ opportunityId: string; reason: string }>;
+}>;
+
+/**
+ * Default ledger confirmer: resolve the Index API key the same way the
+ * context builder does and call the MCP server directly. When no key is
+ * available every id is reported as failed — never throws.
+ */
+const defaultConfirmDeliveries: DeliveryConfirmer = async (opportunityIds) => {
+  if (opportunityIds.length === 0) return { confirmed: [], failed: [] };
+  const apiKey = resolveIndexApiKey();
+  if (!apiKey) {
+    return {
+      confirmed: [],
+      failed: opportunityIds.map((opportunityId) => ({ opportunityId, reason: "INDEX_API_KEY unavailable" })),
+    };
+  }
+  const mcpUrl = process.env.INDEX_MCP_URL?.trim() || "https://protocol.index.network/mcp";
+  return confirmOpportunityDeliveriesViaMcp({ apiKey, mcpUrl, opportunityIds });
+};
 
 interface SilentResult {
   silent: true;
@@ -129,11 +156,13 @@ export async function sendDailyBrief(options: {
   stateFile?: string;
   outgoingFile?: string;
   hermes?: HermesRunner;
+  confirmDeliveries?: DeliveryConfirmer;
 } = {}): Promise<SendResult | SilentResult> {
   const date = options.date ?? pacificDate();
   const stateFile = options.stateFile ?? "memory/heartbeat-state.json";
   const outgoingFile = options.outgoingFile ?? "memory/digest-outgoing.md";
   const hermes = options.hermes ?? runHermes;
+  const confirmDeliveries = options.confirmDeliveries ?? defaultConfirmDeliveries;
 
   const state = await readJsonObject(stateFile);
   const prepared = state.prepared && typeof state.prepared === "object" && !Array.isArray(state.prepared)
@@ -188,8 +217,25 @@ export async function sendDailyBrief(options: {
 
   await hermes(["kanban", "complete", taskId, "--summary", "delivered"]);
 
+  // Confirm digest delivery on the Index ledger deterministically. This used
+  // to be an LLM-prompt step ("call confirm_opportunity_delivery for each
+  // id") and was skipped often enough that opportunities re-surfaced in later
+  // digests. Failures are diagnostics only — the brief still goes out.
+  let confirmedOpportunityIds: string[] = [];
+  let confirmFailed: Array<{ opportunityId: string; reason: string }> = [];
+  try {
+    const confirmResult = await confirmDeliveries(opportunityIds);
+    confirmedOpportunityIds = confirmResult.confirmed;
+    confirmFailed = confirmResult.failed;
+  } catch (err) {
+    confirmFailed = opportunityIds.map((opportunityId) => ({
+      opportunityId,
+      reason: err instanceof Error ? err.message : String(err),
+    }));
+  }
+
   const { output: finalBrief } = sanitizeDigestUrls(body, { stripDigestMetadata: true });
-  return { taskId, opportunityIds, questionIds, finalBrief };
+  return { taskId, opportunityIds, questionIds, finalBrief, confirmedOpportunityIds, confirmFailed };
 }
 
 async function main(): Promise<void> {

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -140,7 +140,10 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
       const action = opp.acceptUrl ? ` [Say hi](${opp.acceptUrl}).` : " Say hi.";
       const reason = opportunityReason(opp, "Relevant overlap with your current signals.");
       const lineBody = reason.includesLabel ? reason.text : `${opportunityLabel(opp)} — ${reason.text}`;
-      lines.push(`- ${opportunityMarker(opp)}${lineBody}.${action}`);
+      // Cooldown re-shows are framed as reminders so the user knows this is a
+      // deliberate nudge about something still waiting, not a repeated rec.
+      const prefix = opp.redelivery ? "Still open — " : "";
+      lines.push(`- ${opportunityMarker(opp)}${prefix}${lineBody}.${action}`);
     }
     lines.push("");
     hasVerifiedContent = true;
@@ -156,7 +159,8 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
       const action = opp.acceptUrl ? ` Know someone? [Make intro](${opp.acceptUrl}).` : " Know someone? Make intro.";
       const reason = opportunityReason(opp, "They are looking for a relevant introduction.");
       const lineBody = reason.includesLabel ? reason.text : `${opportunityLabel(opp)} — ${reason.text}`;
-      lines.push(`- ${opportunityMarker(opp)}${lineBody}.${action}`);
+      const prefix = opp.redelivery ? "Still open — " : "";
+      lines.push(`- ${opportunityMarker(opp)}${prefix}${lineBody}.${action}`);
     }
     lines.push("");
     hasVerifiedContent = true;

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   buildDailyBriefContext,
+  confirmOpportunityDeliveriesViaMcp,
   extractInterestTags,
   fetchOpportunitiesFromMcp,
   fetchPendingQuestionsFromMcp,
@@ -164,6 +165,28 @@ describe("build-daily-brief-context helpers", () => {
     expect(parsed[1].confidence).toBeUndefined();
     expect(parsed[2]).toMatchObject({ name: "Carol" });
     expect(parsed[2].confidence).toBeUndefined();
+  });
+
+  test("parseOpportunityTranscript parses the redelivery flag as a boolean", () => {
+    const parsed = parseOpportunityTranscript(`1. Alice
+   <!-- digest-opportunity:id=alice -->
+   builds agents
+   status: pending
+   redelivery: true
+
+2. Bob
+   <!-- digest-opportunity:id=bob -->
+   seeks collaborators
+   status: pending
+
+3. Carol
+   <!-- digest-opportunity:id=carol -->
+   odd value
+   redelivery: yes-ish`);
+
+    expect(parsed[0]).toMatchObject({ name: "Alice", redelivery: true });
+    expect(parsed[1].redelivery).toBeUndefined();
+    expect(parsed[2].redelivery).toBe(false);
   });
 
   test("filterDedupedOpportunities keeps cards without ids and drops delivered ids", () => {
@@ -776,6 +799,124 @@ describe("fetchPendingQuestionsFromMcp", () => {
       expect(prompt).not.toContain("\n");
       expect(prompt.length).toBeLessThanOrEqual(300);
       expect(prompt.endsWith("…")).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("confirmOpportunityDeliveriesViaMcp", () => {
+  const MCP_URL = "https://example.com/mcp";
+
+  type ConfirmCall = { opportunityId?: string; trigger?: string };
+
+  function makeConfirmFetch(
+    toolsCallFn: (args: ConfirmCall, callIndex: number) => Response,
+  ): { fetch: typeof fetch; calls: ConfirmCall[] } {
+    const calls: ConfirmCall[] = [];
+    const fetchFn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string ?? "{}") as {
+        method: string;
+        params?: { name?: string; arguments?: ConfirmCall };
+      };
+      if (body.method === "initialize") {
+        return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } });
+      }
+      if (body.method === "tools/call") {
+        expect(body.params?.name).toBe("confirm_opportunity_delivery");
+        const args = body.params?.arguments ?? {};
+        calls.push(args);
+        return toolsCallFn(args, calls.length - 1);
+      }
+      throw new Error(`unexpected method: ${body.method}`);
+    }) as typeof fetch;
+    return { fetch: fetchFn, calls };
+  }
+
+  test("confirms each id with trigger=digest and reports them confirmed", async () => {
+    const originalFetch = globalThis.fetch;
+    const { fetch: mockFetch, calls } = makeConfirmFetch(() =>
+      Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: JSON.stringify({ success: true, data: { status: "confirmed" } }) }] } }),
+    );
+    globalThis.fetch = mockFetch;
+    try {
+      const result = await confirmOpportunityDeliveriesViaMcp({
+        apiKey: "test-key",
+        mcpUrl: MCP_URL,
+        opportunityIds: ["opp-1", "opp-2"],
+      });
+      expect(result.confirmed).toEqual(["opp-1", "opp-2"]);
+      expect(result.failed).toEqual([]);
+      expect(calls).toEqual([
+        { opportunityId: "opp-1", trigger: "digest" },
+        { opportunityId: "opp-2", trigger: "digest" },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns immediately for an empty id list without network calls", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("should not be called");
+    }) as typeof fetch;
+    try {
+      const result = await confirmOpportunityDeliveriesViaMcp({ apiKey: "k", mcpUrl: MCP_URL, opportunityIds: [] });
+      expect(result).toEqual({ confirmed: [], failed: [] });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("retries once and succeeds on the second attempt", async () => {
+    const originalFetch = globalThis.fetch;
+    const { fetch: mockFetch, calls } = makeConfirmFetch((_args, callIndex) =>
+      callIndex === 0
+        ? Response.json({ jsonrpc: "2.0", id: 2, error: { code: -32000, message: "transient" } })
+        : Response.json({ jsonrpc: "2.0", id: 3, result: { content: [{ type: "text", text: JSON.stringify({ success: true }) }] } }),
+    );
+    globalThis.fetch = mockFetch;
+    try {
+      const result = await confirmOpportunityDeliveriesViaMcp({ apiKey: "k", mcpUrl: MCP_URL, opportunityIds: ["opp-1"] });
+      expect(result.confirmed).toEqual(["opp-1"]);
+      expect(calls).toHaveLength(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("reports per-id failure when the tool keeps failing, without throwing", async () => {
+    const originalFetch = globalThis.fetch;
+    const { fetch: mockFetch } = makeConfirmFetch((args) =>
+      args.opportunityId === "opp-bad"
+        ? Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: JSON.stringify({ success: false, error: "not yours" }) }] } })
+        : Response.json({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: JSON.stringify({ success: true }) }] } }),
+    );
+    globalThis.fetch = mockFetch;
+    try {
+      const result = await confirmOpportunityDeliveriesViaMcp({
+        apiKey: "k",
+        mcpUrl: MCP_URL,
+        opportunityIds: ["opp-good", "opp-bad"],
+      });
+      expect(result.confirmed).toEqual(["opp-good"]);
+      expect(result.failed).toEqual([{ opportunityId: "opp-bad", reason: "not yours" }]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("fails every id when initialize fails, without throwing", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+    try {
+      const result = await confirmOpportunityDeliveriesViaMcp({ apiKey: "k", mcpUrl: MCP_URL, opportunityIds: ["opp-1", "opp-2"] });
+      expect(result.confirmed).toEqual([]);
+      expect(result.failed).toHaveLength(2);
+      expect(result.failed[0].reason).toContain("network down");
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/skills/index-network/scripts/tests/send-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/send-daily-brief.test.ts
@@ -61,6 +61,7 @@ describe("sendDailyBrief", () => {
       "[fabricated](https://index.network/accept/123)",
     ].join("\n");
 
+    const confirmCalls: string[][] = [];
     const result = await sendDailyBrief({
       date: "2026-06-04",
       stateFile: "state.json",
@@ -71,12 +72,21 @@ describe("sendDailyBrief", () => {
         if (args[0] === "kanban" && args[1] === "complete") return "completed";
         throw new Error(`unexpected hermes call: ${args.join(" ")}`);
       },
+      confirmDeliveries: async (ids) => {
+        confirmCalls.push(ids);
+        return { confirmed: ids, failed: [] };
+      },
     });
 
     expect("silent" in result).toBe(false);
     if ("silent" in result) throw new Error("unexpected silent result");
     expect(result.taskId).toBe("t_digest");
     expect(result.opportunityIds).toEqual(["opp-1"]);
+    // Ledger confirmation is owned by the script and keyed off the markers
+    // surviving in the (possibly human-edited) body — not the staged ids.
+    expect(confirmCalls).toEqual([["opp-1"]]);
+    expect(result.confirmedOpportunityIds).toEqual(["opp-1"]);
+    expect(result.confirmFailed).toEqual([]);
     expect(result.finalBrief).toContain("[Maya](https://index.network/u/11111111-1111-1111-1111-111111111111)");
     expect(result.finalBrief).toContain("[say hi](https://protocol.index.network/c/abc123)");
     expect(result.finalBrief).toContain("fabricated");
@@ -104,6 +114,7 @@ describe("sendDailyBrief", () => {
       "<!-- digest-question:id=q-0001 -->**One for you:** What are you building?",
     ].join("\n");
 
+    const confirmCalls: string[][] = [];
     const result = await sendDailyBrief({
       date: "2026-06-10",
       stateFile: "state.json",
@@ -112,6 +123,10 @@ describe("sendDailyBrief", () => {
         if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest", status: "ready", body } });
         if (args[0] === "kanban" && args[1] === "complete") return "completed";
         throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+      confirmDeliveries: async (ids) => {
+        confirmCalls.push(ids);
+        return { confirmed: ids, failed: [] };
       },
     });
 
@@ -125,5 +140,84 @@ describe("sendDailyBrief", () => {
     // q-old (9 days ago, past the 3-day cooldown) pruned; q-recent kept; q-0001 recorded today.
     expect(state.questionDelivery).toEqual({ "q-recent": "2026-06-09", "q-0001": "2026-06-10" });
     expect(state.signalElicitation).toEqual({ lastAskedDate: "2026-06-09" });
+    // No opportunity markers in the body → nothing to confirm.
+    expect(confirmCalls).toEqual([[]]);
+  });
+
+  test("a failing ledger confirm is diagnostics-only — the brief still ships", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      prepared: { date: "2026-06-04", taskId: "t_digest" },
+    }));
+    const body = "<!-- digest-opportunity:id=opp-1 -->[Maya](https://index.network/u/11111111-1111-1111-1111-111111111111) — relevant";
+
+    const result = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      outgoingFile: "outgoing.md",
+      hermes: (args) => {
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest", status: "ready", body } });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+      confirmDeliveries: async (ids) => ({
+        confirmed: [],
+        failed: ids.map((opportunityId) => ({ opportunityId, reason: "mcp unreachable" })),
+      }),
+    });
+
+    expect("silent" in result).toBe(false);
+    if ("silent" in result) throw new Error("unexpected silent result");
+    expect(result.finalBrief).toContain("Maya");
+    expect(result.confirmedOpportunityIds).toEqual([]);
+    expect(result.confirmFailed).toEqual([{ opportunityId: "opp-1", reason: "mcp unreachable" }]);
+    // Delivery state was still recorded locally despite the ledger failure.
+    expect(JSON.parse(await Bun.file("state.json").text()).deliveredToday).toEqual({ date: "2026-06-04", ids: ["opp-1"] });
+  });
+
+  test("a throwing confirmer never breaks the send", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      prepared: { date: "2026-06-04", taskId: "t_digest" },
+    }));
+    const body = "<!-- digest-opportunity:id=opp-1 -->Maya — relevant";
+
+    const result = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      outgoingFile: "outgoing.md",
+      hermes: (args) => {
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest", status: "ready", body } });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+      confirmDeliveries: async () => {
+        throw new Error("confirmer exploded");
+      },
+    });
+
+    expect("silent" in result).toBe(false);
+    if ("silent" in result) throw new Error("unexpected silent result");
+    expect(result.finalBrief).toContain("Maya");
+    expect(result.confirmedOpportunityIds).toEqual([]);
+    expect(result.confirmFailed).toEqual([{ opportunityId: "opp-1", reason: "confirmer exploded" }]);
+  });
+
+  test("silent results never invoke the confirmer", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({ prepared: { date: "2026-06-03", taskId: "t_old" } }));
+
+    const result = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      hermes: () => {
+        throw new Error("hermes should not be called");
+      },
+      confirmDeliveries: async () => {
+        throw new Error("confirmer should not be called");
+      },
+    });
+
+    expect(result).toEqual({ silent: true, reason: "no-staged-task" });
   });
 });

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -123,6 +123,41 @@ describe("composeDailyBrief", () => {
     expect(body).not.toContain("Potential connections via Index Network");
     expect(body).toContain("<!-- digest-opportunity:id=opp-1 -->[Maya]");
     expect(body).toContain("[Say hi](https://protocol.index.network/c/abc123)");
+    // Fresh opportunity — no reminder framing.
+    expect(body).not.toContain("Still open");
+  });
+
+  test("frames cooldown re-shows as 'Still open' reminders in both sections", () => {
+    const connection = {
+      name: "Maya",
+      opportunityId: "opp-1",
+      mainText: "You both care about privacy-preserving agents",
+      profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
+      acceptUrl: "https://protocol.index.network/c/abc123",
+      feedCategory: "connection",
+      redelivery: true,
+    };
+    const community = {
+      name: "Remi",
+      opportunityId: "opp-2",
+      mainText: "Looking for a systems engineer.",
+      profileUrl: "https://index.network/u/22222222-2222-2222-2222-222222222222",
+      acceptUrl: "https://protocol.index.network/c/def456",
+      feedCategory: "connector-flow",
+      redelivery: true,
+    };
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      opportunities: [connection, community],
+      connectionOpportunities: [connection],
+      communityOpportunities: [community],
+    });
+
+    expect(body).toContain("<!-- digest-opportunity:id=opp-1 -->Still open — ");
+    expect(body).toContain("<!-- digest-opportunity:id=opp-2 -->Still open — ");
+    // Reminder framing must not break action links.
+    expect(body).toContain("[Say hi](https://protocol.index.network/c/abc123)");
+    expect(body).toContain("[Make intro](https://protocol.index.network/c/def456)");
   });
 
   test("renders digest-ready presenter summaries and linkifies the person name", () => {


### PR DESCRIPTION
## Problem

Digest deliveries were not reliably confirmed on the Index ledger. Prod evidence: an opportunity shown to a user ~3 mornings in a row had only **one** `digest` delivery row (written today). The confirm step lived in the send-pass LLM prompt ("call `confirm_opportunity_delivery` for each id") — exactly the class of step prompts skip. Without ledger rows, the new server-side cross-day digest dedup (indexnetwork/index#949) has nothing to key on.

## Changes

- **`send-daily-brief.ts` owns ledger confirmation.** After the approval gate, state bookkeeping, and Kanban completion, the script confirms every extracted opportunity id via direct MCP JSON-RPC (`confirm_opportunity_delivery`, `trigger="digest"`) using the new `confirmOpportunityDeliveriesViaMcp` helper — one retry per id, never throws, per-id failures surfaced as diagnostics (`confirmedOpportunityIds` / `confirmFailed` in the output JSON). A failing confirm never blocks the brief.
- **`send.md`**: the LLM must not call any MCP tool in the send pass anymore; step 4 documents that the script owns confirmation.
- **`redelivery` field**: `parseOpportunityTranscript` parses the new `redelivery: true` line emitted by `list_opportunities` digest mode for cooldown re-shows.
- **"Still open — …" framing**: `composeDailyBrief` prefixes redelivery cards in both the connection and community sections so a deliberate reminder reads as one, with markers and action links intact.

## Tests

72 pass across all 4 script suites, including new coverage for: confirm happy path / retry / per-id failure / initialize failure / empty-list short-circuit, throwing-confirmer isolation, silent-path guard (confirmer never invoked), `redelivery` boolean parsing, and "Still open" rendering in both sections.

## Deploy notes

Works against the existing prod MCP server (the confirm tool already exists), so this is safe to merge before or after indexnetwork/index#949 — but cross-day suppression only activates once both are live. First post-deploy digest should show empty `confirmFailed` in the send output.