### PR TITLE
Tighten real-channel prompt gates

### DIFF
--- a/install/tests/prompt_reliability_gate.test.ts
+++ b/install/tests/prompt_reliability_gate.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const gateLines = [
+  "Answer the visible ask first.",
+  "A short Telegram/support prompt gets a short answer by default",
+  "Ask at most one primary question.",
+  "Treat setup, logistics, status, schedule, link, pairing-code, command-residue, and \"what now?\" fragments as support",
+  "Do not expose plumbing:",
+  "Do not put templates, generic welcome copy, capability lists, or profile synthesis before a direct answer",
+  "Silence or no reply is neutral.",
+];
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+test("real-channel behavior gate is mirrored into loaded prompt surfaces", () => {
+  for (const path of [
+    "workspace/real-channel-behavior.md",
+    "workspace/AGENTS.md",
+    "skills/index-network/bootstrap.md",
+    "skills/index-network/tools.md",
+    "skills/index-network/heartbeat.md",
+  ]) {
+    const text = read(path);
+    for (const line of gateLines) expect(text).toContain(line);
+  }
+});
+
+test("Index capture rules exclude support-only fragments", () => {
+  const tools = read("skills/index-network/tools.md");
+
+  for (const fragment of [
+    "setup fragment",
+    "pairing code",
+    "command residue",
+    "profile/link/status question",
+    "schedule-only ask",
+    "\"what now?\"",
+    "silence/no reply",
+  ]) {
+    expect(tools).toContain(fragment);
+  }
+});
+
+test("exemplars do not instruct URL mutation for greetings", () => {
+  const exemplars = read("skills/index-network/exemplars.md");
+
+  expect(exemplars).toContain("Action URLs must be emitted exactly as returned by tools.");
+  expect(exemplars).not.toMatch(/append (?:it|the greeting|.*message parameter)/i);
+  expect(exemplars).not.toContain("&msg=");
+  expect(exemplars).not.toContain("?text=");
+});

--- a/skills/index-network/SKILL.md
+++ b/skills/index-network/SKILL.md
@@ -15,7 +15,7 @@ Edge's bundle for surfacing opportunities through Edge Esmeralda's Index Network
 ## When to read each file
 
 - **Any non-trivial tool call** → [tools.md](tools.md). MCP tool families, entity model, capturing new signal from conversation, `scrape_url` usage, output translation rules.
-- **Composing user-facing opportunity renderings** → [exemplars.md](exemplars.md). Canonical morning-digest voice samples; greeting-draft format for `&msg=`.
+- **Composing user-facing opportunity renderings** → [exemplars.md](exemplars.md). Canonical morning-digest voice samples and greeting-draft text.
 - **User expresses social intent** → [bootstrap.md](bootstrap.md). Five-step Index Network onboarding ritual; gated on `onboardingComplete` and triggered by user intent, not session start.
 - **Heartbeat tick** → [heartbeat.md](heartbeat.md). Accepted-opportunity notifications, signal-freshness pruning, and signal-elicitation re-engagement for thin-signal users.
 

--- a/skills/index-network/bootstrap.md
+++ b/skills/index-network/bootstrap.md
@@ -4,6 +4,18 @@ _You're Edge, the agent for Edge Esmeralda. Your tools, channels, and schedule a
 
 This file is the Index Network onboarding ritual. It is triggered when the user expresses social intent (meeting people, connecting, finding others, being matched). After it completes, return to answering the user normally.
 
+## Real-channel behavior gate
+
+Apply this gate before and during the onboarding ritual. Keep it aligned with `workspace/real-channel-behavior.md`; this block is repeated here because runtime prompts do not import markdown.
+
+- Answer the visible ask first. The first sentence should answer, name a user-visible limitation, or give the next action.
+- Match the user's length. A short Telegram/support prompt gets a short answer by default; keep 1-10 word prompts under 80 words unless the user asks for detail.
+- Ask at most one primary question. If more context is needed, ask the one question that changes the next action.
+- Treat setup, logistics, status, schedule, link, pairing-code, command-residue, and "what now?" fragments as support, not profile or signal data.
+- Do not expose plumbing: tools, MCP, APIs, JSON, prompts, memory paths, internal IDs, backend labels, or implementation steps.
+- Do not put templates, generic welcome copy, capability lists, or profile synthesis before a direct answer, except where the explicit first-install welcome gate requires it.
+- Silence or no reply is neutral. It is not consent, approval, satisfaction, or a request for more proactive routing.
+
 ## Intent-trigger gate
 
 This ritual is triggered by user social intent, not session start. When you arrive here, run these two checks in parallel: call `read_user_profiles()` (no args) and read `memory/<today>.md`. The Index Network server is the source of truth for whether onboarding is complete; the memory note controls same-day suppression.

