### PR TITLE
Introduce shared daily-loop canary layer

### DIFF
--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -17,6 +17,12 @@
  *     migrates jobs still on the old synchronized defaults (0 2 / 0 8) to their
  *     staggered slot, and otherwise preserves each job's schedule and pause
  *     state (user-customized schedules are never touched).
+ *   - Daily-loop crons are a separate, additive, canary-only non-brief
+ *     evaluation layer. `--enable-daily-loop-crons` or
+ *     `ENABLE_DAILY_LOOP_CRONS=true` installs/reconciles internal wakeups at
+ *     14/17/20 prepare and 15/18/21 send host-local. Normal installs leave them
+ *     disabled, and these wakeups do not change morning digest or control-plane
+ *     evening behavior.
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -157,6 +163,10 @@ export interface DigestCronSpec {
   overrideFlag: string;
   /** Env var that overrides `schedule` at install time (flag wins). */
   overrideEnv: string;
+  /** Back-compat CLI flag accepted during the rename from check-in to daily loop. */
+  legacyOverrideFlag?: string;
+  /** Back-compat env var accepted during the rename from check-in to daily loop. */
+  legacyOverrideEnv?: string;
 }
 
 /**
@@ -194,6 +204,43 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     overrideEnv: "DIGEST_SEND_CRON",
   },
 ];
+
+export const DAILY_LOOP_CRON_SPECS: DigestCronSpec[] = [
+  {
+    schedule: "0 14,17,20 * * *",
+    staggerWindowMinutes: 1,
+    promptFile: "daily-loop-prepare.md",
+    name: "Edge — daily loop prepare",
+    deliver: false,
+    overrideFlag: "--daily-loop-prepare-cron",
+    overrideEnv: "DAILY_LOOP_PREPARE_CRON",
+    legacyOverrideFlag: "--checkin-prepare-cron",
+    legacyOverrideEnv: "CHECKIN_PREPARE_CRON",
+  },
+  {
+    schedule: "0 15,18,21 * * *",
+    staggerWindowMinutes: 1,
+    promptFile: "daily-loop-send.md",
+    name: "Edge — daily loop send",
+    deliver: true,
+    overrideFlag: "--daily-loop-send-cron",
+    overrideEnv: "DAILY_LOOP_SEND_CRON",
+    legacyOverrideFlag: "--checkin-send-cron",
+    legacyOverrideEnv: "CHECKIN_SEND_CRON",
+  },
+];
+
+const EDGE_CRON_SPECS: DigestCronSpec[] = [...DIGEST_CRON_SPECS, ...DAILY_LOOP_CRON_SPECS];
+
+export function dailyLoopCronsEnabled(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (argv.includes("--enable-daily-loop-crons")) return true;
+  if (argv.includes("--enable-checkin-crons")) return true;
+  const value = (env.ENABLE_DAILY_LOOP_CRONS ?? env.ENABLE_CHECKIN_CRONS)?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes";
+}
 
 /** FNV-1a 32-bit hash — deterministic, dependency-free. */
 export function fnv1a(input: string): number {
@@ -258,7 +305,12 @@ export function resolveCronSchedule(
   const fallback = staggerSeed ? staggeredSchedule(spec, staggerSeed) : spec.schedule;
   const flagIdx = argv.indexOf(spec.overrideFlag);
   const fromFlag = flagIdx >= 0 ? argv[flagIdx + 1]?.trim() : undefined;
-  const override = fromFlag || env[spec.overrideEnv]?.trim();
+  const legacyFlagIdx = spec.legacyOverrideFlag ? argv.indexOf(spec.legacyOverrideFlag) : -1;
+  const fromLegacyFlag = legacyFlagIdx >= 0 ? argv[legacyFlagIdx + 1]?.trim() : undefined;
+  const override = fromFlag
+    || fromLegacyFlag
+    || env[spec.overrideEnv]?.trim()
+    || (spec.legacyOverrideEnv ? env[spec.legacyOverrideEnv]?.trim() : undefined);
   if (!override) return fallback;
   if (!isValidCron(override)) {
     console.warn(
@@ -295,7 +347,10 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
   }
 
   const existing = readCronJobs();
-  const specNames = new Set(DIGEST_CRON_SPECS.map((s) => s.name));
+  const activeCronSpecs = dailyLoopCronsEnabled(process.argv, process.env)
+    ? EDGE_CRON_SPECS
+    : DIGEST_CRON_SPECS;
+  const specNames = new Set(activeCronSpecs.map((s) => s.name));
   // Stable per-tenant seed for schedule staggering. The tenant's own Index
   // API key never changes across reinstalls, so the derived minute is stable.
   const staggerSeed = process.env.INDEX_API_KEY?.trim() || readPersistedEnvVar("INDEX_API_KEY");
@@ -317,7 +372,11 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
     console.warn("  warning: could not run `hermes kanban init` — board may auto-init on first use");
   }
 
-  for (const spec of DIGEST_CRON_SPECS) {
+  if (!dailyLoopCronsEnabled(process.argv, process.env)) {
+    console.log("→ daily loop crons disabled (set --enable-daily-loop-crons or ENABLE_DAILY_LOOP_CRONS=true to install canary jobs)");
+  }
+
+  for (const spec of activeCronSpecs) {
     const promptPath = join(promptsDir, spec.promptFile);
     if (!existsSync(promptPath)) {
       console.error(`error: prompt missing at ${promptPath} — run install.ts first`);

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -1,8 +1,10 @@
 import { test, expect } from "bun:test";
 
 import {
+  DAILY_LOOP_CRON_SPECS,
   DIGEST_CRON_SPECS,
   buildIndexMcpHeaders,
+  dailyLoopCronsEnabled,
   cronCreateArgs,
   cronEditArgs,
   fnv1a,
@@ -27,6 +29,40 @@ test("three digest cron specs: signals (01:00), prepare (02:00, no deliver), sen
   expect(send.name).toBe("Edge — daily digest");
   expect(send.promptFile).toBe("send.md");
   expect(send.deliver).toBe(true);
+});
+
+test("daily-loop crons are separate canary non-brief evaluation wakeups", () => {
+  expect(DAILY_LOOP_CRON_SPECS).toHaveLength(2);
+  const [prepare, send] = DAILY_LOOP_CRON_SPECS;
+
+  expect(prepare.schedule).toBe("0 14,17,20 * * *");
+  expect(prepare.name).toBe("Edge — daily loop prepare");
+  expect(prepare.promptFile).toBe("daily-loop-prepare.md");
+  expect(prepare.deliver).toBe(false);
+  expect(prepare.overrideFlag).toBe("--daily-loop-prepare-cron");
+  expect(prepare.overrideEnv).toBe("DAILY_LOOP_PREPARE_CRON");
+
+  expect(send.schedule).toBe("0 15,18,21 * * *");
+  expect(send.name).toBe("Edge — daily loop send");
+  expect(send.promptFile).toBe("daily-loop-send.md");
+  expect(send.deliver).toBe(true);
+  expect(send.overrideFlag).toBe("--daily-loop-send-cron");
+  expect(send.overrideEnv).toBe("DAILY_LOOP_SEND_CRON");
+});
+
+test("daily loop cron args are separate from unchanged digest prepare/send crons", () => {
+  const home = "/home/x/.hermes";
+  const [prepare, send] = DAILY_LOOP_CRON_SPECS;
+
+  expect(cronCreateArgs(prepare, "DAILY_LOOP_PREPARE", home)).toEqual([
+    "cron", "create", "0 14,17,20 * * *", "DAILY_LOOP_PREPARE",
+    "--name", "Edge — daily loop prepare", "--workdir", home,
+  ]);
+
+  expect(cronCreateArgs(send, "DAILY_LOOP_SEND", home)).toEqual([
+    "cron", "create", "0 15,18,21 * * *", "DAILY_LOOP_SEND",
+    "--name", "Edge — daily loop send", "--deliver", "telegram", "--workdir", home,
+  ]);
 });
 
 test("signals/prepare cron args omit --deliver; send cron args include --deliver telegram", () => {
@@ -114,6 +150,39 @@ test("each spec declares its install-time override flag + env var", () => {
   expect(prepare.overrideEnv).toBe("DIGEST_PREPARE_CRON");
   expect(send.overrideFlag).toBe("--digest-send-cron");
   expect(send.overrideEnv).toBe("DIGEST_SEND_CRON");
+});
+
+test("daily loop cron schedules honor flag/env overrides", () => {
+  const [prepare, send] = DAILY_LOOP_CRON_SPECS;
+
+  expect(resolveCronSchedule(prepare, [], {})).toBe("0 14,17,20 * * *");
+  expect(resolveCronSchedule(send, [], { DAILY_LOOP_SEND_CRON: "30 15,18,21 * * *" })).toBe("30 15,18,21 * * *");
+  expect(
+    resolveCronSchedule(
+      prepare,
+      ["bun", "--daily-loop-prepare-cron", "15 13,16,19 * * *"],
+      { DAILY_LOOP_PREPARE_CRON: "0 12 * * *" },
+    ),
+  ).toBe("15 13,16,19 * * *");
+});
+
+test("daily-loop cron schedules keep legacy check-in override aliases during rename", () => {
+  const [prepare, send] = DAILY_LOOP_CRON_SPECS;
+
+  expect(
+    resolveCronSchedule(prepare, ["bun", "--checkin-prepare-cron", "15 13,16,19 * * *"], {}),
+  ).toBe("15 13,16,19 * * *");
+  expect(resolveCronSchedule(send, [], { CHECKIN_SEND_CRON: "30 15,18,21 * * *" })).toBe("30 15,18,21 * * *");
+});
+
+test("daily loop cron install gate is disabled by default and opt-in by flag/env aliases", () => {
+  expect(dailyLoopCronsEnabled([], {})).toBe(false);
+  expect(dailyLoopCronsEnabled(["bun", "--enable-daily-loop-crons"], {})).toBe(true);
+  expect(dailyLoopCronsEnabled(["bun", "--enable-checkin-crons"], {})).toBe(true);
+  expect(dailyLoopCronsEnabled([], { ENABLE_DAILY_LOOP_CRONS: "true" })).toBe(true);
+  expect(dailyLoopCronsEnabled([], { ENABLE_CHECKIN_CRONS: "true" })).toBe(true);
+  expect(dailyLoopCronsEnabled([], { ENABLE_DAILY_LOOP_CRONS: "1" })).toBe(true);
+  expect(dailyLoopCronsEnabled([], { ENABLE_DAILY_LOOP_CRONS: "false" })).toBe(false);
 });
 
 test("isValidCron accepts 5-field expressions and rejects malformed ones", () => {

--- a/install/tests/reconcile_digest_crons.test.ts
+++ b/install/tests/reconcile_digest_crons.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  DAILY_LOOP_CRON_SPECS,
   DIGEST_CRON_SPECS,
   reconcileDigestCronJobs,
   staggeredSchedule,
@@ -17,6 +18,7 @@ import {
 
 const SEED = "ix_integration_seed";
 const [SIGNALS, PREPARE, SEND] = DIGEST_CRON_SPECS;
+const [DAILY_LOOP_PREPARE, DAILY_LOOP_SEND] = DAILY_LOOP_CRON_SPECS;
 
 let home: string;
 let stubLog: string;
@@ -63,6 +65,8 @@ function writePrompts(): void {
   writeFileSync(join(prompts, SIGNALS.promptFile), "SIGNALS_BODY");
   writeFileSync(join(prompts, PREPARE.promptFile), "PREPARE_BODY");
   writeFileSync(join(prompts, SEND.promptFile), "SEND_BODY");
+  writeFileSync(join(prompts, DAILY_LOOP_PREPARE.promptFile), "DAILY_LOOP_PREPARE_BODY");
+  writeFileSync(join(prompts, DAILY_LOOP_SEND.promptFile), "DAILY_LOOP_SEND_BODY");
 }
 
 function writeJobs(jobs: unknown[]): void {
@@ -80,6 +84,23 @@ function currentSignalsJob() {
   };
 }
 
+function currentDailyLoopJobs() {
+  return [
+    {
+      id: "cp1",
+      name: DAILY_LOOP_PREPARE.name,
+      prompt: "DAILY_LOOP_PREPARE_BODY",
+      schedule: { expr: DAILY_LOOP_PREPARE.schedule },
+    },
+    {
+      id: "cs1",
+      name: DAILY_LOOP_SEND.name,
+      prompt: "DAILY_LOOP_SEND_BODY",
+      schedule: { expr: DAILY_LOOP_SEND.schedule },
+    },
+  ];
+}
+
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "edge-reconcile-"));
   stubLog = join(home, "calls.log");
@@ -90,6 +111,9 @@ beforeEach(() => {
     DIGEST_SIGNALS_CRON: process.env.DIGEST_SIGNALS_CRON,
     DIGEST_PREPARE_CRON: process.env.DIGEST_PREPARE_CRON,
     DIGEST_SEND_CRON: process.env.DIGEST_SEND_CRON,
+    DAILY_LOOP_PREPARE_CRON: process.env.DAILY_LOOP_PREPARE_CRON,
+    DAILY_LOOP_SEND_CRON: process.env.DAILY_LOOP_SEND_CRON,
+    ENABLE_DAILY_LOOP_CRONS: process.env.ENABLE_DAILY_LOOP_CRONS,
   };
   process.env.HERMES_HOME = home;
   process.env.HERMES_BIN = writeStubHermes(home);
@@ -97,6 +121,9 @@ beforeEach(() => {
   delete process.env.DIGEST_SIGNALS_CRON;
   delete process.env.DIGEST_PREPARE_CRON;
   delete process.env.DIGEST_SEND_CRON;
+  delete process.env.DAILY_LOOP_PREPARE_CRON;
+  delete process.env.DAILY_LOOP_SEND_CRON;
+  delete process.env.ENABLE_DAILY_LOOP_CRONS;
   writePrompts();
 });
 
@@ -108,7 +135,7 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
-test("fresh install creates all three crons on their staggered schedules", () => {
+test("fresh install creates only unchanged digest crons by default", () => {
   reconcileDigestCronJobs({ ...process.env });
 
   const creates = cronCalls().filter((argv) => argv[1] === "create");
@@ -126,6 +153,26 @@ test("fresh install creates all three crons on their staggered schedules", () =>
   expect(send[3]).toBe("SEND_BODY");
   expect(send).toContain("--deliver");
   expect(prepare).not.toContain("--deliver");
+  expect(creates.some((argv) => argv.includes(DAILY_LOOP_PREPARE.name))).toBe(false);
+  expect(creates.some((argv) => argv.includes(DAILY_LOOP_SEND.name))).toBe(false);
+});
+
+test("canary daily-loop crons install only when explicitly enabled", () => {
+  process.env.ENABLE_DAILY_LOOP_CRONS = "true";
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const creates = cronCalls().filter((argv) => argv[1] === "create");
+  expect(creates).toHaveLength(5);
+
+  const dailyLoopPrepare = creates.find((argv) => argv.includes(DAILY_LOOP_PREPARE.name))!;
+  const dailyLoopSend = creates.find((argv) => argv.includes(DAILY_LOOP_SEND.name))!;
+  expect(dailyLoopPrepare[2]).toBe(DAILY_LOOP_PREPARE.schedule);
+  expect(dailyLoopPrepare[3]).toBe("DAILY_LOOP_PREPARE_BODY");
+  expect(dailyLoopPrepare).not.toContain("--deliver");
+  expect(dailyLoopSend[2]).toBe(DAILY_LOOP_SEND.schedule);
+  expect(dailyLoopSend[3]).toBe("DAILY_LOOP_SEND_BODY");
+  expect(dailyLoopSend).toContain("--deliver");
 });
 
 test("job still on the old synchronized default gets a schedule-only migration", () => {
@@ -206,6 +253,37 @@ test("retired Edge-prefixed crons are removed; foreign crons are untouched", () 
   expect(removes).toEqual([["cron", "remove", "old1"]]);
 });
 
+test("existing daily loop crons are removed when the canary gate is disabled", () => {
+  writeJobs([
+    currentSignalsJob(),
+    {
+      id: "p1",
+      name: PREPARE.name,
+      prompt: "PREPARE_BODY",
+      schedule: { expr: staggeredSchedule(PREPARE, SEED) },
+    },
+    {
+      id: "s1",
+      name: SEND.name,
+      prompt: "SEND_BODY",
+      schedule: { expr: staggeredSchedule(SEND, SEED) },
+    },
+    ...currentDailyLoopJobs(),
+    { id: "oldcp", name: "Edge — check-in prepare", prompt: "OLD", schedule: { expr: "0 14,17,20 * * *" } },
+    { id: "oldcs", name: "Edge — check-in send", prompt: "OLD", schedule: { expr: "0 15,18,21 * * *" } },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const removes = cronCalls().filter((argv) => argv[1] === "remove");
+  expect(removes).toEqual([
+    ["cron", "remove", "cp1"],
+    ["cron", "remove", "cs1"],
+    ["cron", "remove", "oldcp"],
+    ["cron", "remove", "oldcs"],
+  ]);
+});
+
 test("a Hermes that rejects --schedule still gets the prompt update (degraded migration)", () => {
   process.env.HERMES_BIN = writeStubHermes(home, { rejectScheduleFlag: true });
   writeJobs([
@@ -234,4 +312,14 @@ test("DIGEST_SEND_CRON override beats the staggered default on create", () => {
 
   const send = cronCalls().find((argv) => argv[1] === "create" && argv.includes(SEND.name))!;
   expect(send[2]).toBe("45 7 * * *");
+});
+
+test("DAILY_LOOP_SEND_CRON override beats the default on create", () => {
+  process.env.DAILY_LOOP_SEND_CRON = "30 15,18,21 * * *";
+  process.env.ENABLE_DAILY_LOOP_CRONS = "true";
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const send = cronCalls().find((argv) => argv[1] === "create" && argv.includes(DAILY_LOOP_SEND.name))!;
+  expect(send[2]).toBe("30 15,18,21 * * *");
 });

--- a/skills/edge-esmeralda/prompts/daily-loop-prepare.md
+++ b/skills/edge-esmeralda/prompts/daily-loop-prepare.md
@@ -1,0 +1,41 @@
+You are Edge, the user's agent for Edge Esmeralda. This is a daily-loop prepare wakeup. You deliver NOTHING here — staging only.
+
+# Product status
+
+Daily-loop tone/question framing is intentionally a placeholder launch surface. The deterministic mechanics are canary-only, and broad launch remains blocked on product/tone refinement. Do not polish, invent, or expand copy in this prompt; placeholder templates live in `skills/index-network/scripts/daily-loop.ts`.
+
+# Shared daily-loop boundary
+
+This prepare pass is the non-brief side of a shared daily loop. It normalizes current context, consults shared state for what Edge already surfaced/asked/sent/skipped today, applies interruption policy and budget, and stages at most one reviewed Kanban card.
+
+Morning brief does not yet write this full contract. Current context input is `memory/daily-loop-context.json` by default; pass `--context-file <path>` only if a fresher deterministic context artifact exists. `memory/daily-brief-context.json` is intentionally not the default because it is morning-owned and can be stale.
+
+# Cadence and behavior boundary
+
+Morning brief remains the daily anchor and is unchanged by this canary. The existing memory-signal, digest-prepare, and digest-send crons keep their current timing and behavior.
+
+This daily-loop prepare pass is an additive, disabled-by-default, non-brief evaluation wakeup. The 14/17/20 prepare windows are candidate evaluation times only, not promised sends. Integration with morning or any future evening brief surface is deferred.
+
+# Job
+
+Run the deterministic staging script exactly once:
+
+```
+bun skills/index-network/scripts/daily-loop.ts --state-file memory/daily-loop-state.json
+```
+
+Window resolution is host-local to match the host-local cron schedule. If this prompt runs outside a configured prepare hour (14, 17, 20) and no explicit `--window` is passed, the script returns `[SILENT]` rather than guessing a window.
+
+If the script exits non-zero, end with the host no-reply marker exactly: Hermes → `[SILENT]`; OpenClaw → `NO_REPLY`; Claude Code → produce no user-facing text if the host supports a silent turn, otherwise stop without commentary.
+
+End this turn with the host no-reply marker. Do not deliver from the prepare pass.
+
+# Hard rules
+
+- Never send Telegram from this prepare pass.
+- Do not create or edit Kanban cards manually; the script is the only staging path.
+- Always require review: staged cards stay blocked until an operator approves copy.
+- Operator delivery approval requires moving the card to `ready` and adding the literal marker `APPROVED_DAILY_LOOP_SEND` to the Kanban body. A plain unblock/todo state is not enough.
+- Do not call Index MCP tools manually.
+- Do not name people unless the script source includes real profile/action URLs.
+- Keep the placeholder/tone TODO visible in this prompt/config surface. Launch is blocked until product/tone refinement approves final copy.

--- a/skills/edge-esmeralda/prompts/daily-loop-send.md
+++ b/skills/edge-esmeralda/prompts/daily-loop-send.md
@@ -1,0 +1,41 @@
+You are Edge, the user's agent for Edge Esmeralda. This is a daily-loop send wakeup. Hermes delivers your final assistant reply to Telegram only when the deterministic script returns approved copy.
+
+# Product status
+
+Daily-loop tone/question framing is intentionally a placeholder launch surface. The mechanics may run in canary/review mode, but broad launch remains blocked on product/tone refinement. Do not compose, improve, or supplement copy here; the reviewed Kanban body is the source of truth.
+
+# Cadence and behavior boundary
+
+Morning brief remains the daily anchor and is unchanged by this canary. This send pass belongs to a separate, additive, disabled-by-default non-brief evaluation layer.
+
+The 15/18/21 send wakeups are internal evaluation times, not promised sends. Visible delivery is still capped by policy, defaults to one non-brief interruption per day, and requires explicit Kanban approval. No control-plane or evening-brief behavior changes here.
+
+# Job
+
+Run the deterministic send script exactly once:
+
+```
+bun skills/index-network/scripts/daily-loop.ts --send --state-file memory/daily-loop-state.json
+```
+
+If the script exits non-zero, end immediately with `[SILENT]`. Do not diagnose, retry, or attempt alternatives.
+
+Window resolution is host-local to match the host-local cron schedule. If this prompt runs outside a configured send hour (15, 18, 21) and no explicit `--window` is passed, the script returns `[SILENT]` rather than guessing a window.
+
+If stdout is exactly `[SILENT]`, end your turn with exactly `[SILENT]`.
+
+If stdout is JSON, parse it:
+
+```json
+{ "sent": true, "taskId": "...", "finalMessage": "..." }
+```
+
+Your final assistant reply must be `finalMessage` verbatim and complete — nothing before it, nothing after it, no commentary, no reformatting.
+
+# Hard rules
+
+- Send only cards approved by Kanban status `ready` and the literal marker `APPROVED_DAILY_LOOP_SEND` in the Kanban body. A plain unblock/todo card is not approval.
+- Never regenerate the daily-loop message in this send pass.
+- Never call Index MCP tools manually.
+- Never expose internal IDs, raw JSON, marker comments, or internal vocabulary.
+- Stale, blocked, missing, empty, budget-used, duplicate-question, or already-sent cards mean `[SILENT]`.

--- a/skills/index-network/scripts/daily-loop.ts
+++ b/skills/index-network/scripts/daily-loop.ts
@@ -1,0 +1,661 @@
+#!/usr/bin/env bun
+/**
+ * Shared daily-loop canary for non-brief Edge interruptions.
+ *
+ * The point of this module is the boundary, not final copy. Morning brief can
+ * later write into the same state/context contract so Edge has one record of
+ * what it already surfaced or asked today.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { access } from "node:fs/promises";
+import { dirname } from "node:path";
+
+// context: normalized calendar/RSVP/Index/memory/brief-history inputs
+export type DailyLoopWindow = "1500" | "1800" | "2100";
+export type DailyLoopRole =
+  | "orient"
+  | "calibrate_rest_of_day"
+  | "event_followup"
+  | "close_loop"
+  | "tomorrow_prep"
+  | "silent";
+export type DailyLoopInput =
+  | "pending-question"
+  | "thin-signal"
+  | "pace-preference"
+  | "ended-rsvp"
+  | "live-opportunity"
+  | "active-want"
+  | "reflection"
+  | "brief-history";
+export type DailyLoopSkipReason =
+  | "brief-already-asked"
+  | "event-followup-replaces-evening"
+  | "quiet-pace"
+  | "no-new-context"
+  | "budget-used"
+  | "cooldown"
+  | "stale";
+
+export interface DailyLoopWindowSpec {
+  window: DailyLoopWindow;
+  prepareHour: number;
+  sendHour: number;
+  titleTime: string;
+}
+
+export const DAILY_LOOP_WINDOWS: DailyLoopWindowSpec[] = [
+  { window: "1500", prepareHour: 14, sendHour: 15, titleTime: "15:00" },
+  { window: "1800", prepareHour: 17, sendHour: 18, titleTime: "18:00" },
+  { window: "2100", prepareHour: 20, sendHour: 21, titleTime: "21:00" },
+];
+
+export interface DailyLoopEvent {
+  title?: string;
+  eventUrl?: string;
+}
+
+export interface DailyLoopContext {
+  pendingQuestion?: { id?: string; prompt?: string };
+  thinSignal?: string;
+  pacePreference?: string;
+  endedRsvpEvent?: DailyLoopEvent;
+  opportunityCount?: number;
+  opportunityCategory?: string;
+  opportunityNames?: string[];
+  opportunityUrls?: string[];
+  activeWant?: string;
+  dayEventCount?: number;
+  unansweredEarlierLoop?: boolean;
+  briefAskedQuestionIds?: string[];
+}
+
+export interface DailyLoopCandidate {
+  body: string;
+  role: DailyLoopRole;
+  inputType: DailyLoopInput;
+  inputLabel: string;
+  questionId?: string;
+  replacesRoles?: DailyLoopRole[];
+}
+
+// render: placeholder tone/templates; launch-blocking copy surface
+export const DAILY_LOOP_RENDER_CONFIG = {
+  status: "placeholder",
+  launchBlockedOn: "product/tone refinement",
+  approvalMarker: "APPROVED_DAILY_LOOP_SEND",
+  todo:
+    "TODO before launch: replace examples with approved Edge daily-loop question/tone guidance. Keep mechanics deterministic.",
+  examplesByWindow: {
+    "1500": "What would make the rest of today useful — a person, a topic, or quiet time?",
+    "1800": "Did you make it to {event}? If yes, did it surface anyone or anything you want help following up on?",
+    "2100": "What should I carry forward from today — a person, idea, moment, or something you want more of tomorrow?",
+  } satisfies Record<DailyLoopWindow, string>,
+};
+
+// state: surfaced/asked/sent/skipped, visible budget, cooldowns
+interface DailyLoopRecord {
+  at: string;
+  role: DailyLoopRole;
+  window?: DailyLoopWindow;
+  reason?: string;
+  questionId?: string;
+  taskId?: string;
+}
+
+interface WindowRecord {
+  date?: string;
+  taskId?: string;
+  idempotencyKey?: string;
+  role?: DailyLoopRole;
+  inputType?: DailyLoopInput;
+  inputLabel?: string;
+  questionId?: string;
+  body?: string;
+  preparedAt?: string;
+  sentAt?: string;
+  skippedAt?: string;
+  skipReason?: DailyLoopSkipReason;
+}
+
+export interface DailyLoopState {
+  date?: string;
+  visibleBudget?: { date?: string; nonBriefLimit?: number; nonBriefSent?: number; lastSentAt?: string };
+  cooldowns?: { nonBriefMinutes?: number };
+  surfaced?: DailyLoopRecord[];
+  asked?: DailyLoopRecord[];
+  sent?: DailyLoopRecord[];
+  skipped?: DailyLoopRecord[];
+  windows?: Partial<Record<DailyLoopWindow, WindowRecord>>;
+}
+
+type HermesRunner = (args: string[]) => string | Promise<string>;
+
+const DEFAULT_NON_BRIEF_LIMIT = 1;
+const DEFAULT_COOLDOWN_MINUTES = 90;
+const DEFAULT_STALE_AFTER_MINUTES = 90;
+const APPROVAL_MARKER = DAILY_LOOP_RENDER_CONFIG.approvalMarker;
+
+function argValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
+}
+
+function hostLocalDate(now = new Date()): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+function hostLocalTime(date: string, hour: number): Date {
+  const [year, month, day] = date.split("-").map(Number);
+  return new Date(year, month - 1, day, hour);
+}
+
+function windowSpec(window: DailyLoopWindow): DailyLoopWindowSpec {
+  const spec = DAILY_LOOP_WINDOWS.find((entry) => entry.window === window);
+  if (!spec) throw new Error(`unknown daily-loop window: ${window}`);
+  return spec;
+}
+
+export function scheduledWindowForHostHour(kind: "prepare" | "send", hour: number): DailyLoopWindow | undefined {
+  const spec = DAILY_LOOP_WINDOWS.find((entry) => (kind === "prepare" ? entry.prepareHour : entry.sendHour) === hour);
+  return spec?.window;
+}
+
+export function resolveWindowArg(args: string[], kind: "prepare" | "send", now = new Date()): DailyLoopWindow | undefined {
+  const explicit = argValue(args, "--window");
+  if (explicit) {
+    if (!DAILY_LOOP_WINDOWS.some((entry) => entry.window === explicit)) return undefined;
+    return explicit as DailyLoopWindow;
+  }
+  return scheduledWindowForHostHour(kind, now.getHours());
+}
+
+function titleFor(date: string, window: DailyLoopWindow): string {
+  return `Daily loop ${windowSpec(window).titleTime} — ${date}`;
+}
+
+function idempotencyKey(date: string, window: DailyLoopWindow): string {
+  return `daily-loop-${date}-${window}`;
+}
+
+function firstAllowedOpportunityName(context: DailyLoopContext): string | undefined {
+  if (!context.opportunityUrls?.some((url) => /^https?:\/\//.test(url))) return undefined;
+  return context.opportunityNames?.find((name) => name.trim());
+}
+
+function linkEvent(event: DailyLoopEvent): string {
+  const title = event.title?.trim() || "that event";
+  return event.eventUrl ? `[${title}](${event.eventUrl})` : title;
+}
+
+function quietPace(context: DailyLoopContext): boolean {
+  return /\b(quiet|stay quiet|do not interrupt|don't interrupt)\b/i.test(context.pacePreference ?? "");
+}
+
+// roles + render: explicit role/input/outcome contract
+export function composeDailyLoopCandidate(options: {
+  date: string;
+  window: DailyLoopWindow;
+  context: DailyLoopContext;
+}): DailyLoopCandidate | null {
+  const { window, context } = options;
+
+  if (window === "1500") {
+    const prompt = context.pendingQuestion?.prompt?.trim();
+    if (prompt) {
+      return {
+        body: prompt,
+        role: "calibrate_rest_of_day",
+        inputType: "pending-question",
+        inputLabel: "pending Index question",
+        questionId: context.pendingQuestion?.id,
+      };
+    }
+    if (context.thinSignal?.trim()) {
+      return {
+        body: DAILY_LOOP_RENDER_CONFIG.examplesByWindow["1500"],
+        role: "calibrate_rest_of_day",
+        inputType: "thin-signal",
+        inputLabel: "thin or older signal",
+      };
+    }
+    return null;
+  }
+
+  if ((window === "1800" || window === "2100") && (context.endedRsvpEvent?.title || context.endedRsvpEvent?.eventUrl)) {
+    return {
+      body: `Did you make it to ${linkEvent(context.endedRsvpEvent)}? If yes, did it surface anyone or anything you want help following up on?`,
+      role: "event_followup",
+      inputType: "ended-rsvp",
+      inputLabel: "ended RSVP event",
+      replacesRoles: ["close_loop", "tomorrow_prep"],
+    };
+  }
+
+  if (window === "1800") {
+    if ((context.opportunityCount ?? 0) > 0) {
+      const name = firstAllowedOpportunityName(context);
+      const personPhrase = name ? `${name} or someone adjacent` : "one useful person";
+      return {
+        body: `If ${personPhrase} would be worth meeting this evening, what kind of person would that be?`,
+        role: "calibrate_rest_of_day",
+        inputType: "live-opportunity",
+        inputLabel: `${context.opportunityCount} live ${context.opportunityCategory || "opportunity"} candidate(s)`,
+      };
+    }
+    if (context.activeWant?.trim()) {
+      return {
+        body: "What kind of person would be useful to meet this evening?",
+        role: "calibrate_rest_of_day",
+        inputType: "active-want",
+        inputLabel: "active want",
+      };
+    }
+    return null;
+  }
+
+  if (context.unansweredEarlierLoop) {
+    return {
+      body: "Anything you are looking for tomorrow based on today?",
+      role: "close_loop",
+      inputType: "reflection",
+      inputLabel: "unanswered earlier daily-loop card",
+    };
+  }
+  if ((context.dayEventCount ?? 0) > 0 || context.activeWant?.trim()) {
+    return {
+      body: DAILY_LOOP_RENDER_CONFIG.examplesByWindow["2100"],
+      role: "tomorrow_prep",
+      inputType: "reflection",
+      inputLabel: "reflection or tomorrow prep",
+    };
+  }
+  return null;
+}
+
+async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+  try {
+    if (!existsSync(path)) return {};
+    const parsed = JSON.parse(await Bun.file(path).text());
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  mkdirSync(dirname(path), { recursive: true });
+  await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveHermesCommand(): Promise<string> {
+  if (process.env.HERMES_BIN) return process.env.HERMES_BIN;
+  if (await fileExists("/opt/hermes/.venv/bin/hermes")) return "/opt/hermes/.venv/bin/hermes";
+  return "hermes";
+}
+
+async function runHermes(args: string[]): Promise<string> {
+  const hermes = await resolveHermesCommand();
+  const result = Bun.spawnSync([hermes, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, HOME: process.env.HERMES_HOME ?? process.env.HOME, HERMES_HOME: process.env.HERMES_HOME ?? process.cwd() },
+  });
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    const stdout = new TextDecoder().decode(result.stdout).trim();
+    throw new Error(`${hermes} ${args.join(" ")} failed: ${stderr || stdout}`);
+  }
+  return new TextDecoder().decode(result.stdout);
+}
+
+function extractTaskId(raw: string): string {
+  const trimmed = raw.trim();
+  try {
+    const parsed = JSON.parse(trimmed) as { id?: unknown; task?: { id?: unknown } };
+    const id = typeof parsed.id === "string" ? parsed.id : typeof parsed.task?.id === "string" ? parsed.task.id : "";
+    if (id) return id;
+  } catch {
+    // fall through
+  }
+  const match = trimmed.match(/\b(t_[A-Za-z0-9_-]+)\b/);
+  if (match) return match[1];
+  throw new Error(`could not parse task id from kanban create output: ${trimmed.slice(0, 200)}`);
+}
+
+function parseTask(raw: string): { id?: string; status?: string; body?: string } | null {
+  try {
+    const parsed = JSON.parse(raw) as { task?: { id?: string; status?: string; body?: string } } & {
+      id?: string;
+      status?: string;
+      body?: string;
+    };
+    const task = parsed.task && typeof parsed.task === "object" ? parsed.task : parsed;
+    return task && typeof task === "object" ? task : null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeDailyLoopState(value: Record<string, unknown>, date: string): DailyLoopState {
+  const state = value as DailyLoopState;
+  if (state.date !== date) {
+    return {
+      date,
+      visibleBudget: { date, nonBriefLimit: DEFAULT_NON_BRIEF_LIMIT, nonBriefSent: 0 },
+      cooldowns: { nonBriefMinutes: DEFAULT_COOLDOWN_MINUTES },
+      surfaced: [],
+      asked: [],
+      sent: [],
+      skipped: [],
+      windows: {},
+    };
+  }
+  state.visibleBudget = state.visibleBudget?.date === date
+    ? state.visibleBudget
+    : { date, nonBriefLimit: DEFAULT_NON_BRIEF_LIMIT, nonBriefSent: 0 };
+  state.visibleBudget.nonBriefLimit ??= DEFAULT_NON_BRIEF_LIMIT;
+  state.visibleBudget.nonBriefSent ??= 0;
+  state.cooldowns ??= { nonBriefMinutes: DEFAULT_COOLDOWN_MINUTES };
+  state.cooldowns.nonBriefMinutes ??= DEFAULT_COOLDOWN_MINUTES;
+  state.surfaced ??= [];
+  state.asked ??= [];
+  state.sent ??= [];
+  state.skipped ??= [];
+  state.windows ??= {};
+  return state;
+}
+
+function minutesSince(iso: string | undefined, nowIso: string): number {
+  if (!iso) return Number.POSITIVE_INFINITY;
+  return (new Date(nowIso).getTime() - new Date(iso).getTime()) / 60_000;
+}
+
+function isStale(date: string, window: DailyLoopWindow, nowIso: string, staleAfterMinutes: number): boolean {
+  const sendAt = hostLocalTime(date, windowSpec(window).sendHour);
+  return (new Date(nowIso).getTime() - sendAt.getTime()) / 60_000 > staleAfterMinutes;
+}
+
+function recordSkip(
+  state: DailyLoopState,
+  nowIso: string,
+  role: DailyLoopRole,
+  window: DailyLoopWindow,
+  reason: DailyLoopSkipReason,
+): void {
+  state.skipped ??= [];
+  state.skipped.push({ at: nowIso, role, window, reason });
+}
+
+// policy: should interrupt? replacement rules? visible budget?
+export function evaluateDailyLoopPolicy(options: {
+  state: DailyLoopState;
+  context: DailyLoopContext;
+  candidate: DailyLoopCandidate | null;
+  window: DailyLoopWindow;
+  nowIso: string;
+}): { ok: true; candidate: DailyLoopCandidate } | { ok: false; reason: DailyLoopSkipReason } {
+  const { state, context, candidate, nowIso, window } = options;
+  if (quietPace(context)) {
+    recordSkip(state, nowIso, "silent", window, "quiet-pace");
+    return { ok: false, reason: "quiet-pace" };
+  }
+  if (!candidate) {
+    recordSkip(state, nowIso, "silent", window, "no-new-context");
+    return { ok: false, reason: "no-new-context" };
+  }
+  if (
+    candidate.questionId
+    && (
+      state.asked?.some((record) => record.questionId === candidate.questionId)
+      || context.briefAskedQuestionIds?.includes(candidate.questionId)
+    )
+  ) {
+    recordSkip(state, nowIso, candidate.role, window, "brief-already-asked");
+    return { ok: false, reason: "brief-already-asked" };
+  }
+  const budget = state.visibleBudget ?? { nonBriefLimit: DEFAULT_NON_BRIEF_LIMIT, nonBriefSent: 0 };
+  if ((budget.nonBriefSent ?? 0) >= (budget.nonBriefLimit ?? DEFAULT_NON_BRIEF_LIMIT)) {
+    recordSkip(state, nowIso, candidate.role, window, "budget-used");
+    return { ok: false, reason: "budget-used" };
+  }
+  if (minutesSince(budget.lastSentAt, nowIso) < (state.cooldowns?.nonBriefMinutes ?? DEFAULT_COOLDOWN_MINUTES)) {
+    recordSkip(state, nowIso, candidate.role, window, "cooldown");
+    return { ok: false, reason: "cooldown" };
+  }
+  if (candidate.role === "event_followup" && candidate.replacesRoles?.length) {
+    recordSkip(state, nowIso, "close_loop", window, "event-followup-replaces-evening");
+  }
+  return { ok: true, candidate };
+}
+
+function bodyWithReviewNote(body: string, candidate: DailyLoopCandidate): string {
+  return [
+    body,
+    "",
+    "<!-- daily-loop-review: placeholder launch copy; product/tone refinement required before broad launch -->",
+    `<!-- daily-loop-source:role=${candidate.role}; input=${candidate.inputType}; label=${candidate.inputLabel} -->`,
+  ].join("\n");
+}
+
+function stripDailyLoopMetadata(body: string): string {
+  return body
+    .replace(/<!--\s*daily-loop-(?:review|source):[\s\S]*?-->\n?/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function hasApprovalMarker(body: string): boolean {
+  return new RegExp(`\\b${APPROVAL_MARKER}\\b`).test(body);
+}
+
+// kanban: staging/review/send helpers
+export async function stageDailyLoop(options: {
+  date?: string;
+  window: DailyLoopWindow;
+  nowIso?: string;
+  stateFile?: string;
+  context: DailyLoopContext;
+  hermes?: HermesRunner;
+}): Promise<
+  | { staged: true; taskId: string; idempotencyKey: string; reused?: true }
+  | { staged: false; reason: DailyLoopSkipReason }
+> {
+  const date = options.date ?? hostLocalDate();
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const stateFile = options.stateFile ?? "memory/daily-loop-state.json";
+  const hermes = options.hermes ?? runHermes;
+
+  const state = normalizeDailyLoopState(await readJsonObject(stateFile), date);
+  const existing = state.windows?.[options.window];
+  if (existing?.taskId) {
+    return { staged: true, taskId: existing.taskId, idempotencyKey: existing.idempotencyKey ?? idempotencyKey(date, options.window), reused: true };
+  }
+
+  const candidate = composeDailyLoopCandidate({ date, window: options.window, context: options.context });
+  const decision = evaluateDailyLoopPolicy({ state, context: options.context, candidate, window: options.window, nowIso });
+  if (!decision.ok) {
+    await writeJson(stateFile, state);
+    return { staged: false, reason: decision.reason };
+  }
+
+  const key = idempotencyKey(date, options.window);
+  const body = bodyWithReviewNote(decision.candidate.body, decision.candidate);
+  const createOutput = await hermes([
+    "kanban",
+    "create",
+    titleFor(date, options.window),
+    "--body",
+    body,
+    "--idempotency-key",
+    key,
+    "--json",
+  ]);
+  const taskId = extractTaskId(createOutput);
+  await hermes(["kanban", "block", taskId, `review-required: daily loop ${windowSpec(options.window).titleTime} — ${date}`]);
+
+  state.surfaced?.push({ at: nowIso, role: decision.candidate.role, window: options.window, taskId });
+  if (decision.candidate.questionId) {
+    state.asked?.push({ at: nowIso, role: decision.candidate.role, window: options.window, questionId: decision.candidate.questionId, taskId });
+  }
+  state.windows ??= {};
+  state.windows[options.window] = {
+    date,
+    taskId,
+    idempotencyKey: key,
+    role: decision.candidate.role,
+    inputType: decision.candidate.inputType,
+    inputLabel: decision.candidate.inputLabel,
+    questionId: decision.candidate.questionId,
+    body,
+    preparedAt: nowIso,
+  };
+  await writeJson(stateFile, state);
+
+  return { staged: true, taskId, idempotencyKey: key };
+}
+
+export async function sendDailyLoop(options: {
+  date?: string;
+  window: DailyLoopWindow;
+  nowIso?: string;
+  stateFile?: string;
+  hermes?: HermesRunner;
+  staleAfterMinutes?: number;
+}): Promise<
+  | { sent: true; taskId: string; finalMessage: string }
+  | { sent: false; reason: string }
+> {
+  const date = options.date ?? hostLocalDate();
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const stateFile = options.stateFile ?? "memory/daily-loop-state.json";
+  const hermes = options.hermes ?? runHermes;
+  const staleAfterMinutes = options.staleAfterMinutes ?? DEFAULT_STALE_AFTER_MINUTES;
+
+  const state = normalizeDailyLoopState(await readJsonObject(stateFile), date);
+  const record = state.windows?.[options.window];
+  const taskId = record?.taskId ?? "";
+  if (!taskId || record?.date !== date) return { sent: false, reason: "no-staged-task" };
+  if (record.sentAt) return { sent: false, reason: "already-sent" };
+
+  if (isStale(date, options.window, nowIso, staleAfterMinutes)) {
+    record.skippedAt = nowIso;
+    record.skipReason = "stale";
+    recordSkip(state, nowIso, record.role ?? "silent", options.window, "stale");
+    await writeJson(stateFile, state);
+    await hermes(["kanban", "complete", taskId, "--summary", "skipped-stale"]);
+    return { sent: false, reason: "stale" };
+  }
+
+  const task = parseTask(await hermes(["kanban", "show", taskId, "--json"]));
+  if (!task) return { sent: false, reason: "task-unreadable" };
+
+  const status = String(task.status ?? "").toLowerCase();
+  if (status !== "ready") return { sent: false, reason: `not-approved:${status || "unknown"}` };
+
+  const rawBody = typeof task.body === "string" ? task.body : "";
+  if (!hasApprovalMarker(rawBody)) return { sent: false, reason: "missing-approval-marker" };
+  const body = stripDailyLoopMetadata(rawBody.replace(new RegExp(`\\b${APPROVAL_MARKER}\\b`, "g"), ""));
+  if (!body) return { sent: false, reason: "empty-body" };
+
+  state.visibleBudget = state.visibleBudget?.date === date
+    ? state.visibleBudget
+    : { date, nonBriefLimit: DEFAULT_NON_BRIEF_LIMIT, nonBriefSent: 0 };
+  state.visibleBudget.nonBriefSent = (state.visibleBudget.nonBriefSent ?? 0) + 1;
+  state.visibleBudget.lastSentAt = nowIso;
+  state.sent?.push({ at: nowIso, role: record.role ?? "silent", window: options.window, taskId });
+  record.sentAt = nowIso;
+  await writeJson(stateFile, state);
+
+  await hermes(["kanban", "complete", taskId, "--summary", "delivered"]);
+
+  return { sent: true, taskId, finalMessage: body };
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+async function loadContext(path?: string, state?: DailyLoopState): Promise<DailyLoopContext> {
+  if (!path || !existsSync(path)) {
+    return { briefAskedQuestionIds: state?.asked?.map((record) => record.questionId).filter((id): id is string => Boolean(id)) ?? [] };
+  }
+  const raw = await readJsonObject(path);
+  const questions = Array.isArray(raw.questions) ? raw.questions as Array<Record<string, unknown>> : [];
+  const rsvpEvents = Array.isArray(raw.rsvpEvents) ? raw.rsvpEvents as Array<Record<string, unknown>> : [];
+  const opportunities = Array.isArray(raw.connectionOpportunities)
+    ? raw.connectionOpportunities as Array<Record<string, unknown>>
+    : Array.isArray(raw.opportunities)
+      ? raw.opportunities as Array<Record<string, unknown>>
+      : [];
+  const prepared = raw.prepared && typeof raw.prepared === "object" && !Array.isArray(raw.prepared)
+    ? raw.prepared as Record<string, unknown>
+    : {};
+
+  return {
+    pendingQuestion: questions[0]
+      ? { id: String(questions[0].id ?? ""), prompt: String(questions[0].prompt ?? "") }
+      : undefined,
+    endedRsvpEvent: rsvpEvents[0]
+      ? { title: String(rsvpEvents[0].title ?? ""), eventUrl: typeof rsvpEvents[0].eventUrl === "string" ? rsvpEvents[0].eventUrl : undefined }
+      : undefined,
+    opportunityCount: opportunities.length,
+    opportunityCategory: opportunities.length > 0 ? String(opportunities[0].feedCategory ?? "connection") : undefined,
+    opportunityNames: opportunities.map((opp) => String(opp.name ?? "")).filter(Boolean),
+    opportunityUrls: opportunities.flatMap((opp) => [opp.profileUrl, opp.acceptUrl]).filter((url): url is string => typeof url === "string"),
+    dayEventCount: Array.isArray(raw.highlightedEvents) ? raw.highlightedEvents.length : undefined,
+    briefAskedQuestionIds: [
+      ...stringArray(raw.questionIds),
+      ...stringArray(prepared.questionIds),
+      ...(state?.asked?.map((record) => record.questionId).filter((id): id is string => Boolean(id)) ?? []),
+    ],
+  };
+}
+
+// cron entrypoints: prepare/send wakeups
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const mode = hasFlag(args, "--send") ? "send" : "prepare";
+  const now = new Date();
+  const window = resolveWindowArg(args, mode, now);
+  const date = argValue(args, "--date") ?? hostLocalDate(now);
+  const stateFile = argValue(args, "--state-file") ?? "memory/daily-loop-state.json";
+
+  if (!window) {
+    process.stdout.write("[SILENT]\n");
+    return;
+  }
+
+  if (mode === "send") {
+    const result = await sendDailyLoop({ date, window, stateFile });
+    if (!result.sent) {
+      process.stdout.write("[SILENT]\n");
+      return;
+    }
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  const existingState = normalizeDailyLoopState(await readJsonObject(stateFile), date);
+  const context = await loadContext(argValue(args, "--context-file") ?? "memory/daily-loop-context.json", existingState);
+  const result = await stageDailyLoop({ date, window, stateFile, context });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/skills/index-network/scripts/tests/daily-loop.test.ts
+++ b/skills/index-network/scripts/tests/daily-loop.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  DAILY_LOOP_RENDER_CONFIG,
+  DAILY_LOOP_WINDOWS,
+  composeDailyLoopCandidate,
+  evaluateDailyLoopPolicy,
+  normalizeDailyLoopState,
+  resolveWindowArg,
+  scheduledWindowForHostHour,
+  sendDailyLoop,
+  stageDailyLoop,
+} from "../daily-loop";
+
+const originalCwd = process.cwd();
+
+function tempWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "daily-loop-"));
+  process.chdir(dir);
+  return dir;
+}
+
+async function writeState(value: unknown): Promise<void> {
+  mkdirSync("memory", { recursive: true });
+  await Bun.write("memory/daily-loop-state.json", JSON.stringify(value));
+}
+
+afterEach(() => {
+  const cwd = process.cwd();
+  process.chdir(originalCwd);
+  if (cwd !== originalCwd && cwd.includes("daily-loop-")) rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("daily-loop config", () => {
+  test("declares internal evaluation windows and launch-blocking render config", () => {
+    expect(DAILY_LOOP_WINDOWS.map((w) => [w.window, w.prepareHour, w.sendHour])).toEqual([
+      ["1500", 14, 15],
+      ["1800", 17, 18],
+      ["2100", 20, 21],
+    ]);
+    expect(DAILY_LOOP_RENDER_CONFIG.status).toBe("placeholder");
+    expect(DAILY_LOOP_RENDER_CONFIG.launchBlockedOn).toContain("product/tone refinement");
+    expect(DAILY_LOOP_RENDER_CONFIG.approvalMarker).toBe("APPROVED_DAILY_LOOP_SEND");
+  });
+
+  test("maps host-local scheduled hours to windows and never falls back off schedule", () => {
+    expect(scheduledWindowForHostHour("prepare", 14)).toBe("1500");
+    expect(scheduledWindowForHostHour("prepare", 17)).toBe("1800");
+    expect(scheduledWindowForHostHour("prepare", 20)).toBe("2100");
+    expect(scheduledWindowForHostHour("send", 15)).toBe("1500");
+    expect(scheduledWindowForHostHour("send", 18)).toBe("1800");
+    expect(scheduledWindowForHostHour("send", 21)).toBe("2100");
+    expect(scheduledWindowForHostHour("send", 16)).toBeUndefined();
+  });
+
+  test("explicit --window wins, invalid window is silent-safe, and off-schedule hours do not fallback", () => {
+    expect(resolveWindowArg(["--window", "1800"], "prepare", new Date(2026, 5, 13, 2))).toBe("1800");
+    expect(resolveWindowArg(["--window", "bogus"], "prepare", new Date(2026, 5, 13, 14))).toBeUndefined();
+    expect(resolveWindowArg([], "prepare", new Date(2026, 5, 13, 14))).toBe("1500");
+    expect(resolveWindowArg([], "prepare", new Date(2026, 5, 13, 12))).toBeUndefined();
+  });
+});
+
+describe("daily-loop roles and policy", () => {
+  test("normalizes shared state with visible budget and record arrays for morning to write later", () => {
+    const state = normalizeDailyLoopState({}, "2026-06-13");
+    expect(state.visibleBudget).toEqual({ date: "2026-06-13", nonBriefLimit: 1, nonBriefSent: 0 });
+    expect(state.cooldowns).toEqual({ nonBriefMinutes: 90 });
+    expect(state.surfaced).toEqual([]);
+    expect(state.asked).toEqual([]);
+    expect(state.sent).toEqual([]);
+    expect(state.skipped).toEqual([]);
+  });
+
+  test("calibration questions carry explicit role/input/question id", () => {
+    const candidate = composeDailyLoopCandidate({
+      date: "2026-06-13",
+      window: "1500",
+      context: { pendingQuestion: { id: "q-1", prompt: "What would make today useful?" } },
+    });
+
+    expect(candidate).toMatchObject({
+      role: "calibrate_rest_of_day",
+      inputType: "pending-question",
+      questionId: "q-1",
+    });
+  });
+
+  test("event follow-up can replace close-loop/tomorrow-prep in the evening", () => {
+    const candidate = composeDailyLoopCandidate({
+      date: "2026-06-13",
+      window: "2100",
+      context: {
+        endedRsvpEvent: {
+          title: "Dinner Salon",
+          eventUrl: "https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        },
+        dayEventCount: 4,
+      },
+    });
+
+    expect(candidate?.role).toBe("event_followup");
+    expect(candidate?.replacesRoles).toEqual(["close_loop", "tomorrow_prep"]);
+    expect(candidate?.body).toContain("Did you make it to [Dinner Salon]");
+    expect(candidate?.body).not.toContain("I saw");
+  });
+
+  test("policy records duplicate, quiet, no-context, replacement, and budget skip reasons", () => {
+    const state = normalizeDailyLoopState({
+      date: "2026-06-13",
+      visibleBudget: { date: "2026-06-13", nonBriefLimit: 1, nonBriefSent: 1 },
+      asked: [{ at: "2026-06-13T08:00:00.000Z", role: "orient", questionId: "q-1" }],
+    }, "2026-06-13");
+
+    expect(evaluateDailyLoopPolicy({
+      state,
+      context: { pendingQuestion: { id: "q-1", prompt: "Same question?" } },
+      candidate: { body: "Same question?", role: "calibrate_rest_of_day", inputType: "pending-question", inputLabel: "pending", questionId: "q-1" },
+      window: "1500",
+      nowIso: "2026-06-13T14:00:00.000Z",
+    })).toEqual({ ok: false, reason: "brief-already-asked" });
+
+    expect(evaluateDailyLoopPolicy({
+      state: normalizeDailyLoopState({}, "2026-06-13"),
+      context: { briefAskedQuestionIds: ["q-brief"] },
+      candidate: { body: "Brief already asked this?", role: "calibrate_rest_of_day", inputType: "pending-question", inputLabel: "pending", questionId: "q-brief" },
+      window: "1500",
+      nowIso: "2026-06-13T14:00:00.000Z",
+    })).toEqual({ ok: false, reason: "brief-already-asked" });
+
+    expect(evaluateDailyLoopPolicy({
+      state: normalizeDailyLoopState({}, "2026-06-13"),
+      context: { pacePreference: "stay quiet unless I ask" },
+      candidate: { body: "Ping?", role: "calibrate_rest_of_day", inputType: "thin-signal", inputLabel: "thin" },
+      window: "1500",
+      nowIso: "2026-06-13T14:00:00.000Z",
+    })).toEqual({ ok: false, reason: "quiet-pace" });
+
+    expect(evaluateDailyLoopPolicy({
+      state: normalizeDailyLoopState({}, "2026-06-13"),
+      context: {},
+      candidate: null,
+      window: "1800",
+      nowIso: "2026-06-13T17:00:00.000Z",
+    })).toEqual({ ok: false, reason: "no-new-context" });
+
+    expect(evaluateDailyLoopPolicy({
+      state,
+      context: {},
+      candidate: { body: "Budget?", role: "tomorrow_prep", inputType: "reflection", inputLabel: "reflection" },
+      window: "2100",
+      nowIso: "2026-06-13T20:00:00.000Z",
+    })).toEqual({ ok: false, reason: "budget-used" });
+
+    const replacementState = normalizeDailyLoopState({}, "2026-06-13");
+    const replacement = evaluateDailyLoopPolicy({
+      state: replacementState,
+      context: {},
+      candidate: {
+        body: "Follow up?",
+        role: "event_followup",
+        inputType: "ended-rsvp",
+        inputLabel: "event",
+        replacesRoles: ["close_loop", "tomorrow_prep"],
+      },
+      window: "2100",
+      nowIso: "2026-06-13T20:00:00.000Z",
+    });
+    expect(replacement.ok).toBe(true);
+    expect(replacementState.skipped?.[0].reason).toBe("event-followup-replaces-evening");
+  });
+});
+
+describe("daily-loop kanban flow", () => {
+  test("stages one blocked Kanban card with daily-loop state/idempotency", async () => {
+    tempWorkspace();
+    const calls: string[][] = [];
+    const result = await stageDailyLoop({
+      date: "2026-06-13",
+      window: "1800",
+      nowIso: "2026-06-13T17:00:00.000Z",
+      stateFile: "memory/daily-loop-state.json",
+      context: { opportunityCount: 2, opportunityCategory: "connection" },
+      hermes: (args) => {
+        calls.push(args);
+        if (args[0] === "kanban" && args[1] === "create") return JSON.stringify({ task: { id: "t_daily_loop" } });
+        if (args[0] === "kanban" && args[1] === "block") return "blocked";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+    });
+
+    expect(result).toEqual({ staged: true, taskId: "t_daily_loop", idempotencyKey: "daily-loop-2026-06-13-1800" });
+    expect(calls[0]).toEqual([
+      "kanban",
+      "create",
+      "Daily loop 18:00 — 2026-06-13",
+      "--body",
+      expect.stringContaining("If one useful person would be worth meeting this evening"),
+      "--idempotency-key",
+      "daily-loop-2026-06-13-1800",
+      "--json",
+    ]);
+    expect(calls[1]).toEqual(["kanban", "block", "t_daily_loop", "review-required: daily loop 18:00 — 2026-06-13"]);
+
+    const state = JSON.parse(await Bun.file("memory/daily-loop-state.json").text());
+    expect(state.windows["1800"].taskId).toBe("t_daily_loop");
+    expect(state.windows["1800"].role).toBe("calibrate_rest_of_day");
+    expect(state.surfaced[0].taskId).toBe("t_daily_loop");
+  });
+
+  test("default non-brief budget is 1/day", async () => {
+    tempWorkspace();
+    await writeState({
+      date: "2026-06-13",
+      visibleBudget: { date: "2026-06-13", nonBriefLimit: 1, nonBriefSent: 1 },
+      windows: {},
+    });
+
+    const capped = await stageDailyLoop({
+      date: "2026-06-13",
+      window: "2100",
+      nowIso: "2026-06-13T20:00:00.000Z",
+      stateFile: "memory/daily-loop-state.json",
+      context: { activeWant: "meet protocol designers" },
+      hermes: () => {
+        throw new Error("hermes should not be called");
+      },
+    });
+    expect(capped).toEqual({ staged: false, reason: "budget-used" });
+  });
+
+  test("sends only ready cards with explicit marker and updates shared state", async () => {
+    tempWorkspace();
+    await writeState({
+      date: "2026-06-14",
+      windows: {
+        "1800": {
+          date: "2026-06-14",
+          taskId: "t_daily_loop",
+          role: "calibrate_rest_of_day",
+          body: "If one useful person would be worth meeting this evening, what kind of person would that be?",
+          preparedAt: "2026-06-14T17:00:00.000Z",
+        },
+      },
+    });
+    const calls: string[][] = [];
+    const result = await sendDailyLoop({
+      date: "2026-06-14",
+      window: "1800",
+      nowIso: "2026-06-14T18:00:00.000Z",
+      stateFile: "memory/daily-loop-state.json",
+      hermes: (args) => {
+        calls.push(args);
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({
+          task: {
+            id: "t_daily_loop",
+            status: "ready",
+            body: "Approved daily-loop body\nAPPROVED_DAILY_LOOP_SEND\n<!-- daily-loop-review: internal -->\n<!-- daily-loop-source:role=calibrate_rest_of_day; input=live-opportunity; label=x -->",
+          },
+        });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+    });
+
+    expect(result).toEqual({ sent: true, taskId: "t_daily_loop", finalMessage: "Approved daily-loop body" });
+    expect(calls).toEqual([
+      ["kanban", "show", "t_daily_loop", "--json"],
+      ["kanban", "complete", "t_daily_loop", "--summary", "delivered"],
+    ]);
+
+    const state = JSON.parse(await Bun.file("memory/daily-loop-state.json").text());
+    expect(state.visibleBudget).toEqual({ date: "2026-06-14", nonBriefLimit: 1, nonBriefSent: 1, lastSentAt: "2026-06-14T18:00:00.000Z" });
+    expect(state.sent[0].taskId).toBe("t_daily_loop");
+    expect(state.windows["1800"].sentAt).toBe("2026-06-14T18:00:00.000Z");
+  });
+
+  test("rejects todo/missing marker and skips stale cards", async () => {
+    tempWorkspace();
+    await writeState({
+      date: "2026-06-13",
+      windows: {
+        "1500": { date: "2026-06-13", taskId: "t_blocked", role: "calibrate_rest_of_day", preparedAt: "2026-06-13T14:00:00.000Z" },
+        "1800": { date: "2026-06-13", taskId: "t_stale", role: "event_followup", preparedAt: "2026-06-13T17:00:00.000Z" },
+      },
+    });
+
+    const todo = await sendDailyLoop({
+      date: "2026-06-13",
+      window: "1500",
+      nowIso: "2026-06-13T15:00:00.000Z",
+      stateFile: "memory/daily-loop-state.json",
+      hermes: () => JSON.stringify({ task: { id: "t_blocked", status: "todo", body: "draft\nAPPROVED_DAILY_LOOP_SEND" } }),
+    });
+    expect(todo).toEqual({ sent: false, reason: "not-approved:todo" });
+
+    const missingMarker = await sendDailyLoop({
+      date: "2026-06-13",
+      window: "1500",
+      nowIso: "2026-06-13T15:00:00.000Z",
+      stateFile: "memory/daily-loop-state.json",
+      hermes: () => JSON.stringify({ task: { id: "t_blocked", status: "ready", body: "draft" } }),
+    });
+    expect(missingMarker).toEqual({ sent: false, reason: "missing-approval-marker" });
+
+    const staleCalls: string[][] = [];
+    const stale = await sendDailyLoop({
+      date: "2026-06-13",
+      window: "1800",
+      nowIso: "2026-06-13T20:00:00.000Z",
+      stateFile: "memory/daily-loop-state.json",
+      hermes: (args) => {
+        staleCalls.push(args);
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+    });
+    expect(stale).toEqual({ sent: false, reason: "stale" });
+    expect(staleCalls).toEqual([["kanban", "complete", "t_stale", "--summary", "skipped-stale"]]);
+  });
+});


### PR DESCRIPTION
## Summary
- Refocus the canary from isolated daypart check-ins to a shared daily-loop layer for non-brief Edge interruptions.
- Rename check-in cron/prompt/script surfaces to daily-loop names while preserving legacy check-in flag/env aliases during the rename.
- Add a lightweight daily-loop contract with context normalization, shared state, explicit roles, policy/budget/replacement rules, render placeholders, Kanban review/send helpers, and cron entrypoints.
- Keep launch blocked by default: daily-loop crons are canary-gated, sends require `ready` plus `APPROVED_DAILY_LOOP_SEND`, and placeholder tone remains centralized.

## Cadence and behavior boundary
- Morning brief remains the daily anchor and is unchanged by this PR. Existing digest crons stay as-is: memory signal sync around 01:00, prepare around 02:00, and send at/around 08:00 with existing stagger behavior.
- Daily-loop crons are separate internal non-brief evaluation wakeups at 14/17/20 prepare and 15/18/21 send. They install only with `--enable-daily-loop-crons` or `ENABLE_DAILY_LOOP_CRONS=true`.
- Candidate windows are not promised sends; visible budget defaults to 1 non-brief interruption/day and delivery still requires explicit review approval.
- No control-plane or evening-brief behavior is changed. Integration with morning/evening surfaces is deferred.

## What was duplicated
- Calendar/Index context was morning-owned: `build-daily-brief-context` produced `memory/daily-brief-context.json`, and the canary borrowed that stale morning artifact.
- State was split by surface: morning `heartbeat-state` tracked prepared/deliveredToday/questionDelivery/memorySignals while check-ins tracked separate windows/sent/task state.
- Questions were selected independently between morning One-for-you and non-brief prompts, creating duplicate/adjacent prompt risk.
- Frequency was local to each surface, with no visible global interruption budget.
- Role was implicit in code: orient/calibrate/follow-up/reflection behavior was encoded as windows rather than a role/input/outcome contract.

## What changes
- New daily-loop state file (`memory/daily-loop-state.json`) tracks surfaced/asked/sent/skipped records, visible non-brief budget, cooldowns, and window task state.
- Roles are explicit: `orient`, `calibrate_rest_of_day`, `event_followup`, `close_loop`, `tomorrow_prep`, `silent`.
- Policy is explicit: default non-brief visible budget is 1/day, quiet pace suppresses, brief-asked questions suppress, event follow-up can replace close-loop/tomorrow prep, and skip reasons include `brief-already-asked`, `event-followup-replaces-evening`, `quiet-pace`, `no-new-context`, `budget-used`, `cooldown`, `stale`.
- Daily-loop context now defaults to `memory/daily-loop-context.json`; borrowing morning context is no longer the default.
- Crons/prompts are renamed to `Edge — daily loop prepare/send`, `daily-loop-prepare.md`, `daily-loop-send.md`, gated by `--enable-daily-loop-crons` / `ENABLE_DAILY_LOOP_CRONS=true`; old check-in aliases are accepted for compatibility.

## Tests
- `bun test install/tests/cron_specs.test.ts install/tests/reconcile_digest_crons.test.ts skills/index-network/scripts/tests/daily-loop.test.ts`

## Intentionally deferred seams
- Morning brief still writes `heartbeat-state` and `memory/daily-brief-context.json`; this PR only prepares the shared daily-loop state/context contract for morning to write later.
- No control-plane DB/UI is added.
- Tone/templates remain placeholder launch-blocking surfaces pending product/tone refinement.