### PR TITLE
Add opt-in automated morning brief delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AgentVillage is the public skills package and onboarding scripts that an agent (
 Today, capabilities come from **Index Network** (discovery + intent negotiation). **Geo** (knowledge graph) and **EdgeOS** (calendar + directory) are also in scope. Once installed, AgentVillage:
 
 - **Runs privacy-first onboarding** the first time you message it (greet → ask one data-use consent question covering EdgeOS data and public lookup → require a public social/profile URL before any internet lookup → profile draft → user approval → first signal → silent handle capture → `complete_onboarding`).
-- **Prepares a morning brief for 08:00 host-local time** with admin-set village announcements, today's EdgeOS calendar highlights, the connections worth your attention, and the asks where you can help. Each night's brief is staged and held for review; it is delivered at 08:00 only after an operator approves it by unblocking the staged card on the board.
+- **Prepares a morning brief for 08:00 host-local time** with admin-set village announcements, today's EdgeOS calendar highlights, the connections worth your attention, and the asks where you can help. Each night's brief is staged and held for review by default; it is delivered only after an operator approves it by unblocking the staged card on the board. Operators can opt into automated delivery with `DIGEST_REVIEW_REQUIRED=false`.
 - **Notifies you when someone accepts** a connection on your behalf.
 - **Curates memory** every few days — distills daily notes into long-term `MEMORY.md`.
 
@@ -216,23 +216,40 @@ bun install/install.ts \
 
 ### Overriding the digest cron times
 
-The morning digest runs as two fixed crons — **prepare at `0 2 * * *`** and **send at `0 8 * * *`** (host-local). To install them at different times (a different timezone, a test window, etc.), pass full 5-field cron expressions. A flag wins over the matching env var; an invalid expression is ignored with a warning and the default is kept.
+The morning digest runs as three host-local crons with deterministic per-tenant staggering by default: memory signal sync spreads across **01:00-01:49**, prepare spreads across **02:00-02:49**, and send spreads across **08:00-08:24**. To install them at exact times (a different timezone, a test window, etc.), pass full 5-field cron expressions. A flag wins over the matching env var; an invalid expression is ignored with a warning and the staggered default is kept.
 
 ```bash
 # via flags
 bun install/install.ts --index-api-key <YOUR_API_KEY> \
+  --digest-signals-cron "0 1 * * *" \
   --digest-prepare-cron "0 3 * * *" \
   --digest-send-cron    "0 9 * * *"
 
 # or via environment
-DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="0 9 * * *" \
+DIGEST_SIGNALS_CRON="0 1 * * *" DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="0 9 * * *" \
   bun install/install.ts --index-api-key <YOUR_API_KEY>
 ```
 
 | Cron | Flag | Env var | Default |
 |---|---|---|---|
-| Prepare pass | `--digest-prepare-cron "<expr>"` | `DIGEST_PREPARE_CRON` | `0 2 * * *` |
-| Send pass | `--digest-send-cron "<expr>"` | `DIGEST_SEND_CRON` | `0 8 * * *` |
+| Memory signal sync | `--digest-signals-cron "<expr>"` | `DIGEST_SIGNALS_CRON` | staggered from `0 1 * * *` over 01:00-01:49 |
+| Prepare pass | `--digest-prepare-cron "<expr>"` | `DIGEST_PREPARE_CRON` | staggered from `0 2 * * *` over 02:00-02:49 |
+| Send pass | `--digest-send-cron "<expr>"` | `DIGEST_SEND_CRON` | staggered from `0 8 * * *` over 08:00-08:24 |
+
+### Opting into automated digest delivery
+
+The human review gate is the default. The prepare pass creates a **blocked** Kanban task, and the send pass stays silent until an operator approves it by unblocking the task (`hermes kanban unblock <id>` or the board's unblock control).
+
+For hosted/operator-controlled installs where the morning brief should deliver without manual Kanban approval, set `DIGEST_REVIEW_REQUIRED=false` or pass `--no-digest-review-required` / `--no-review-required` during install:
+
+```bash
+DIGEST_REVIEW_REQUIRED=false bun install/install.ts --index-api-key <YOUR_API_KEY>
+
+# equivalent flag form
+bun install/install.ts --index-api-key <YOUR_API_KEY> --no-digest-review-required
+```
+
+The installer persists `DIGEST_REVIEW_REQUIRED=false` into the Hermes env only when this switch is provided. To return an install to the default gate, rerun with `--digest-review-required true` or set `DIGEST_REVIEW_REQUIRED=true`.
 
 The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openclaw.json`; on the next gateway start they become process-env on the gateway and inherit into the agent's shell tool, so `curl -H "Authorization: Bearer $EDGEOS_API_KEY"` recipes and Geo CLI commands work without further plumbing.
 
@@ -244,7 +261,7 @@ The installer:
 4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
-7. Installs the two digest cron jobs: a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. The end user can't change the schedule from chat, but the installer can override both times via `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the digest cron times" above.
+7. Installs the three digest cron jobs: memory signal sync (staggered across 01:00-01:49), a prepare pass (staggered across 02:00-02:49) that composes the morning brief and stages it as an editable Kanban task, and a send pass (staggered across 08:00-08:24) that delivers the staged brief. By default, the prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. Operator-controlled installs can opt into automated delivery with `DIGEST_REVIEW_REQUIRED=false` / `--no-digest-review-required`, which stages the task in a deliverable state for the send pass. The end user can't change the schedule from chat, but the installer can override cron times via `--digest-signals-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or matching `DIGEST_*_CRON` env vars) — see "Overriding the digest cron times" above.
 8. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent setup gates with different triggers:
@@ -276,7 +293,7 @@ bun install/reset.ts --wipe-user
 
 ## How it runs
 
-Time-sensitive prompts (the morning digest's prepare pass at 02:00 and send pass at 08:00 — host-local) run as **OpenClaw cron jobs**, not heartbeat tasks. Cron has its own scheduler and runs in isolated sessions with `--light-context` so each tick is cheap. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
+Time-sensitive prompts (memory signal sync near 01:00, the morning digest prepare pass near 02:00, and the send pass near 08:00 — host-local, each staggered per tenant) run as **OpenClaw cron jobs**, not heartbeat tasks. Cron has its own scheduler and runs in isolated sessions with `--light-context` so each tick is cheap. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
 
 Accepted-opportunity notifications, freshness audits, memory curation, and any other latency-tolerant background work stay on the heartbeat tick because 30-minute latency is acceptable for those flows.
 
@@ -334,11 +351,12 @@ AgentVillage's behaviour is markdown-driven. Almost everything you'd want to cha
 
 ### Schedule & cron
 
-The digest runs as a fixed prepare/send pair — **prepare `0 2 * * *`, send `0 8 * * *`** (host-local) — and the end user can't change it from chat. The installer can override either time (see "Overriding the digest cron times" under **Install**).
+The digest runs as a host-local cron sequence — memory signal sync around 01:00, prepare around 02:00, send around 08:00 — with deterministic per-tenant staggering. The end user can't change it from chat. The installer can override these times (see "Overriding the digest cron times" under **Install**).
 
 | You want to… | Edit | Notes |
 |---|---|---|
-| Override the digest times for one install | `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the default. |
+| Override the digest times for one install | `--digest-signals-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or matching `DIGEST_*_CRON` env vars) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the staggered default. |
+| Opt into automated digest delivery for one install | `DIGEST_REVIEW_REQUIRED=false`, `--no-digest-review-required`, or `--no-review-required` | Default is human review: prepare blocks the card and send stays silent until approval. Automation mode skips the block/unblocks the card so send can deliver without manual Kanban approval. |
 | Change the default digest schedule for everyone | `install/install_index.ts` (`DIGEST_CRON_SPECS`) | The installer writes the cron entries from this table. Existing installs pick up changes on the next `install.ts` run. |
 | Change a cron prompt without changing the schedule | the matching `skills/edge-esmeralda/prompts/<name>.md` | Hermes stores prompt copies in cron jobs. Hosted residents are refreshed by the control-plane post-merge sync, which calls each sidecar's `/update` endpoint and reruns the installer. For non-control-plane installs or recovery, run `HERMES_HOME=<resident-home> bun install/reconcile_digest_crons.ts` after updated skill files are copied. |
 

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -56,6 +56,45 @@ function readTelegramHandle(): string {
     || "";
 }
 
+function parseBoolean(value: string | undefined): boolean | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function readOptionalFlag(argv: string[], name: string): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === name) return argv[i + 1]?.startsWith("--") ? undefined : argv[i + 1];
+    if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1);
+  }
+  return undefined;
+}
+
+export function readDigestReviewRequiredOverride(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean | undefined {
+  if (argv.includes("--no-review-required") || argv.includes("--no-digest-review-required")) {
+    return false;
+  }
+
+  const fromFlag = parseBoolean(
+    readOptionalFlag(argv, "--digest-review-required") ?? readOptionalFlag(argv, "--review-required"),
+  );
+  if (fromFlag !== undefined) return fromFlag;
+
+  const rawEnv = env.DIGEST_REVIEW_REQUIRED;
+  const fromEnv = parseBoolean(rawEnv);
+  if (fromEnv !== undefined) return fromEnv;
+  if (rawEnv?.trim()) {
+    console.warn(`  warning: ignoring invalid DIGEST_REVIEW_REQUIRED value "${rawEnv}"`);
+  }
+  return undefined;
+}
+
 export function buildIndexMcpHeaders(apiKey: string, telegramHandle = ""): Record<string, string> {
   const headers: Record<string, string> = {
     "x-api-key": apiKey,
@@ -382,11 +421,16 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
 export function installIndex(): void {
   const apiKey = readApiKey();
   const telegramHandle = readTelegramHandle();
+  const digestReviewRequired = readDigestReviewRequiredOverride();
   console.log(
     `→ index network: target=${IS_DEV ? "dev" : "production"} (${PROTOCOL_MCP_URL})`,
   );
   upsertEnvVar("INDEX_API_KEY", apiKey);
   if (telegramHandle) upsertEnvVar("INDEX_TELEGRAM_HANDLE", telegramHandle);
+  if (digestReviewRequired !== undefined) {
+    upsertEnvVar("DIGEST_REVIEW_REQUIRED", digestReviewRequired ? "true" : "false");
+    console.log(`→ digest review gate: ${digestReviewRequired ? "required" : "automation opt-in"}`);
+  }
   writeMcpServerEntry(apiKey, telegramHandle);
 
   if (!process.argv.includes("--skip-crons")) {

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -7,6 +7,7 @@ import {
   cronEditArgs,
   fnv1a,
   isValidCron,
+  readDigestReviewRequiredOverride,
   resolveCronSchedule,
   staggeredSchedule,
   storedSchedule,
@@ -104,6 +105,18 @@ test("index MCP headers include telegram surface and optional handle", () => {
     "x-index-surface": "telegram",
     "x-index-telegram-username": "@alice",
   });
+});
+
+test("digest review gate override is explicit and defaults to unchanged", () => {
+  expect(readDigestReviewRequiredOverride([], {})).toBeUndefined();
+  expect(readDigestReviewRequiredOverride(["bun", "--no-digest-review-required"], {})).toBe(false);
+  expect(readDigestReviewRequiredOverride(["bun", "--no-review-required"], {})).toBe(false);
+  expect(readDigestReviewRequiredOverride(["bun", "--digest-review-required=false"], {})).toBe(false);
+  expect(readDigestReviewRequiredOverride(["bun", "--review-required", "true"], {
+    DIGEST_REVIEW_REQUIRED: "false",
+  })).toBe(true);
+  expect(readDigestReviewRequiredOverride([], { DIGEST_REVIEW_REQUIRED: "false" })).toBe(false);
+  expect(readDigestReviewRequiredOverride([], { DIGEST_REVIEW_REQUIRED: "true" })).toBe(true);
 });
 
 test("each spec declares its install-time override flag + env var", () => {

--- a/skills/edge-esmeralda/prompts/prepare.md
+++ b/skills/edge-esmeralda/prompts/prepare.md
@@ -26,7 +26,9 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
    bun skills/index-network/scripts/stage-daily-brief.ts --state-file memory/heartbeat-state.json --context-out memory/daily-brief-context.json
    ```
 
-   The script resolves the America/Los_Angeles date, fetches opportunities and pending questions from the Index MCP server, builds structured context, composes the markdown body (including the optional closing question postscript), runs the URL guard, creates the Kanban task with argv-safe `--body`, blocks it for review, and records `prepared.taskId` in `memory/heartbeat-state.json`. Its JSON stdout is for diagnostics only; do not expose it.
+   The script resolves the America/Los_Angeles date, fetches opportunities and pending questions from the Index MCP server, builds structured context, composes the markdown body (including the optional closing question postscript), runs the URL guard, creates the Kanban task with argv-safe `--body`, applies the review gate, and records `prepared.taskId` in `memory/heartbeat-state.json`. Its JSON stdout is for diagnostics only; do not expose it.
+
+   Default behavior is human review: the script blocks the staged card so it ships only after an operator approves it by unblocking. Operators can opt into fully automated delivery at install/runtime with `DIGEST_REVIEW_REQUIRED=false` (or, for a manual run, `--no-review-required`); in that mode the script leaves or unblocks the card into a deliverable `todo`/`ready` state for the send pass. Do not add that flag yourself unless the runtime/operator has explicitly opted in.
 
    If the script exits with a non-zero code, end your turn immediately with the host-specific no-reply marker. Do not diagnose the failure, retry the script, or attempt alternative staging paths. One attempt only.
 
@@ -36,7 +38,8 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 - Never invent announcements, events, people, venues, times, tracks, or action URLs.
 - Do not compose or stage the Kanban card manually; `stage-daily-brief.ts` is the only allowed staging path.
 - One attempt at the staging script. If it fails, end immediately with the no-reply marker — no retries, no diagnosis, no alternative paths.
-- Always stage the brief **blocked** (held for review) and record its `taskId`; it ships only if a human unblocks (approves) it before the send pass. Never assign it or move it to **Ready**.
+- By default, stage the brief **blocked** (held for review) and record its `taskId`; it ships only if a human unblocks (approves) it before the send pass.
+- Only when the runtime/operator has explicitly opted in with `DIGEST_REVIEW_REQUIRED=false` or `--no-review-required`, let the staging script skip the block/unblock into a deliverable `todo`/`ready` state. Do not manually assign or move the card.
 - Calendar failures must not block launch: ship people-only plus the one-line calendar pointer, or the pointer-only fallback if there is nothing else.
 - The question postscript is sanctioned: when the digest has verified content and a pending question exists, the body ends with `---` followed by a single `**One for you:**` question after the sign-off line. The pointer-only fallback digest never carries a question. The hidden `digest-question` marker beside it is delivery bookkeeping — like opportunity markers, it is stripped before the user sees the brief; do not remove or edit it.
 - Never confirm delivery here. Never write `deliveredToday` here.

--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -5,7 +5,7 @@
  * The cron prompt still fetches Index opportunities through MCP and writes the
  * transcript to `memory/digest-opportunities.txt`. This script owns everything
  * after that: context building, markdown composition, URL validation, Kanban
- * create/block, and heartbeat bookkeeping. Keeping this deterministic avoids
+ * create/review-state, and heartbeat bookkeeping. Keeping this deterministic avoids
  * prompt-generated shell quoting bugs and CLI flag drift.
  */
 
@@ -18,9 +18,45 @@ import { sanitizeDigestUrls } from "./validate-digest-urls";
 const CONNECTION_DIGEST_LIMIT = 1;
 const COMMUNITY_DIGEST_LIMIT = 1;
 
+type HermesRunner = (args: string[]) => string | Promise<string>;
+type DailyBriefContextBuilder = typeof buildDailyBriefContext;
+
 function argValue(args: string[], name: string): string | undefined {
   const idx = args.indexOf(name);
   return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
+}
+
+function booleanArgValue(args: string[], name: string): string | undefined {
+  const direct = argValue(args, name);
+  if (direct !== undefined) return direct;
+  const prefix = `${name}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+export function resolveReviewRequired(
+  args: string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (hasFlag(args, "--no-review-required") || hasFlag(args, "--no-digest-review-required")) return false;
+
+  const fromFlag = parseBoolean(booleanArgValue(args, "--review-required")
+    ?? booleanArgValue(args, "--digest-review-required"));
+  if (fromFlag !== undefined) return fromFlag;
+
+  const fromEnv = parseBoolean(env.DIGEST_REVIEW_REQUIRED);
+  return fromEnv ?? true;
 }
 
 function pacificDate(): string {
@@ -240,6 +276,40 @@ async function runHermes(args: string[]): Promise<string> {
   return new TextDecoder().decode(result.stdout);
 }
 
+function parseTaskStatus(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { status?: unknown; task?: { status?: unknown } };
+    const status = typeof parsed.status === "string"
+      ? parsed.status
+      : typeof parsed.task?.status === "string"
+        ? parsed.task.status
+        : "";
+    return status.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+async function markTaskDeliverable(hermes: HermesRunner, taskId: string): Promise<void> {
+  try {
+    await hermes(["kanban", "unblock", taskId]);
+    return;
+  } catch (unblockError) {
+    let status = "";
+    try {
+      status = parseTaskStatus(await hermes(["kanban", "show", taskId, "--json"]));
+    } catch (showError) {
+      const reason = showError instanceof Error ? showError.message : String(showError);
+      throw new Error(`could not verify automated digest task status after unblock failed: ${reason}`);
+    }
+
+    if (status === "todo" || status === "ready") return;
+
+    const reason = unblockError instanceof Error ? unblockError.message : String(unblockError);
+    throw new Error(`automated digest task is not deliverable after unblock failed: status=${status || "unknown"}; ${reason}`);
+  }
+}
+
 function extractTaskId(raw: string): string {
   const trimmed = raw.trim();
   try {
@@ -259,20 +329,26 @@ export async function stageDailyBrief(options: {
   opportunitiesFile?: string;
   stateFile?: string;
   contextOut?: string;
+  reviewRequired?: boolean;
+  hermes?: HermesRunner;
+  buildContext?: DailyBriefContextBuilder;
 } = {}): Promise<{ taskId: string; body: string; opportunityIds: string[]; questionIds: string[] }> {
   const date = options.date ?? pacificDate();
   const opportunitiesFile = options.opportunitiesFile ?? "memory/digest-opportunities.txt";
   const stateFile = options.stateFile ?? "memory/heartbeat-state.json";
   const contextOut = options.contextOut ?? "memory/daily-brief-context.json";
+  const reviewRequired = options.reviewRequired ?? true;
+  const hermes = options.hermes ?? runHermes;
+  const buildContext = options.buildContext ?? buildDailyBriefContext;
 
-  const context = await buildDailyBriefContext({ date, opportunitiesFile, stateFile });
+  const context = await buildContext({ date, opportunitiesFile, stateFile });
   await writeJson(contextOut, context);
 
   const { body, opportunityIds, questionIds } = composeDailyBrief(context);
   const { output: sanitizedBody } = sanitizeDigestUrls(body);
   await Bun.write("memory/digest-draft.md", `${sanitizedBody}\n`);
 
-  const createOutput = await runHermes([
+  const createOutput = await hermes([
     "kanban",
     "create",
     `Morning digest — ${date}`,
@@ -284,13 +360,19 @@ export async function stageDailyBrief(options: {
   ]);
   const taskId = extractTaskId(createOutput);
 
-  await runHermes(["kanban", "block", taskId, `review-required: morning brief — ${date}`]);
+  if (reviewRequired) {
+    await hermes(["kanban", "block", taskId, `review-required: morning brief — ${date}`]);
+  } else {
+    await markTaskDeliverable(hermes, taskId);
+  }
 
   const state = await readJsonObject(stateFile);
   state.prepared = {
     date,
     taskId,
     taskTitle: `Morning digest — ${date}`,
+    reviewRequired,
+    deliveryGate: reviewRequired ? "human-review" : "automated",
     opportunityIds,
     questionIds,
   };
@@ -308,6 +390,7 @@ async function main(): Promise<void> {
     opportunitiesFile: argValue(args, "--opportunities-file"),
     stateFile: argValue(args, "--state-file"),
     contextOut: argValue(args, "--context-out"),
+    reviewRequired: resolveReviewRequired(args),
   });
   process.stdout.write(`${JSON.stringify({ taskId: result.taskId, opportunityIds: result.opportunityIds, questionIds: result.questionIds })}\n`);
 }

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { composeDailyBrief } from "../stage-daily-brief";
+import { composeDailyBrief, resolveReviewRequired, stageDailyBrief } from "../stage-daily-brief";
 import type { DailyBriefContext } from "../build-daily-brief-context";
 
 const baseContext: DailyBriefContext = {
@@ -23,6 +26,158 @@ const baseContext: DailyBriefContext = {
     interestTags: [],
   },
 };
+
+let previousCwd = process.cwd();
+const tempDirs: string[] = [];
+
+function makeTempWorkdir(): string {
+  previousCwd = process.cwd();
+  const dir = mkdtempSync(join(tmpdir(), "stage-daily-brief-"));
+  tempDirs.push(dir);
+  mkdirSync(join(dir, "memory"), { recursive: true });
+  process.chdir(dir);
+  return dir;
+}
+
+afterEach(() => {
+  process.chdir(previousCwd);
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveReviewRequired", () => {
+  test("defaults to requiring human review", () => {
+    expect(resolveReviewRequired([], {})).toBe(true);
+  });
+
+  test("honors env and CLI opt-out switches", () => {
+    expect(resolveReviewRequired([], { DIGEST_REVIEW_REQUIRED: "false" })).toBe(false);
+    expect(resolveReviewRequired(["--no-review-required"], {})).toBe(false);
+    expect(resolveReviewRequired(["--no-digest-review-required"], {})).toBe(false);
+    expect(resolveReviewRequired(["--digest-review-required=false"], { DIGEST_REVIEW_REQUIRED: "true" })).toBe(false);
+    expect(resolveReviewRequired(["--review-required", "true"], { DIGEST_REVIEW_REQUIRED: "false" })).toBe(true);
+  });
+});
+
+describe("stageDailyBrief", () => {
+  test("creates and blocks the Morning digest task by default", async () => {
+    makeTempWorkdir();
+    const calls: string[][] = [];
+    const hermes = async (args: string[]) => {
+      calls.push(args);
+      return args[1] === "create" ? JSON.stringify({ task: { id: "t_digest" } }) : "";
+    };
+
+    const result = await stageDailyBrief({
+      date: "2026-06-04",
+      stateFile: "memory/heartbeat-state.json",
+      contextOut: "memory/daily-brief-context.json",
+      hermes,
+      buildContext: async () => ({
+        ...baseContext,
+        announcements: [{ body: "Town hall at 5pm." }],
+      }),
+    });
+
+    expect(result.taskId).toBe("t_digest");
+    expect(calls).toEqual([
+      [
+        "kanban",
+        "create",
+        "Morning digest — 2026-06-04",
+        "--body",
+        result.body,
+        "--idempotency-key",
+        "digest-2026-06-04",
+        "--json",
+      ],
+      ["kanban", "block", "t_digest", "review-required: morning brief — 2026-06-04"],
+    ]);
+
+    const state = await Bun.file("memory/heartbeat-state.json").json();
+    expect(state.prepared).toMatchObject({
+      date: "2026-06-04",
+      taskId: "t_digest",
+      reviewRequired: true,
+      deliveryGate: "human-review",
+    });
+  });
+
+  test("automation mode creates and unblocks the Morning digest task", async () => {
+    makeTempWorkdir();
+    const calls: string[][] = [];
+    const hermes = async (args: string[]) => {
+      calls.push(args);
+      return args[1] === "create" ? JSON.stringify({ id: "t_digest" }) : "";
+    };
+
+    const result = await stageDailyBrief({
+      date: "2026-06-04",
+      stateFile: "memory/heartbeat-state.json",
+      contextOut: "memory/daily-brief-context.json",
+      reviewRequired: false,
+      hermes,
+      buildContext: async () => ({
+        ...baseContext,
+        announcements: [{ body: "Town hall at 5pm." }],
+      }),
+    });
+
+    expect(calls).toEqual([
+      [
+        "kanban",
+        "create",
+        "Morning digest — 2026-06-04",
+        "--body",
+        result.body,
+        "--idempotency-key",
+        "digest-2026-06-04",
+        "--json",
+      ],
+      ["kanban", "unblock", "t_digest"],
+    ]);
+
+    const state = await Bun.file("memory/heartbeat-state.json").json();
+    expect(state.prepared).toMatchObject({
+      date: "2026-06-04",
+      taskId: "t_digest",
+      reviewRequired: false,
+      deliveryGate: "automated",
+    });
+  });
+
+  test("automation mode rejects when an existing task remains blocked after unblock fails", async () => {
+    makeTempWorkdir();
+    const calls: string[][] = [];
+    const hermes = async (args: string[]) => {
+      calls.push(args);
+      if (args[1] === "create") return JSON.stringify({ id: "t_existing" });
+      if (args[1] === "unblock") throw new Error("cannot unblock");
+      if (args[1] === "show") return JSON.stringify({ task: { id: "t_existing", status: "blocked" } });
+      return "";
+    };
+
+    await expect(stageDailyBrief({
+      date: "2026-06-04",
+      stateFile: "memory/heartbeat-state.json",
+      contextOut: "memory/daily-brief-context.json",
+      reviewRequired: false,
+      hermes,
+      buildContext: async () => ({
+        ...baseContext,
+        announcements: [{ body: "Town hall at 5pm." }],
+      }),
+    })).rejects.toThrow("status=blocked");
+
+    expect(calls[0]?.slice(0, 4)).toEqual(["kanban", "create", "Morning digest — 2026-06-04", "--body"]);
+    expect(calls.slice(1)).toEqual([
+      ["kanban", "unblock", "t_existing"],
+      ["kanban", "show", "t_existing", "--json"],
+    ]);
+    expect(await Bun.file("memory/heartbeat-state.json").exists()).toBe(false);
+  });
+});
 
 describe("composeDailyBrief", () => {
   test("renders real calendar content instead of calendar-unavailable fallback", () => {


### PR DESCRIPTION
## Maintainer context

This keeps the existing safe default: morning briefs are still staged for human review unless an operator explicitly opts into automated delivery.

The change is meant to make automation trustworthy when enabled:
- `DIGEST_REVIEW_REQUIRED=false` / `--no-digest-review-required` makes the prepare pass stage the card in a deliverable state.
- If an existing idempotent card is still blocked and cannot be unblocked, prepare now fails instead of recording a false “automated” state that send would silently skip.
- The prompt/docs now describe the review gate and the current staggered cron windows.

## Rollout notes

No behavior changes unless the operator sets the review switch. To return to manual review, rerun install with `DIGEST_REVIEW_REQUIRED=true` or `--digest-review-required true`.

This PR only covers the resident-side morning brief gate. Fleet scheduling/fallback is handled separately in the control-plane PR.

## Validation

- `bun test install/tests/cron_specs.test.ts`
- `bun test install/tests`
- `bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts skills/index-network/scripts/tests/send-daily-brief.test.ts`
