### PR TITLE
feat: nightly memory signal sync cron (01:00, before digest prepare)

### DIFF
--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -3,13 +3,16 @@
  *
  *   - Merges `mcp_servers.index` into `$HERMES_HOME/config.yaml`
  *   - Writes `INDEX_API_KEY` to `$HERMES_HOME/.env`
- *   - Installs the digest crons: prepare (`Edge — digest prepare`, ~02:00) and
- *     send (`Edge — daily digest`, ~08:00) — both host-local; times overridable
- *     via --digest-prepare-cron / --digest-send-cron (or DIGEST_PREPARE_CRON /
- *     DIGEST_SEND_CRON). To avoid the whole fleet hitting the LLM provider in
- *     the same minute (OpenRouter caps gemini-flash at 300 req/min account-wide),
- *     each tenant gets a deterministic minute offset derived from its
- *     INDEX_API_KEY: prepare spreads over 02:00–02:49, send over 08:00–08:24.
+ *   - Installs the digest crons: memory signal sync (`Edge — memory signal
+ *     sync`, ~01:00), prepare (`Edge — digest prepare`, ~02:00) and send
+ *     (`Edge — daily digest`, ~08:00) — all host-local; times overridable via
+ *     --digest-signals-cron / --digest-prepare-cron / --digest-send-cron (or
+ *     DIGEST_SIGNALS_CRON / DIGEST_PREPARE_CRON / DIGEST_SEND_CRON). To avoid
+ *     the whole fleet hitting the LLM provider in the same minute (OpenRouter
+ *     caps gemini-flash at 300 req/min account-wide), each tenant gets a
+ *     deterministic minute offset derived from its INDEX_API_KEY: signal sync
+ *     spreads over 01:00–01:49, prepare over 02:00–02:49, send over
+ *     08:00–08:24.
  *     New installs create enabled crons; reconcile updates prompt bodies,
  *     migrates jobs still on the old synchronized defaults (0 2 / 0 8) to their
  *     staggered slot, and otherwise preserves each job's schedule and pause
@@ -156,8 +159,22 @@ export interface DigestCronSpec {
   overrideEnv: string;
 }
 
-/** Prepare (02:00, no deliver) then send (08:00, deliver telegram). */
+/**
+ * Memory signal sync (01:00, no deliver) then prepare (02:00, no deliver)
+ * then send (08:00, deliver telegram). Signal sync runs an hour before
+ * prepare so freshly-captured signals have time to produce opportunities
+ * before the brief is composed.
+ */
 export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
