### PR TITLE
Fix daily digest calendar event ordering

### DIFF
--- a/skills/index-network/scripts/stage-daily-brief.ts
+++ b/skills/index-network/scripts/stage-daily-brief.ts
@@ -34,10 +34,20 @@ function pacificDate(): string {
   return `${get("year")}-${get("month")}-${get("day")}`;
 }
 
-function eventLine(event: DailyBriefContext["highlightedEvents"][number]): string {
+function eventLine(event: DailyBriefContext["highlightedEvents"][number], label?: string): string {
   const venue = event.venue ? ` at ${event.venue}` : "";
   const title = event.eventUrl ? `[${event.title}](${event.eventUrl})` : event.title;
-  return `- ${event.timePacific} — ${title}${venue}`;
+  const suffix = label ? ` (${label})` : "";
+  return `- ${event.timePacific} — ${title}${venue}${suffix}`;
+}
+
+function compareEventsByStartTime(
+  a: DailyBriefContext["highlightedEvents"][number],
+  b: DailyBriefContext["highlightedEvents"][number],
+): number {
+  const byStart = a.startTime.localeCompare(b.startTime);
+  if (byStart !== 0) return byStart;
+  return a.title.localeCompare(b.title);
 }
 
 function opportunityLabel(opp: BriefOpportunity): string {
@@ -109,21 +119,20 @@ export function composeDailyBrief(context: DailyBriefContext): { body: string; o
     hasVerifiedContent = true;
   }
 
-  if (context.rsvpEvents.length > 0) {
-    lines.push("**On your calendar today (your RSVPs):**");
-    for (const event of context.rsvpEvents) lines.push(eventLine(event));
-    lines.push("");
-    hasVerifiedContent = true;
-  }
-
   // Key on id + start time so distinct occurrences of a recurring event are not collapsed.
   const eventKey = (event: DailyBriefContext["highlightedEvents"][number]) => `${event.id ?? event.title}:${event.startTime}`;
   const rsvpKeys = new Set(context.rsvpEvents.map(eventKey));
-  const events = [...context.highlightedEvents, ...context.interestEvents].filter((event) => !rsvpKeys.has(eventKey(event)));
-  if (events.length > 0) {
-    lines.push(context.rsvpEvents.length > 0 ? "**Also on today:**" : "**A few things on today:**");
-    for (const event of events) lines.push(eventLine(event));
-    if (context.diagnostics.calendarSource === "edgeos") {
+  const suggestedEvents = [...context.highlightedEvents, ...context.interestEvents]
+    .filter((event) => !rsvpKeys.has(eventKey(event)));
+  const calendarEvents = [
+    ...context.rsvpEvents.map((event) => ({ event, label: "your RSVP" })),
+    ...suggestedEvents.map((event) => ({ event, label: undefined })),
+  ].sort((a, b) => compareEventsByStartTime(a.event, b.event));
+
+  if (calendarEvents.length > 0) {
+    lines.push(context.rsvpEvents.length > 0 ? "**On today (your RSVPs marked):**" : "**A few things on today:**");
+    for (const item of calendarEvents) lines.push(eventLine(item.event, item.label));
+    if (suggestedEvents.length > 0 && context.diagnostics.calendarSource === "edgeos") {
       lines.push("That's a selection, not the whole day — ask me for the full calendar anytime.");
     }
     lines.push("");

--- a/skills/index-network/scripts/tests/stage-daily-brief.test.ts
+++ b/skills/index-network/scripts/tests/stage-daily-brief.test.ts
@@ -54,7 +54,7 @@ describe("composeDailyBrief", () => {
     expect(body).not.toContain("\\ud83c");
   });
 
-  test("renders an RSVP section and excludes RSVPed events from the discovery list", () => {
+  test("renders RSVPs in chronological calendar order and excludes RSVPed events from discovery", () => {
     const rsvped = {
       id: "event-rsvp",
       title: "Qi Gong",
@@ -85,12 +85,50 @@ describe("composeDailyBrief", () => {
       diagnostics: { ...baseContext.diagnostics, calendarSource: "edgeos", rsvpSource: "edgeos" },
     });
 
-    expect(body).toContain("**On your calendar today (your RSVPs):**");
-    expect(body).toContain("8:00 AM — [Qi Gong]");
-    expect(body).toContain("**Also on today:**");
+    expect(body).toContain("**On today (your RSVPs marked):**");
+    expect(body).toContain("8:00 AM — [Qi Gong](https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb) at Plaza (your RSVP)");
+    expect(body).toContain("9:00 AM — [GNOSIS Journey]");
+    expect(body).not.toContain("**Also on today:**");
     expect(body).toContain("That's a selection, not the whole day — ask me for the full calendar anytime.");
+    expect(body.indexOf("8:00 AM — [Qi Gong]")).toBeLessThan(body.indexOf("9:00 AM — [GNOSIS Journey]"));
     // Qi Gong is an RSVP, so it must not also appear in the discovery list.
     expect(body.match(/Qi Gong/g) ?? []).toHaveLength(1);
+  });
+
+  test("does not move backward in time when a suggested event starts before a later RSVP", () => {
+    const laterRsvp = {
+      id: "event-rsvp-late",
+      title: "Connection Lab",
+      startTime: "2026-06-04T23:30:00Z",
+      timePacific: "4:30 PM",
+      venue: "The Loft",
+      eventUrl: "https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/cccccccc-cccc-cccc-cccc-cccccccccccc",
+      tags: [],
+      highlighted: true,
+      reasonHint: "You RSVPed to this.",
+    };
+    const earlierSuggestion = {
+      id: "event-suggested-earlier",
+      title: "Village Tours",
+      startTime: "2026-06-04T21:00:00Z",
+      timePacific: "2:00 PM",
+      venue: "Meet at the Hub",
+      eventUrl: "https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/dddddddd-dddd-dddd-dddd-dddddddddddd",
+      tags: [],
+      highlighted: true,
+      reasonHint: "Highlighted by the EdgeOS calendar.",
+    };
+
+    const { body } = composeDailyBrief({
+      ...baseContext,
+      rsvpEvents: [laterRsvp],
+      highlightedEvents: [earlierSuggestion],
+      diagnostics: { ...baseContext.diagnostics, calendarSource: "edgeos", rsvpSource: "edgeos" },
+    });
+
+    expect(body).toContain("**On today (your RSVPs marked):**");
+    expect(body.indexOf("2:00 PM — [Village Tours]")).toBeLessThan(body.indexOf("4:30 PM — [Connection Lab]"));
+    expect(body).toContain("4:30 PM — [Connection Lab](https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/cccccccc-cccc-cccc-cccc-cccccccccccc) at The Loft (your RSVP)");
   });
 
   test("renders opportunities with digest markers and collects ids", () => {


### PR DESCRIPTION
## Summary
- merge RSVP and suggested digest events into one chronological calendar section
- mark RSVP events inline instead of rendering a separate earlier-priority section
- add coverage for the late-RSVP / earlier-suggested-event regression from indexnetwork/index#956

## Before / after

Before, RSVP events rendered in their own section before suggested events. That could make the visible timeline move backward:

```md
**On your calendar today (your RSVPs):**
- 4:30 PM — [Connection Lab](...) at The Loft

**Also on today:**
- 2:00 PM — [Village Tours](...) at Meet at the Hub
```

After, calendar items render as one chronological list, with RSVPs marked inline:

```md
**On today (your RSVPs marked):**
- 2:00 PM — [Village Tours](...) at Meet at the Hub
- 4:30 PM — [Connection Lab](...) at The Loft (your RSVP)
```

## Tests
- bun test skills/index-network/scripts/tests/stage-daily-brief.test.ts

Refs indexnetwork/index#956