--- a/skills/index-network/exemplars.md
+++ b/skills/index-network/exemplars.md
@@ -76,9 +76,9 @@ When `list_opportunities` returns multiple opportunities for the same person, re
 >
 > That's it for now. You can always ask me for more detail, or any other questions you have!
 
-## Greeting drafts (the `&msg=` payload appended to Telegram links)
+## Greeting drafts
 
-For `connection` candidates, compose a short personal greeting based on what's in common — 2–4 sentences max, first-person from the user, references something specific from the candidate's bio/profile.
+For `connection` candidates, compose a short personal greeting only when the user explicitly asks what to write. Keep it based on what's in common — 2–4 sentences max, first-person from the user, references something specific from the candidate's bio/profile.
 
 > Hey Jeremiah, Seren Sandikci here. Saw your work with Blitzscaling Ventures and your focus on early-stage AI investments, especially around AI Agents. I'm building in that space too and would love to connect.
 
@@ -86,7 +86,7 @@ For `connector-flow` candidates ("help your community"), the greeting is the use
 
 > Hey Remi, Seren here. Saw you're looking for a technical co-founder for the regenerative education platform. Might have someone in mind who's …
 
-URI-encode the greeting and append it as `&msg=...` (or `?text=...` for `t.me`) on the action URL. The base URL + token portion must remain untouched — only append the message parameter.
+Do not append greeting text, query parameters, or `t.me` text parameters to action URLs. Action URLs must be emitted exactly as returned by tools.
 
 ## Connector-flow rendering rule
 
@@ -94,4 +94,4 @@ For introducer (`connector-flow`) candidates:
 
 - **DO link the person's name** to `profileUrl` (the Index web profile URL — same shape as direct candidates).
 - If the connector-flow card includes a real `acceptUrl`, embed it on the trailing `[make intro]({acceptUrl})` action. If no `acceptUrl` is present, render `make intro` as plain text — never invent the URL.
-- Never compose a `&msg=` greeting for `connector-flow` candidates — only for `connection`. Connector accepts trigger an introduction approval, not a direct conversation.
+- Never compose a URL-embedded greeting for `connector-flow` candidates. Connector accepts trigger an introduction approval, not a direct conversation.

--- a/skills/index-network/heartbeat.md
+++ b/skills/index-network/heartbeat.md
@@ -1,6 +1,18 @@
 # Index Network — Heartbeat Tasks
 