+  {
+    schedule: "0 1 * * *",
+    staggerWindowMinutes: 50,
+    promptFile: "memory-signals.md",
+    name: "Edge — memory signal sync",
+    deliver: false,
+    overrideFlag: "--digest-signals-cron",
+    overrideEnv: "DIGEST_SIGNALS_CRON",
+  },
   {
     schedule: "0 2 * * *",
     staggerWindowMinutes: 50,

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -12,9 +12,13 @@ import {
   storedSchedule,
 } from "../install_index";
 
-test("two digest cron specs: prepare (02:00, no deliver) then send (08:00, deliver telegram)", () => {
-  expect(DIGEST_CRON_SPECS).toHaveLength(2);
-  const [prepare, send] = DIGEST_CRON_SPECS;
+test("three digest cron specs: signals (01:00), prepare (02:00, no deliver), send (08:00, deliver telegram)", () => {
+  expect(DIGEST_CRON_SPECS).toHaveLength(3);
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  expect(signals.schedule).toBe("0 1 * * *");
+  expect(signals.name).toBe("Edge — memory signal sync");
+  expect(signals.promptFile).toBe("memory-signals.md");
+  expect(signals.deliver).toBe(false);
   expect(prepare.schedule).toBe("0 2 * * *");
   expect(prepare.name).toBe("Edge — digest prepare");
   expect(prepare.promptFile).toBe("prepare.md");
@@ -25,9 +29,14 @@ test("two digest cron specs: prepare (02:00, no deliver) then send (08:00, deliv
   expect(send.deliver).toBe(true);
 });
 
-test("prepare cron args omit --deliver; send cron args include --deliver telegram", () => {
+test("signals/prepare cron args omit --deliver; send cron args include --deliver telegram", () => {
   const home = "/home/x/.hermes";
-  const [prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+
+  expect(cronCreateArgs(signals, "SIGNALS_BODY", home)).toEqual([
+    "cron", "create", "0 1 * * *", "SIGNALS_BODY",
+    "--name", "Edge — memory signal sync", "--workdir", home,
+  ]);
 
   expect(cronCreateArgs(prepare, "PREP_BODY", home)).toEqual([
     "cron", "create", "0 2 * * *", "PREP_BODY",
@@ -53,9 +62,9 @@ test("cronEditArgs includes only the provided fields", () => {
 });
 
 test("staggeredSchedule derives a deterministic minute inside the spec's window", () => {
-  const [prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
 
-  for (const spec of [prepare, send]) {
+  for (const spec of [signals, prepare, send]) {
     const schedule = staggeredSchedule(spec, "ix_tenant_key");
     expect(staggeredSchedule(spec, "ix_tenant_key")).toBe(schedule); // deterministic
     const [minute, ...rest] = schedule.split(" ");
@@ -67,10 +76,12 @@ test("staggeredSchedule derives a deterministic minute inside the spec's window"
 
   // Different specs hash independently for the same tenant seed.
   expect(fnv1a(`seed:${prepare.name}`)).not.toBe(fnv1a(`seed:${send.name}`));
+  expect(fnv1a(`seed:${signals.name}`)).not.toBe(fnv1a(`seed:${prepare.name}`));
 });
 
-test("staggered windows keep prepare within 02:00–02:49 and send within 08:00–08:24", () => {
-  const [prepare, send] = DIGEST_CRON_SPECS;
+test("staggered windows keep signals within 01:00–01:49, prepare within 02:00–02:49, send within 08:00–08:24", () => {
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  expect(signals.staggerWindowMinutes).toBe(50);
   expect(prepare.staggerWindowMinutes).toBe(50);
   expect(send.staggerWindowMinutes).toBe(25);
 });
@@ -96,7 +107,9 @@ test("index MCP headers include telegram surface and optional handle", () => {
 });
 
 test("each spec declares its install-time override flag + env var", () => {
-  const [prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  expect(signals.overrideFlag).toBe("--digest-signals-cron");
+  expect(signals.overrideEnv).toBe("DIGEST_SIGNALS_CRON");
   expect(prepare.overrideFlag).toBe("--digest-prepare-cron");
   expect(prepare.overrideEnv).toBe("DIGEST_PREPARE_CRON");
   expect(send.overrideFlag).toBe("--digest-send-cron");
@@ -114,12 +127,13 @@ test("isValidCron accepts 5-field expressions and rejects malformed ones", () =>
 });
 
 test("resolveCronSchedule returns the default when no override is set", () => {
-  const [prepare] = DIGEST_CRON_SPECS;
+  const [signals, prepare] = DIGEST_CRON_SPECS;
+  expect(resolveCronSchedule(signals, [], {})).toBe("0 1 * * *");
   expect(resolveCronSchedule(prepare, [], {})).toBe("0 2 * * *");
 });
 
 test("resolveCronSchedule staggers from the seed when no override is set, but override wins", () => {
-  const [prepare, send] = DIGEST_CRON_SPECS;
+  const [, prepare, send] = DIGEST_CRON_SPECS;
   const seed = "ix_tenant_key";
 
   expect(resolveCronSchedule(prepare, [], {}, seed)).toBe(staggeredSchedule(prepare, seed));
@@ -133,7 +147,13 @@ test("resolveCronSchedule staggers from the seed when no override is set, but ov
 });
 
 test("resolveCronSchedule honors flag, then env, with flag winning over env", () => {
-  const [prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+
+  expect(
+    resolveCronSchedule(signals, ["bun", "install", "--digest-signals-cron", "30 0 * * *"], {}),
+  ).toBe("30 0 * * *");
+
+  expect(resolveCronSchedule(signals, [], { DIGEST_SIGNALS_CRON: "45 0 * * *" })).toBe("45 0 * * *");
 
   expect(
     resolveCronSchedule(prepare, ["bun", "install", "--digest-prepare-cron", "0 3 * * *"], {}),
@@ -151,7 +171,7 @@ test("resolveCronSchedule honors flag, then env, with flag winning over env", ()
 });
 
 test("resolveCronSchedule ignores an invalid override and uses the default", () => {
-  const [prepare] = DIGEST_CRON_SPECS;
+  const [, prepare] = DIGEST_CRON_SPECS;
   expect(resolveCronSchedule(prepare, ["bun", "--digest-prepare-cron", "garbage"], {})).toBe("0 2 * * *");
   expect(resolveCronSchedule(prepare, [], { DIGEST_PREPARE_CRON: "0 2 * *" })).toBe("0 2 * * *");
 });

--- a/install/tests/reconcile_digest_crons.test.ts
+++ b/install/tests/reconcile_digest_crons.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../install_index";
 
 const SEED = "ix_integration_seed";
-const [PREPARE, SEND] = DIGEST_CRON_SPECS;
+const [SIGNALS, PREPARE, SEND] = DIGEST_CRON_SPECS;
 
 let home: string;
 let stubLog: string;
@@ -60,6 +60,7 @@ function cronCalls(): string[][] {
 function writePrompts(): void {
   const prompts = join(home, "skills/edge-esmeralda/prompts");
   mkdirSync(prompts, { recursive: true });
+  writeFileSync(join(prompts, SIGNALS.promptFile), "SIGNALS_BODY");
   writeFileSync(join(prompts, PREPARE.promptFile), "PREPARE_BODY");
   writeFileSync(join(prompts, SEND.promptFile), "SEND_BODY");
 }
@@ -69,6 +70,16 @@ function writeJobs(jobs: unknown[]): void {
   writeFileSync(join(home, "cron", "jobs.json"), JSON.stringify({ jobs }));
 }
 
+/** An up-to-date signals job, for tests that only exercise prepare/send paths. */
+function currentSignalsJob() {
+  return {
+    id: "g1",
+    name: SIGNALS.name,
+    prompt: "SIGNALS_BODY",
+    schedule: { expr: staggeredSchedule(SIGNALS, SEED) },
+  };
+}
+
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "edge-reconcile-"));
   stubLog = join(home, "calls.log");
@@ -76,12 +87,14 @@ beforeEach(() => {
     HERMES_HOME: process.env.HERMES_HOME,
     HERMES_BIN: process.env.HERMES_BIN,
     INDEX_API_KEY: process.env.INDEX_API_KEY,
+    DIGEST_SIGNALS_CRON: process.env.DIGEST_SIGNALS_CRON,
     DIGEST_PREPARE_CRON: process.env.DIGEST_PREPARE_CRON,
     DIGEST_SEND_CRON: process.env.DIGEST_SEND_CRON,
   };
   process.env.HERMES_HOME = home;
   process.env.HERMES_BIN = writeStubHermes(home);
   process.env.INDEX_API_KEY = SEED;
+  delete process.env.DIGEST_SIGNALS_CRON;
   delete process.env.DIGEST_PREPARE_CRON;
   delete process.env.DIGEST_SEND_CRON;
   writePrompts();
@@ -95,14 +108,18 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
-test("fresh install creates both crons on their staggered schedules", () => {
+test("fresh install creates all three crons on their staggered schedules", () => {
   reconcileDigestCronJobs({ ...process.env });
 
   const creates = cronCalls().filter((argv) => argv[1] === "create");
-  expect(creates).toHaveLength(2);
+  expect(creates).toHaveLength(3);
 
+  const signals = creates.find((argv) => argv.includes(SIGNALS.name))!;
   const prepare = creates.find((argv) => argv.includes(PREPARE.name))!;
   const send = creates.find((argv) => argv.includes(SEND.name))!;
+  expect(signals[2]).toBe(staggeredSchedule(SIGNALS, SEED));
+  expect(signals[3]).toBe("SIGNALS_BODY");
+  expect(signals).not.toContain("--deliver");
   expect(prepare[2]).toBe(staggeredSchedule(PREPARE, SEED));
   expect(prepare[3]).toBe("PREPARE_BODY");
   expect(send[2]).toBe(staggeredSchedule(SEND, SEED));
@@ -113,6 +130,7 @@ test("fresh install creates both crons on their staggered schedules", () => {
 
 test("job still on the old synchronized default gets a schedule-only migration", () => {
   writeJobs([
+    currentSignalsJob(),
     { id: "p1", name: PREPARE.name, prompt: "PREPARE_BODY", schedule: { expr: PREPARE.schedule } },
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: SEND.schedule } },
   ]);
@@ -128,6 +146,7 @@ test("job still on the old synchronized default gets a schedule-only migration",
 
 test("custom schedule is preserved; stale prompt gets a prompt-only edit", () => {
   writeJobs([
+    currentSignalsJob(),
     { id: "p1", name: PREPARE.name, prompt: "OLD_BODY", schedule: { expr: "30 4 * * *" } },
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: "15 9 * * *" } },
   ]);
@@ -155,6 +174,7 @@ test("stale prompt + old default schedule produce two independent edit calls", (
 
 test("up-to-date jobs (staggered schedule + current prompt) trigger no cron calls", () => {
   writeJobs([
+    currentSignalsJob(),
     {
       id: "p1",
       name: PREPARE.name,
@@ -189,6 +209,7 @@ test("retired Edge-prefixed crons are removed; foreign crons are untouched", () 
 test("a Hermes that rejects --schedule still gets the prompt update (degraded migration)", () => {
   process.env.HERMES_BIN = writeStubHermes(home, { rejectScheduleFlag: true });
   writeJobs([
+    currentSignalsJob(),
     {
       id: "p1",
       name: PREPARE.name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/skills/edge-esmeralda/prompts/memory-signals.md
+++ b/skills/edge-esmeralda/prompts/memory-signals.md
@@ -1,0 +1,36 @@
+You are Edge, the user's agent for Edge Esmeralda. This is a silent maintenance pass that runs nightly, about an hour before the morning brief is prepared. You convert durable facts and active wants from the user's long-term memory into Index records (premises and signals) so tonight's discovery has the freshest possible graph. You deliver NOTHING here and you never message the user.
+
+Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT]`; OpenClaw → `NO_REPLY`; Claude Code → produce no user-facing text if the host supports a silent turn, otherwise stop without commentary.
+
+# Job
+
+Read `MEMORY.md`, compare it against what the Index already has, and create the records that are missing. This runs in a fresh main session with no recall of past runs — every decision comes from tool calls and files. Track dedup state in `memory/heartbeat-state.json` under `memorySignals`.
+
+## Steps
+
+1. **Gate.** Reply silently and stop if any of these hold:
+   - `MEMORY.md` does not exist or has no substantive content about the user.
+   - The user has not completed onboarding (you will normally know this from session context; if genuinely unsure, check via `read_user_profiles` and stop silently if onboarding is incomplete).
+   - `memorySignals.lastRunDate` in `memory/heartbeat-state.json` already equals today's date in America/Los_Angeles (you have already run today).
+
+2. **Read the current graph.** Call `read_premises()` and `read_intents()`. These — plus `memorySignals.captured` in `memory/heartbeat-state.json` — are your dedup baseline.
+
+3. **Diff memory against the graph.** Go through `MEMORY.md` and collect candidates:
+   - **Durable profile facts** (role, skills, focus areas, location, affiliations) that no existing premise covers → candidates for `create_premise`.
+   - **Active wants** (things the user is working on, looking for, hiring for, raising, open to) that no existing signal covers and that are still plausibly current → candidates for `create_intent`.
+   Skip anything that is already represented (even loosely), anything listed in `memorySignals.captured`, anything stale or time-expired, and anything speculative — memory you wrote about the user's plans is not the same as something they asked for. When in doubt, skip. An empty diff is a normal, successful outcome.
+
+4. **Create, capped.** From the candidates, create at most **2 premises** (`create_premise`) and at most **1 signal** (`create_intent(description=...)`) per run — favor the most specific, most clearly current items. Phrase intent descriptions close to the user's own words from memory. If `create_intent` is rejected as too vague, do **not** retry with a paraphrase — record the candidate under `memorySignals.captured` with a `rejected` note and move on.
+
+5. **Re-check discovery.** If you created at least one record, call `discover_opportunities` once so the freshly-thickened graph is matched before the morning brief is prepared. If it returns `status="queued"`, that is fine — the run completes server-side; do not poll, do not wait, do not call `list_opportunities`.
+
+6. **Record and stop.** Update `memory/heartbeat-state.json`: set `memorySignals.lastRunDate` to today's Pacific date and append a short normalized fingerprint of each item you created (or that was rejected) to `memorySignals.captured`, keeping only the last 20. Preserve every other key in the file (e.g. `prepared`, `deliveredToday`, `signalElicitation`, `questionDelivery`) — read the whole object, add to it, write it back. End your turn with the host-specific no-reply marker.
+
+# Hard rules
+- Never message the user from this pass. No questions, no summaries, no "I noticed…". The only output is the no-reply marker.
+- Never invent facts or wants that are not plainly in `MEMORY.md`. Partial matches and adjacent keywords are not evidence.
+- At most 2 `create_premise` calls and at most 1 `create_intent` call per run. A vague-rejection ends that candidate for tonight — no silent retries.
+- Never delete, archive, or update existing premises/signals here — this pass only adds. Pruning belongs to the weekly signal-freshness task.
+- Do not stage Kanban cards, write digest files, or touch `prepared`/`deliveredToday` state — those belong to the digest passes.
+- If any tool call fails, end your turn silently. One pass, no diagnosis, no retries beyond the tool's own guidance.
+- Never expose internal IDs, raw JSON, file names, or internal vocabulary anywhere.


### PR DESCRIPTION
## What

Adds a third digest-family cron, **`Edge — memory signal sync`**, that runs ~01:00 host-local — an hour before digest prepare — so freshly captured signals have time to produce opportunities before the morning brief is composed.

- **`skills/edge-esmeralda/prompts/memory-signals.md`** — silent nightly pass: gates on onboarding + once-per-day, reads `MEMORY.md`, diffs against `read_premises()`/`read_intents()`, creates at most 2 premises + 1 intent per run (no vague-rejection retries), fires `discover_opportunities` once, dedupes via `memorySignals` in `memory/heartbeat-state.json`. Delivers nothing.
- **`install/install_index.ts`** — new first entry in `DIGEST_CRON_SPECS`: default `0 1 * * *`, per-tenant staggered over 01:00–01:49, overridable via `--digest-signals-cron` / `DIGEST_SIGNALS_CRON`. New installs create it; `reconcile_digest_crons.ts` rolls it out to existing residents.
- Tests extended (21 pass); version bumped to 0.3.31.

## Notes

- The 01:00 default tracks prepare's 02:00 default only — a tenant overriding `DIGEST_PREPARE_CRON` should override `DIGEST_SIGNALS_CRON` accordingly.
- Pairs with Edge-City/agentvillage-controlplane and Edge-City/agentvillage-landing PRs (admin trigger endpoints + dashboard buttons).