### PR TITLE
fix(digest): retry transient ledger-confirm failures across runs

### DIFF
--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -833,6 +833,10 @@ export async function confirmOpportunityDeliveriesViaMcp(opts: {
   for (const opportunityId of opts.opportunityIds) {
     let lastReason = "unknown";
     let ok = false;
+    // `confirm_opportunity_delivery` is idempotent, so transient failures are
+    // safe to retry. Permanent failures (opportunity deleted, caller not an
+    // actor) carry `retryable: false` — retrying them never succeeds and only
+    // hammers the MCP transport, so we stop early and report the reason.
     for (let attempt = 0; attempt < 2 && !ok; attempt++) {
       try {
         const resp = await postMcpMessage(opts.mcpUrl, opts.apiKey, {
@@ -853,9 +857,14 @@ export async function confirmOpportunityDeliveriesViaMcp(opts: {
         // The tool returns a success/error envelope; treat an explicit
         // success:false as failure so we don't silently drop ledger writes.
         try {
-          const parsed = JSON.parse(text) as { success?: boolean; error?: unknown };
+          const parsed = JSON.parse(text) as { success?: boolean; error?: unknown; code?: unknown; retryable?: unknown };
           if (parsed.success === false) {
-            lastReason = typeof parsed.error === "string" ? parsed.error : "tool reported failure";
+            const code = typeof parsed.code === "string" ? parsed.code : "";
+            lastReason = code
+              ? `${code}: ${typeof parsed.error === "string" ? parsed.error : "tool reported failure"}`
+              : (typeof parsed.error === "string" ? parsed.error : "tool reported failure");
+            // Permanent failure — do not burn the second attempt on it.
+            if (parsed.retryable === false) break;
             continue;
           }
         } catch {

--- a/skills/index-network/scripts/send-daily-brief.ts
+++ b/skills/index-network/scripts/send-daily-brief.ts
@@ -151,6 +151,25 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
 }
 
+/**
+ * Error-code prefixes the Index `confirm_opportunity_delivery` tool marks as
+ * `retryable: false`. A failure whose reason starts with one of these will
+ * never succeed on retry (deleted opportunity, caller not an actor, malformed
+ * id, bad auth), so it must NOT be carried into the cross-run retry queue —
+ * otherwise it accumulates forever and re-hammers the MCP transport daily.
+ */
+const PERMANENT_CONFIRM_CODES = [
+  "opportunity_not_found",
+  "not_authorized",
+  "invalid_opportunity_id",
+  "unauthenticated",
+  "ledger_unavailable",
+];
+
+function isPermanentConfirmFailure(reason: string): boolean {
+  return PERMANENT_CONFIRM_CODES.some((code) => reason.startsWith(code));
+}
+
 export async function sendDailyBrief(options: {
   date?: string;
   stateFile?: string;
@@ -190,6 +209,15 @@ export async function sendDailyBrief(options: {
   const opportunityIds = extractDigestOpportunityIds(body);
   const questionIds = extractDigestQuestionIds(body);
 
+  // Cross-run retry: ids whose ledger confirm failed transiently on a previous
+  // run. Index's cross-day digest suppression reads the ledger (not Hermes'
+  // local deliveredToday state), so a confirm that never lands lets the same
+  // opportunity resurface in a later digest. Re-attempt those here — the tool
+  // is idempotent, so re-confirming an id that actually landed is a cheap
+  // 'already_delivered'.
+  const priorPendingConfirms = stringArray(state.pendingDeliveryConfirms);
+  const confirmBatch = Array.from(new Set([...opportunityIds, ...priorPendingConfirms]));
+
   const deliveredToday = state.deliveredToday && typeof state.deliveredToday === "object" && !Array.isArray(state.deliveredToday)
     ? state.deliveredToday as Record<string, unknown>
     : {};
@@ -224,14 +252,32 @@ export async function sendDailyBrief(options: {
   let confirmedOpportunityIds: string[] = [];
   let confirmFailed: Array<{ opportunityId: string; reason: string }> = [];
   try {
-    const confirmResult = await confirmDeliveries(opportunityIds);
+    const confirmResult = await confirmDeliveries(confirmBatch);
     confirmedOpportunityIds = confirmResult.confirmed;
     confirmFailed = confirmResult.failed;
   } catch (err) {
-    confirmFailed = opportunityIds.map((opportunityId) => ({
+    confirmFailed = confirmBatch.map((opportunityId) => ({
       opportunityId,
       reason: err instanceof Error ? err.message : String(err),
     }));
+  }
+
+  // Persist the still-pending (transient-only) failures for the next run. Drop
+  // permanent failures — retrying them never succeeds. Only re-write state when
+  // the pending set actually changes, to avoid a needless disk write.
+  const nextPendingConfirms = confirmFailed
+    .filter((f) => !isPermanentConfirmFailure(f.reason))
+    .map((f) => f.opportunityId);
+  const pendingChanged =
+    nextPendingConfirms.length !== priorPendingConfirms.length ||
+    nextPendingConfirms.some((id, i) => id !== priorPendingConfirms[i]);
+  if (pendingChanged || priorPendingConfirms.length > 0) {
+    if (nextPendingConfirms.length > 0) {
+      state.pendingDeliveryConfirms = nextPendingConfirms;
+    } else {
+      delete state.pendingDeliveryConfirms;
+    }
+    await writeJson(stateFile, state);
   }
 
   const { output: finalBrief } = sanitizeDigestUrls(body, { stripDigestMetadata: true });

--- a/skills/index-network/scripts/tests/send-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/send-daily-brief.test.ts
@@ -203,6 +203,82 @@ describe("sendDailyBrief", () => {
     expect(result.confirmFailed).toEqual([{ opportunityId: "opp-1", reason: "confirmer exploded" }]);
   });
 
+  test("carries a transient confirm failure into pendingDeliveryConfirms and retries it next run", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      prepared: { date: "2026-06-04", taskId: "t_digest" },
+    }));
+    const body = "<!-- digest-opportunity:id=opp-1 -->Maya — relevant";
+
+    // Run 1: confirm fails transiently — opp-1 is parked for retry.
+    const run1 = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      outgoingFile: "outgoing.md",
+      hermes: (args) => {
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest", status: "ready", body } });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+      confirmDeliveries: async (ids) => ({ confirmed: [], failed: ids.map((opportunityId) => ({ opportunityId, reason: "mcp unreachable" })) }),
+    });
+    expect("silent" in run1).toBe(false);
+    expect(JSON.parse(await Bun.file("state.json").text()).pendingDeliveryConfirms).toEqual(["opp-1"]);
+
+    // Run 2: a fresh digest with opp-2; the parked opp-1 is retried alongside it.
+    await Bun.write("state.json", JSON.stringify({
+      prepared: { date: "2026-06-05", taskId: "t_digest2" },
+      pendingDeliveryConfirms: ["opp-1"],
+    }));
+    const body2 = "<!-- digest-opportunity:id=opp-2 -->Sam — relevant";
+    const confirmCalls: string[][] = [];
+    const run2 = await sendDailyBrief({
+      date: "2026-06-05",
+      stateFile: "state.json",
+      outgoingFile: "outgoing.md",
+      hermes: (args) => {
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest2", status: "ready", body: body2 } });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+      confirmDeliveries: async (ids) => {
+        confirmCalls.push(ids);
+        return { confirmed: ids, failed: [] };
+      },
+    });
+    expect("silent" in run2).toBe(false);
+    // Both the new id and the parked one are confirmed in one batch.
+    expect(confirmCalls).toEqual([["opp-2", "opp-1"]]);
+    // All landed — the retry queue is cleared from state.
+    expect(JSON.parse(await Bun.file("state.json").text()).pendingDeliveryConfirms).toBeUndefined();
+  });
+
+  test("a permanent confirm failure is NOT parked for retry", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      prepared: { date: "2026-06-04", taskId: "t_digest" },
+    }));
+    const body = "<!-- digest-opportunity:id=opp-1 -->Maya — relevant";
+
+    const result = await sendDailyBrief({
+      date: "2026-06-04",
+      stateFile: "state.json",
+      outgoingFile: "outgoing.md",
+      hermes: (args) => {
+        if (args[0] === "kanban" && args[1] === "show") return JSON.stringify({ task: { id: "t_digest", status: "ready", body } });
+        if (args[0] === "kanban" && args[1] === "complete") return "completed";
+        throw new Error(`unexpected hermes call: ${args.join(" ")}`);
+      },
+      confirmDeliveries: async (ids) => ({ confirmed: [], failed: ids.map((opportunityId) => ({ opportunityId, reason: "opportunity_not_found: deleted" })) }),
+    });
+
+    expect("silent" in result).toBe(false);
+    // Permanent failure still surfaces in diagnostics …
+    expect(result.confirmFailed).toEqual([{ opportunityId: "opp-1", reason: "opportunity_not_found: deleted" }]);
+    // … but is never parked for a doomed daily retry.
+    expect(JSON.parse(await Bun.file("state.json").text()).pendingDeliveryConfirms).toBeUndefined();
+  });
+
   test("silent results never invoke the confirmer", async () => {
     tempWorkspace();
     await Bun.write("state.json", JSON.stringify({ prepared: { date: "2026-06-03", taskId: "t_old" } }));


### PR DESCRIPTION
## Problem

In the daily digest flow, the send script marked an opportunity locally delivered even when its Index ledger `confirm_opportunity_delivery` call failed. But Index's cross-day digest suppression reads the **ledger**, not Hermes' local `deliveredToday` state — so a confirm that never landed let the **same opportunity resurface in a later digest**. This is the resurfacing symptom reported in the digest flows.

A secondary issue: the confirm tool used to return one opaque "Failed to confirm… Please try again" for every failure, so the script could not tell a permanent failure (deleted opportunity, caller not an actor) from a transient backend blip, and retried both.

## Changes

- **`confirmOpportunityDeliveriesViaMcp`** now honors the tool's new `retryable` flag. Permanent failures (`opportunity_not_found`, `not_authorized`, `invalid_opportunity_id`, `unauthenticated`, `ledger_unavailable`) stop early instead of burning the second attempt, and the failure `reason` carries the error `code`.
- **`send-daily-brief`** parks transient confirm failures in `state.pendingDeliveryConfirms` and re-attempts them on the next run (merged into the confirm batch). Permanent failures are dropped, never parked. The tool is idempotent, so re-confirming an id that already landed is a cheap `already_delivered`.

## Dependency

Relies on the typed/`retryable` error envelope added to `confirm_opportunity_delivery` in the protocol package — see the companion PR in `indexnetwork/index` (→ `dev`). This PR degrades gracefully if that envelope is absent (no `retryable` field ⇒ treated as retryable, same as before).

## Verification

- `bun test tests/send-daily-brief.test.ts tests/build-daily-brief-context.test.ts` → **42 pass**
- New tests: cross-run retry of a transient failure (parked then confirmed next run), and a permanent failure is NOT parked.

## Notes

Branched from latest `Edge-City/agentvillage:main`; the monorepo submodule was a few automated commits behind. `main`'s advance did not touch the digest script files.