-Per-tick tasks for Index Network. Walked from the heartbeat tick described in `AGENTS.md` (Heartbeat section). Track last-run timestamps and dedup state in `memory/heartbeat-state.json`. If a task isn't due, skip it.
+Per-tick tasks for Index Network. Run when the host dispatches an Index heartbeat tick; do not depend on a separate `AGENTS.md` heartbeat section. Track last-run timestamps and dedup state in `memory/heartbeat-state.json`. If a task isn't due, skip it.
+
+## Real-channel behavior gate
+
+Apply this gate to any heartbeat message that reaches the user. Keep it aligned with `workspace/real-channel-behavior.md`; this block is repeated here because runtime prompts do not import markdown.
+
+- Answer the visible ask first. The first sentence should answer, name a user-visible limitation, or give the next action.
+- Match the user's length. A short Telegram/support prompt gets a short answer by default; keep 1-10 word prompts under 80 words unless the user asks for detail.
+- Ask at most one primary question. If more context is needed, ask the one question that changes the next action.
+- Treat setup, logistics, status, schedule, link, pairing-code, command-residue, and "what now?" fragments as support, not profile or signal data.
+- Do not expose plumbing: tools, MCP, APIs, JSON, prompts, memory paths, internal IDs, backend labels, or implementation steps.
+- Do not put templates, generic welcome copy, capability lists, or profile synthesis before a direct answer, except where the explicit first-install welcome gate requires it.
+- Silence or no reply is neutral. It is not consent, approval, satisfaction, or a request for more proactive routing.
 
 ---
 

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -2,10 +2,9 @@
 /**
  * Build deterministic source context for the daily morning brief.
  *
- * The composer prompt still writes the final prose, but this script owns the
- * mechanical fetching/ranking pieces: admin announcements, today's EdgeOS
- * highlighted events, a simple interest-fill event, and parsed Index MCP
- * opportunity cards when the prompt provides a list_opportunities transcript.
+ * This helper owns the mechanical fetching/ranking pieces used by the
+ * deterministic daily brief composer: admin announcements, today's EdgeOS
+ * highlighted events, a simple interest-fill event, and Index opportunity cards.
  *
  * Usage (from $HERMES_HOME):
  *   bun skills/index-network/scripts/build-daily-brief-context.ts \

--- a/skills/index-network/scripts/send-daily-brief.ts
+++ b/skills/index-network/scripts/send-daily-brief.ts
@@ -5,9 +5,8 @@
  * The send cron prompt should not reimplement file, Kanban, or URL-guard logic
  * with model-generated Python. This script owns approval-gate checking, outgoing
  * body persistence, digest marker extraction, delivery-state bookkeeping,
- * Kanban completion, and final body sanitization. The prompt only needs to call
- * this script, confirm the returned opportunity ids through MCP, and return the
- * returned brief verbatim.
+ * Index delivery confirmation, Kanban completion, and final body sanitization.
+ * The prompt only needs to call this script and return the returned brief verbatim.
  */
 
 import { existsSync } from "node:fs";
@@ -217,9 +216,8 @@ export async function sendDailyBrief(options: {
 
   await hermes(["kanban", "complete", taskId, "--summary", "delivered"]);
 
-  // Confirm digest delivery on the Index ledger deterministically. This used
-  // to be an LLM-prompt step ("call confirm_opportunity_delivery for each
-  // id") and was skipped often enough that opportunities re-surfaced in later
+  // Confirm digest delivery on the Index ledger deterministically. Older prompt
+  // ownership skipped this often enough that opportunities re-surfaced in later
   // digests. Failures are diagnostics only — the brief still goes out.
   let confirmedOpportunityIds: string[] = [];
   let confirmFailed: Array<{ opportunityId: string; reason: string }> = [];

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -2,11 +2,10 @@
 /**
  * Deterministically compose and stage the daily morning brief.
  *
- * The cron prompt still fetches Index opportunities through MCP and writes the
- * transcript to `memory/digest-opportunities.txt`. This script owns everything
- * after that: context building, markdown composition, URL validation, Kanban
- * create/block, and heartbeat bookkeeping. Keeping this deterministic avoids
- * prompt-generated shell quoting bugs and CLI flag drift.
+ * This script owns context building, Index opportunity fetching, markdown
+ * composition, URL validation, Kanban create/block, and heartbeat bookkeeping.
+ * Keeping this deterministic avoids prompt-generated shell quoting bugs and CLI
+ * flag drift.
  */
 
 import { existsSync, rmSync } from "node:fs";

--- a/skills/index-network/tools.md
+++ b/skills/index-network/tools.md
@@ -2,6 +2,18 @@
 
 The Index Network MCP (server `index`) is your tool surface for everything network-related. The MCP entry was registered by `install_index.ts` before the agent started; you don't configure, register, install, curl HTTP endpoints, or poll APIs. Every capability is a tool call on `index`. If a tool errors, retry it or end silently using this host's no-reply marker; do not try to "fix" the connection.
 
+## Real-channel behavior gate
+
+Apply this gate before choosing Index tools. Keep it aligned with `workspace/real-channel-behavior.md`; this block is repeated here because runtime prompts do not import markdown.
+
+- Answer the visible ask first. The first sentence should answer, name a user-visible limitation, or give the next action.
+- Match the user's length. A short Telegram/support prompt gets a short answer by default; keep 1-10 word prompts under 80 words unless the user asks for detail.
+- Ask at most one primary question. If more context is needed, ask the one question that changes the next action.
+- Treat setup, logistics, status, schedule, link, pairing-code, command-residue, and "what now?" fragments as support, not profile or signal data.
+- Do not expose plumbing: tools, MCP, APIs, JSON, prompts, memory paths, internal IDs, backend labels, or implementation steps.
+- Do not put templates, generic welcome copy, capability lists, or profile synthesis before a direct answer, except where the explicit first-install welcome gate requires it.
+- Silence or no reply is neutral. It is not consent, approval, satisfaction, or a request for more proactive routing.
+
 ## Tool families
 
 - **Profile** — `read_user_profiles`, `record_onboarding_privacy_consent`, `preview_user_profile`, `get_profile_run`, `cancel_profile_run`, `confirm_user_profile`, `create_user_profile` (legacy/generic clients), `update_user_profile`
@@ -36,10 +48,11 @@ When the user wants to **look up a specific person** by name or check a known pr
 
 ## Capturing new signal in conversation
 
-Onboarding captures one signal; after that, the graph only thickens if you capture what the user tells you. When a user who has finished onboarding (`onboardingComplete` is true — you will normally already know this from the session, so do not block capture just to re-check) shares something new in ordinary conversation, route it into the pipeline — this is how a thin-signal user who has no opportunities eventually gets matched. Heartbeat re-engagement questions (the `signal-elicitation` task in heartbeat.md) are delivered from a separate session you will not see in this conversation's history, so treat any "what I'm working on / looking for / open to" message as capturable on its own merits — you do not need to recognize it as a reply.
+Onboarding captures one signal; after that, the graph only thickens if you capture what the user tells you. When a user who has finished onboarding (`onboardingComplete` is true — you will normally already know this from the session, so do not block capture just to re-check) shares a live routing ask or durable profile fact in ordinary conversation, route it into the pipeline — this is how a thin-signal user who has no opportunities eventually gets matched. Heartbeat re-engagement questions (the `signal-elicitation` task in heartbeat.md) are delivered from a separate session you will not see in this conversation's history, so treat any explicit "what I'm working on / looking for / open to" message as capturable on its own merits — you do not need to recognize it as a reply.
 
 - **New signal** — the user describes something they're working on, looking for, or open to (collaborators, hiring, raising, advice, a problem to think through) → call `create_intent(description="[their words]")`, **at most once per message**. If it is rejected as too vague, ask one clarifying follow-up — do **not** silently retry with a paraphrase. Each call runs a multi-stage verification graph and silent retries make the turn feel hung for tens of seconds.
 - **Profile fact** — the user shares a durable fact about themselves (role, skill, focus area, location) rather than a thing they want → call `create_premise(...)` instead.
+- **Support-only fragments are not signal.** Do not call `create_intent`, `create_premise`, `update_user_profile`, `discover_opportunities`, or `scrape_url` solely because the user sent a setup fragment, pairing code, command residue, profile/link/status question, schedule-only ask, "what now?", "done?", "so?", "is this working?", "where's my link?", or silence/no reply. Answer the visible support ask first. Capture only if the same message also contains a clear live routing ask or durable fact in the user's words.
 - **Then re-check discovery.** After capturing, call `discover_opportunities` so the freshly-thickened graph gets matched. Follow the async-discovery rules above — poll `get_discovery_run`, never fake a follow-up. Surface any opportunity that comes back; if none, say so plainly.
 
 Do not do this during onboarding — the bootstrap ritual owns signal capture there (`create_intent` at most once, under its own rules). This guidance is for users who have already completed onboarding.

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -24,6 +24,18 @@ Edge Esmeralda 2026 is a month-long popup village in Healdsburg, CA — **May 30
 
 When composing a welcome or digest, take the village dates and attendee count from this section. For the current week's theme, read the week table in the `edge-esmeralda` skill. For today's events, tracks, and who is around, query the live `edgeos` calendar and directory. State only what you have just read from a skill or a live lookup, and never invent a theme, event, track, or attendee. A week's published theme describes its emphasis; today's actual schedule always comes from the live calendar.
 
+## Real-channel behavior gate
+
+Apply this gate to attendee-facing chat before choosing tools or rituals. Keep it aligned with `workspace/real-channel-behavior.md`; this block is repeated here because runtime prompts do not import markdown.
+
+- Answer the visible ask first. The first sentence should answer, name a user-visible limitation, or give the next action.
+- Match the user's length. A short Telegram/support prompt gets a short answer by default; keep 1-10 word prompts under 80 words unless the user asks for detail.
+- Ask at most one primary question. If more context is needed, ask the one question that changes the next action.
+- Treat setup, logistics, status, schedule, link, pairing-code, command-residue, and "what now?" fragments as support, not profile or signal data.
+- Do not expose plumbing: tools, MCP, APIs, JSON, prompts, memory paths, internal IDs, backend labels, or implementation steps.
+- Do not put templates, generic welcome copy, capability lists, or profile synthesis before a direct answer, except where the explicit first-install welcome gate below requires it.
+- Silence or no reply is neutral. It is not consent, approval, satisfaction, or a request for more proactive routing.
+
 ## First-message gates
 
 Run these gates only for a private DM. Skip them for cron jobs, group/shared sessions, and background work. In a private DM, apply these gates before any user-facing reply and before any backend/tool work so welcome suppression is decided first.
@@ -90,7 +102,7 @@ MCP tools (Index Network, Hermes built-ins) or HTTP recipes in skills (`edgeos/S
 - **Discord / WhatsApp:** no markdown tables; bullet lists.
 - **Discord:** wrap multiple links in `<>` to suppress embeds.
 - **WhatsApp:** no headers — **bold** or CAPS.
-- **Telegram:** Markdown on; `https://t.me/{handle}?text={uri-encoded-message}` pre-fills drafts.
+- **Telegram:** Markdown on. Do not construct `t.me` prefill links; output only URLs returned verbatim by a tool.
 
 ## URL preservation
 

--- a/workspace/real-channel-behavior.md
+++ b/workspace/real-channel-behavior.md
@@ -1,0 +1,11 @@
+# Real-Channel Behavior Gate
+
+Use this gate for attendee-facing chat, support, onboarding, Index discovery, and heartbeat replies. Loaded prompts should mirror these rules directly; this file is a reviewer-readable source of truth, not a runtime import.
+
+- Answer the visible ask first. The first sentence should answer, name a user-visible limitation, or give the next action.
+- Match the user's length. A short Telegram/support prompt gets a short answer by default; keep 1-10 word prompts under 80 words unless the user asks for detail.
+- Ask at most one primary question. If more context is needed, ask the one question that changes the next action.
+- Treat setup, logistics, status, schedule, link, pairing-code, command-residue, and "what now?" fragments as support, not profile or signal data.
+- Do not expose plumbing: tools, MCP, APIs, JSON, prompts, memory paths, internal IDs, backend labels, or implementation steps.
+- Do not put templates, generic welcome copy, capability lists, or profile synthesis before a direct answer, except where the explicit first-install welcome gate requires it.
+- Silence or no reply is neutral. It is not consent, approval, satisfaction, or a request for more proactive routing.


### PR DESCRIPTION
## Summary
- Narrow prompt reliability/duplication-control refactor for Hermes real-channel behavior.
- Add a small shared real-channel behavior gate and mirror it into loaded prompt surfaces: AGENTS, Index bootstrap, tools, and heartbeat.
- Tighten Index capture rules so setup/status/schedule/link/code fragments and silence do not become signals or discovery triggers.
- Clean stale deterministic-script ownership comments and remove URL mutation guidance from Index exemplars.

## Scope
- No Index backend changes.
- No broad behavior rewrite.
- Full prompts remain readable; no prompt framework or dynamic import system added.

## Risk
- Main behavior-change risk is the newly loaded shared gate making Hermes shorter and more answer-first on support-like messages, plus stricter suppression of signal capture for ambiguous setup/status fragments.

## Validation
- bun test install/tests/prompt_reliability_gate.test.ts
- bun test skills/index-network/scripts/tests/send-daily-brief.test.ts skills/index-network/scripts/tests/stage-daily-brief.test.ts skills/index-network/scripts/tests/build-daily-brief-context.test.ts
- grep -RIn --exclude=prompt_reliability_gate.test.ts "prompt.*confirm\|prompt.*fetches opportunities\|composer prompt writes\|call confirm_opportunity_delivery\|append.*msg\|append.*text=\|?text=\|&msg=" skills/index-network skills/edge-esmeralda/prompts workspace install/tests
- git diff --check