### PR TITLE
fix: cap Hermes output tokens and harden heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ HEARTBEAT_CRON="*/30 * * * *" DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="
 | Prepare pass | `--digest-prepare-cron "<expr>"` | `DIGEST_PREPARE_CRON` | `0 2 * * *` |
 | Send pass | `--digest-send-cron "<expr>"` | `DIGEST_SEND_CRON` | `0 8 * * *` |
 
+The installer also caps `model.max_tokens` in Hermes `config.yaml` at `4096` by default so background cron turns do not inherit large provider defaults (for example `65536`). Operators can raise or lower that cap for an install by setting `HERMES_MAX_TOKENS`.
+
 The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openclaw.json`; on the next gateway start they become process-env on the gateway and inherit into the agent's shell tool, so `curl -H "Authorization: Bearer $EDGEOS_API_KEY"` recipes and Geo CLI commands work without further plumbing.
 
 The installer:

--- a/README.md
+++ b/README.md
@@ -214,23 +214,25 @@ bun install/install.ts \
   --edgeos-bearer-token eyJ…
 ```
 
-### Overriding the digest cron times
+### Overriding the Index cron times
 
-The morning digest runs as two fixed crons — **prepare at `0 2 * * *`** and **send at `0 8 * * *`** (host-local). To install them at different times (a different timezone, a test window, etc.), pass full 5-field cron expressions. A flag wins over the matching env var; an invalid expression is ignored with a warning and the default is kept.
+Index background work is installed as three Hermes/OpenClaw cron jobs: **heartbeat at `*/30 * * * *`**, **digest prepare at `0 2 * * *`**, and **digest send at `0 8 * * *`** (host-local). To install them at different times (a different timezone, a test window, etc.), pass full 5-field cron expressions. A flag wins over the matching env var; an invalid expression is ignored with a warning and the default is kept.
 
 ```bash
 # via flags
 bun install/install.ts --index-api-key <YOUR_API_KEY> \
+  --heartbeat-cron      "*/30 * * * *" \
   --digest-prepare-cron "0 3 * * *" \
   --digest-send-cron    "0 9 * * *"
 
 # or via environment
-DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="0 9 * * *" \
+HEARTBEAT_CRON="*/30 * * * *" DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="0 9 * * *" \
   bun install/install.ts --index-api-key <YOUR_API_KEY>
 ```
 
 | Cron | Flag | Env var | Default |
 |---|---|---|---|
+| Heartbeat | `--heartbeat-cron "<expr>"` | `HEARTBEAT_CRON` | `*/30 * * * *` |
 | Prepare pass | `--digest-prepare-cron "<expr>"` | `DIGEST_PREPARE_CRON` | `0 2 * * *` |
 | Send pass | `--digest-send-cron "<expr>"` | `DIGEST_SEND_CRON` | `0 8 * * *` |
 
@@ -244,7 +246,7 @@ The installer:
 4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
-7. Installs the two digest cron jobs: a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. The end user can't change the schedule from chat, but the installer can override both times via `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the digest cron times" above.
+7. Installs the Index cron jobs: a heartbeat (`*/30 * * * *`) that runs `skills/index-network/heartbeat.md`, a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. The end user can't change the schedule from chat, but the installer can override the cron times via `--heartbeat-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `HEARTBEAT_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the Index cron times" above.
 8. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent setup gates with different triggers:
@@ -276,9 +278,9 @@ bun install/reset.ts --wipe-user
 
 ## How it runs
 
-Time-sensitive prompts (the morning digest's prepare pass at 02:00 and send pass at 08:00 — host-local) run as **OpenClaw cron jobs**, not heartbeat tasks. Cron has its own scheduler and runs in isolated sessions with `--light-context` so each tick is cheap. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
+Time-sensitive and background prompts run as **Hermes/OpenClaw cron jobs**. There is no separate heartbeat primitive in this repo: `Edge — heartbeat` is a scheduled cron prompt that runs `skills/index-network/heartbeat.md` roughly every 30 minutes, while the morning digest prepare/send prompts run at their own daily cron times. Cron has its own scheduler and runs isolated sessions, so each tick starts fresh from the workspace files. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
 
-Accepted-opportunity notifications, freshness audits, memory curation, and any other latency-tolerant background work stay on the heartbeat tick because 30-minute latency is acceptable for those flows.
+Accepted-opportunity notifications, freshness audits, memory curation, Telegram-handle reconciliation, and other latency-tolerant background work belong in the heartbeat prompt because 30-minute latency is acceptable for those flows.
 
 ## Workspace layout
 
@@ -329,18 +331,18 @@ AgentVillage's behaviour is markdown-driven. Almost everything you'd want to cha
 | Add, remove, or reorder operating rules (memory contract, opportunity quality bar, red lines, group-chat rules) | `workspace/AGENTS.md` | This file is always injected by OpenClaw on every session — durable, unlike `BOOTSTRAP.md`. |
 | Add a new first-message gate (e.g. another skill needs onboarding) | `workspace/AGENTS.md` "Active skills" section + the new `skills/<name>/bootstrap.md` | Gates loop over the active-skills registry. Add the skill row first, then point its bootstrap at the trigger condition (server flag, local marker, …). |
 | Change the returning-user first-message framing | `workspace/AGENTS.md` "First-message gates" | The digest schedule is fixed (set in `install/install_index.ts`) and not adjustable from chat. |
-| Change heartbeat tick behaviour (what tasks fire, dedup rules) | `workspace/HEARTBEAT.md` for cross-backend rules; `skills/<backend>/heartbeat.md` for backend-specific tasks | The tick cadence itself (default ~30 min) is an OpenClaw-side setting, configured through `openclaw config` — not a file in this repo. |
+| Change heartbeat tick behaviour (what tasks fire, dedup rules) | `workspace/HEARTBEAT.md` for cross-backend rules; `skills/<backend>/heartbeat.md` for backend-specific tasks | The tick cadence is the `Edge — heartbeat` cron in `install/install_index.ts`; override one install with `--heartbeat-cron` / `HEARTBEAT_CRON`. |
 | Change how URLs / formatting render per channel (Telegram, WhatsApp, Discord) | `workspace/TOOLS.md` | Cross-backend rule: Telegram is Markdown, not HTML — raw `<…>` tags get escaped. |
 
 ### Schedule & cron
 
-The digest runs as a fixed prepare/send pair — **prepare `0 2 * * *`, send `0 8 * * *`** (host-local) — and the end user can't change it from chat. The installer can override either time (see "Overriding the digest cron times" under **Install**).
+Index background work runs as fixed cron prompts — **heartbeat `*/30 * * * *`, prepare `0 2 * * *`, send `0 8 * * *`** (host-local) — and the end user can't change those schedules from chat. The installer can override any time (see "Overriding the Index cron times" under **Install**).
 
 | You want to… | Edit | Notes |
 |---|---|---|
-| Override the digest times for one install | `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the default. |
-| Change the default digest schedule for everyone | `install/install_index.ts` (`DIGEST_CRON_SPECS`) | The installer writes the cron entries from this table. Existing installs pick up changes on the next `install.ts` run. |
-| Change a cron prompt without changing the schedule | the matching `skills/edge-esmeralda/prompts/<name>.md` | Hermes stores prompt copies in cron jobs. Hosted residents are refreshed by the control-plane post-merge sync, which calls each sidecar's `/update` endpoint and reruns the installer. For non-control-plane installs or recovery, run `HERMES_HOME=<resident-home> bun install/reconcile_digest_crons.ts` after updated skill files are copied. |
+| Override the Index cron times for one install | `--heartbeat-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `HEARTBEAT_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the default. |
+| Change the default Index cron schedule for everyone | `install/install_index.ts` (`DIGEST_CRON_SPECS`) | The installer writes the cron entries from this table. Existing installs pick up changes on the next `install.ts` run. |
+| Change a cron prompt without changing the schedule | the matching prompt file (`skills/index-network/heartbeat.md` or `skills/edge-esmeralda/prompts/<name>.md`) | Hermes stores prompt copies in cron jobs. Hosted residents are refreshed by the control-plane post-merge sync, which calls each sidecar's `/update` endpoint and reruns the installer. For non-control-plane installs or recovery, run `HERMES_HOME=<resident-home> bun install/reconcile_digest_crons.ts` after updated skill files are copied. |
 
 ### Backends & skills
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Every call with the same email returns the same user but a **fresh API key** —
 
 ### What Portal does after signup
 
-1. Runs the AgentVillage installer with the returned `apiKey`: `bun install/install.ts --index-api-key <apiKey>` (or equivalent in the hosted runtime). If Portal knows the attendee's Telegram handle, it passes it as `--telegram-handle @handle` so every Telegram-surface Index MCP request carries `x-index-telegram-username` and self-heals the user's public Telegram social. If Portal has also fetched an EdgeOS personal access token for the attendee, it passes that on the same line: `bun install/install.ts --index-api-key <apiKey> --telegram-handle @handle --edgeos-api-key <eos_live_…> --edgeos-bearer-token <jwt>`.
+1. Runs the AgentVillage installer with the returned `apiKey`: `bun install/install.ts --index-api-key <apiKey>` (or equivalent in the hosted runtime). If Portal has a resident-confirmed Telegram handle, it passes it as a bare handle (`--telegram-handle handle`) so every Telegram-surface Index MCP request carries `x-index-telegram-username`. If Portal has also fetched an EdgeOS personal access token for the attendee, it passes that on the same line: `bun install/install.ts --index-api-key <apiKey> --telegram-handle handle --edgeos-api-key <eos_live_…> --edgeos-bearer-token <jwt>`.
 2. If Portal learns or changes the attendee's Telegram handle later, it should rerun the installer or update `mcp_servers.index.headers.x-index-telegram-username` in the host config.
 
 ### What EdgeOS does after signup (BYOA flow)
@@ -148,7 +148,7 @@ claude plugin install agentvillage@agentvillage-skills
 **OpenClaw:**
 ```bash
 openclaw plugins install agentvillage --marketplace Edge-City/agentvillage-skills
-openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<apiKey>","x-index-surface":"telegram","x-index-telegram-username":"@handle"}}'
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<apiKey>","x-index-surface":"telegram","x-index-telegram-username":"handle"}}'
 openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<jwt>'
 openclaw config set env.vars.EDGEOS_API_KEY '<eos_live_…>'
 openclaw gateway restart
@@ -162,7 +162,7 @@ hermes skills install Edge-City/agentvillage/skills/index-network --force
 hermes config set mcp_servers.index.url 'https://protocol.index.network/mcp'
 hermes config set mcp_servers.index.headers.x-api-key '<apiKey>'
 hermes config set mcp_servers.index.headers.x-index-surface 'telegram'
-hermes config set mcp_servers.index.headers.x-index-telegram-username '@handle'
+hermes config set mcp_servers.index.headers.x-index-telegram-username 'handle'
 hermes config set EDGEOS_BEARER_TOKEN '<jwt>'
 hermes config set EDGEOS_API_KEY '<eos_live_…>'
 ```
@@ -194,7 +194,7 @@ bun install/install.ts --index-api-key <YOUR_API_KEY>
 If this AgentVillage runtime is serving the user through Telegram, include their public Telegram handle. The installer stores it in the Index MCP headers so any Telegram-surface interaction can upsert the user's reachable Telegram social without waiting for onboarding:
 
 ```bash
-bun install/install.ts --index-api-key <YOUR_API_KEY> --telegram-handle @handle
+bun install/install.ts --index-api-key <YOUR_API_KEY> --telegram-handle handle
 ```
 
 To target the dev environment (keys generated on `dev.index.network`), pass `--dev`:

--- a/install/config.ts
+++ b/install/config.ts
@@ -4,20 +4,58 @@ import YAML from "yaml";
 
 import { hermesHome } from "./paths";
 
+const DEFAULT_MODEL_MAX_TOKENS = 4096;
+
+function readConfig(): Record<string, unknown> {
+  const configPath = join(hermesHome(), "config.yaml");
+  if (!existsSync(configPath)) return {};
+  return YAML.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+}
+
+function writeConfig(doc: Record<string, unknown>): void {
+  writeFileSync(join(hermesHome(), "config.yaml"), YAML.stringify(doc));
+}
+
+function configuredMaxTokens(): number {
+  const parsed = Number.parseInt(process.env.HERMES_MAX_TOKENS ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MODEL_MAX_TOKENS;
+}
+
 /** Point gateway / messaging CWD at `$HERMES_HOME` so `AGENTS.md` loads. */
 export function setTerminalCwd(): void {
-  const configPath = join(hermesHome(), "config.yaml");
   const home = hermesHome();
 
-  let doc: Record<string, unknown> = {};
-  if (existsSync(configPath)) {
-    doc = YAML.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
-  }
+  const doc = readConfig();
 
   const terminal = { ...((doc.terminal as Record<string, unknown>) ?? {}) };
   terminal.cwd = home;
   doc.terminal = terminal;
 
-  writeFileSync(configPath, YAML.stringify(doc));
+  writeConfig(doc);
   console.log(`→ set terminal.cwd to ${home}`);
+}
+
+/** Ensure hosted cron turns never inherit a provider's enormous output-token default. */
+export function capModelMaxTokens(): void {
+  const cap = configuredMaxTokens();
+  const doc = readConfig();
+  const rawModel = doc.model;
+  let model: Record<string, unknown>;
+
+  if (typeof rawModel === "string" && rawModel.trim()) {
+    model = { default: rawModel.trim(), model: rawModel.trim() };
+  } else if (rawModel && typeof rawModel === "object" && !Array.isArray(rawModel)) {
+    model = { ...(rawModel as Record<string, unknown>) };
+  } else {
+    model = {};
+  }
+
+  const existing = Number.parseInt(String(model.max_tokens ?? ""), 10);
+  if (!Number.isFinite(existing) || existing <= 0 || existing > cap) {
+    model.max_tokens = cap;
+  }
+
+  doc.model = model;
+  writeConfig(doc);
+  console.log(`→ capped model.max_tokens at ${model.max_tokens}`);
 }

--- a/install/install.ts
+++ b/install/install.ts
@@ -33,7 +33,7 @@ import { execSync } from "node:child_process";
 import { installIndex } from "./install_index";
 import { installEdgeos } from "./install_edgeos";
 import { installGeo } from "./install_geo";
-import { setTerminalCwd } from "./config";
+import { capModelMaxTokens, setTerminalCwd } from "./config";
 import { hermesBin, hermesExecEnv } from "./hermes_cli";
 import {
   EDGE_SKILL_NAMES,
@@ -197,6 +197,7 @@ function main(): void {
   copyWorkspaceFiles(wipeUser);
   copySkillFiles();
   setTerminalCwd();
+  capModelMaxTokens();
 
   installIndex();
   installEdgeos();

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -3,15 +3,17 @@
  *
  *   - Merges `mcp_servers.index` into `$HERMES_HOME/config.yaml`
  *   - Writes `INDEX_API_KEY` to `$HERMES_HOME/.env`
- *   - Installs the digest crons: memory signal sync (`Edge — memory signal
- *     sync`, ~01:00), prepare (`Edge — digest prepare`, ~02:00) and send
- *     (`Edge — daily digest`, ~08:00) — all host-local; times overridable via
+ *   - Installs the Index crons: heartbeat (`Edge — heartbeat`, every 30m),
+ *     memory signal sync (`Edge — memory signal sync`, ~01:00), prepare
+ *     (`Edge — digest prepare`, ~02:00), and send (`Edge — daily digest`,
+ *     ~08:00) — all host-local; times overridable via --heartbeat-cron /
  *     --digest-signals-cron / --digest-prepare-cron / --digest-send-cron (or
- *     DIGEST_SIGNALS_CRON / DIGEST_PREPARE_CRON / DIGEST_SEND_CRON). To avoid
- *     the whole fleet hitting the LLM provider in the same minute (OpenRouter
- *     caps gemini-flash at 300 req/min account-wide), each tenant gets a
- *     deterministic minute offset derived from its INDEX_API_KEY: signal sync
- *     spreads over 01:00–01:49, prepare over 02:00–02:49, send over
+ *     HEARTBEAT_CRON / DIGEST_SIGNALS_CRON / DIGEST_PREPARE_CRON /
+ *     DIGEST_SEND_CRON). To avoid the whole fleet hitting the LLM provider in
+ *     the same minute (OpenRouter caps gemini-flash at 300 req/min account-wide),
+ *     each tenant gets a deterministic minute offset derived from its
+ *     INDEX_API_KEY: heartbeat spreads across two runs per hour, signal sync
+ *     spreads over 01:00–01:49, prepare over 02:00–02:49, and send over
  *     08:00–08:24.
  *     New installs create enabled crons; reconcile updates prompt bodies,
  *     migrates jobs still on the old synchronized defaults (0 2 / 0 8) to their
@@ -56,13 +58,22 @@ function readTelegramHandle(): string {
     || "";
 }
 
+function normalizeTelegramHandle(raw: string): string {
+  const bare = raw
+    .trim()
+    .replace(/^(?:https?:\/\/)?(?:t\.me|telegram\.me)\//i, "")
+    .replace(/^@/, "")
+    .split(/[/?#]/)[0];
+  return /^[A-Za-z0-9_]{5,32}$/.test(bare) ? bare : "";
+}
+
 export function buildIndexMcpHeaders(apiKey: string, telegramHandle = ""): Record<string, string> {
   const headers: Record<string, string> = {
     "x-api-key": apiKey,
     "x-index-surface": "telegram",
   };
-  const trimmedHandle = telegramHandle.trim();
-  if (trimmedHandle) headers["x-index-telegram-username"] = trimmedHandle;
+  const normalizedHandle = normalizeTelegramHandle(telegramHandle);
+  if (normalizedHandle) headers["x-index-telegram-username"] = normalizedHandle;
   return headers;
 }
 
@@ -147,7 +158,7 @@ export interface DigestCronSpec {
   schedule: string;
   /** Width of the per-tenant stagger window, in minutes from the default hour. */
   staggerWindowMinutes: number;
-  /** Prompt file under skills/edge-esmeralda/prompts/. */
+  /** Prompt file under skills/. */
   promptFile: string;
   /** Full Hermes cron name (kept under the CRON_NAME_PREFIX). */
   name: string;
@@ -160,16 +171,25 @@ export interface DigestCronSpec {
 }
 
 /**
- * Memory signal sync (01:00, no deliver) then prepare (02:00, no deliver)
- * then send (08:00, deliver telegram). Signal sync runs an hour before
- * prepare so freshly-captured signals have time to produce opportunities
- * before the brief is composed.
+ * Heartbeat (every 30m, deliver telegram), memory signal sync (01:00, no
+ * deliver), prepare (02:00, no deliver), then send (08:00, deliver telegram).
+ * Signal sync runs an hour before prepare so freshly-captured signals have time
+ * to produce opportunities before the brief is composed.
  */
 export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
   {
+    schedule: "*/30 * * * *",
+    staggerWindowMinutes: 30,
+    promptFile: "index-network/heartbeat.md",
+    name: "Edge — heartbeat",
+    deliver: true,
+    overrideFlag: "--heartbeat-cron",
+    overrideEnv: "HEARTBEAT_CRON",
+  },
+  {
     schedule: "0 1 * * *",
     staggerWindowMinutes: 50,
-    promptFile: "memory-signals.md",
+    promptFile: "edge-esmeralda/prompts/memory-signals.md",
     name: "Edge — memory signal sync",
     deliver: false,
     overrideFlag: "--digest-signals-cron",
@@ -178,7 +198,7 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
   {
     schedule: "0 2 * * *",
     staggerWindowMinutes: 50,
-    promptFile: "prepare.md",
+    promptFile: "edge-esmeralda/prompts/prepare.md",
     name: "Edge — digest prepare",
     deliver: false,
     overrideFlag: "--digest-prepare-cron",
@@ -187,7 +207,7 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
   {
     schedule: "0 8 * * *",
     staggerWindowMinutes: 25,
-    promptFile: "send.md",
+    promptFile: "edge-esmeralda/prompts/send.md",
     name: "Edge — daily digest",
     deliver: true,
     overrideFlag: "--digest-send-cron",
@@ -214,7 +234,10 @@ export function fnv1a(input: string): number {
 export function staggeredSchedule(spec: DigestCronSpec, seed: string): string {
   const fields = spec.schedule.trim().split(/\s+/);
   const minute = fnv1a(`${seed}:${spec.name}`) % Math.max(1, spec.staggerWindowMinutes);
-  return [String(minute), ...fields.slice(1)].join(" ");
+  const minuteField = fields[0] === "*/30" && spec.staggerWindowMinutes <= 30
+    ? `${minute},${minute + 30}`
+    : String(minute);
+  return [minuteField, ...fields.slice(1)].join(" ");
 }
 
 /** Build the argv for `hermes cron create` from a spec + resolved prompt body. */
@@ -286,11 +309,11 @@ function hermesAvailable(bin: string): boolean {
 
 export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()): void {
   const home = hermesHome();
-  const promptsDir = join(home, "skills/edge-esmeralda/prompts");
+  const promptsDir = join(home, "skills");
 
   const bin = hermesBin();
   if (!hermesAvailable(bin)) {
-    console.warn("  warning: hermes CLI not found — skipping digest crons");
+    console.warn("  warning: hermes CLI not found — skipping Index crons");
     return;
   }
 

--- a/install/reconcile_digest_crons.ts
+++ b/install/reconcile_digest_crons.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 /**
- * Reconcile AgentVillage's stored Hermes digest cron jobs with the currently
- * installed prompt files under `$HERMES_HOME/skills/edge-esmeralda/prompts`.
+ * Reconcile AgentVillage's stored Hermes Index cron jobs with the currently
+ * installed prompt files under `$HERMES_HOME/skills`.
  *
  * Hermes stores a copy of each cron prompt at creation time, so updating the
  * workspace files alone does not update existing residents' scheduled jobs.
  * Run this after copying new skill files into a resident workspace, or as a
- * fleet repair command, to remove stale Edge digest jobs and recreate them with
+ * fleet repair command, to remove stale Edge cron jobs and recreate them with
  * current prompt bodies while preserving all user memory and Kanban data.
  *
  * Usage:
@@ -16,7 +16,7 @@
 import { hermesExecEnv } from "./hermes_cli";
 import { reconcileDigestCronJobs } from "./install_index";
 
-console.log("AgentVillage digest cron reconciler");
-console.log("====================================");
+console.log("AgentVillage Index cron reconciler");
+console.log("===================================");
 reconcileDigestCronJobs(hermesExecEnv());
-console.log("✓ digest crons reconciled");
+console.log("✓ Index crons reconciled");

--- a/install/tests/config.test.ts
+++ b/install/tests/config.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, expect, test } from "bun:test";
+import YAML from "yaml";
+
+import { capModelMaxTokens } from "../config";
+
+const ORIGINAL_ENV = {
+  HERMES_HOME: process.env.HERMES_HOME,
+  HERMES_MAX_TOKENS: process.env.HERMES_MAX_TOKENS,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function withConfig(doc: Record<string, unknown>): string {
+  const home = mkdtempSync(join(tmpdir(), "agentvillage-config-"));
+  process.env.HERMES_HOME = home;
+  writeFileSync(join(home, "config.yaml"), YAML.stringify(doc));
+  return join(home, "config.yaml");
+}
+
+function readConfig(path: string): Record<string, unknown> {
+  return YAML.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+test("capModelMaxTokens adds a safe default cap when missing", () => {
+  const configPath = withConfig({
+    model: { provider: "openrouter", default: "qwen/qwen3-coder", model: "qwen/qwen3-coder" },
+  });
+
+  capModelMaxTokens();
+
+  expect(readConfig(configPath).model).toEqual({
+    provider: "openrouter",
+    default: "qwen/qwen3-coder",
+    model: "qwen/qwen3-coder",
+    max_tokens: 4096,
+  });
+});
+
+test("capModelMaxTokens lowers oversized provider defaults", () => {
+  const configPath = withConfig({ model: { default: "qwen/qwen3-coder", max_tokens: 65536 } });
+
+  capModelMaxTokens();
+
+  expect((readConfig(configPath).model as Record<string, unknown>).max_tokens).toBe(4096);
+});
+
+test("capModelMaxTokens preserves an explicit lower cap", () => {
+  const configPath = withConfig({ model: { default: "google/gemini-3.5-flash", max_tokens: 2048 } });
+
+  capModelMaxTokens();
+
+  expect((readConfig(configPath).model as Record<string, unknown>).max_tokens).toBe(2048);
+});
+
+test("capModelMaxTokens honors the operator cap override", () => {
+  process.env.HERMES_MAX_TOKENS = "8192";
+  const configPath = withConfig({ model: { default: "qwen/qwen3-coder", max_tokens: 65536 } });
+
+  capModelMaxTokens();
+
+  expect((readConfig(configPath).model as Record<string, unknown>).max_tokens).toBe(8192);
+});

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -12,26 +12,35 @@ import {
   storedSchedule,
 } from "../install_index";
 
-test("three digest cron specs: signals (01:00), prepare (02:00, no deliver), send (08:00, deliver telegram)", () => {
-  expect(DIGEST_CRON_SPECS).toHaveLength(3);
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+test("four Index cron specs: heartbeat, signals, prepare, then send", () => {
+  expect(DIGEST_CRON_SPECS).toHaveLength(4);
+  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
+  expect(heartbeat.schedule).toBe("*/30 * * * *");
+  expect(heartbeat.name).toBe("Edge — heartbeat");
+  expect(heartbeat.promptFile).toBe("index-network/heartbeat.md");
+  expect(heartbeat.deliver).toBe(true);
   expect(signals.schedule).toBe("0 1 * * *");
   expect(signals.name).toBe("Edge — memory signal sync");
-  expect(signals.promptFile).toBe("memory-signals.md");
+  expect(signals.promptFile).toBe("edge-esmeralda/prompts/memory-signals.md");
   expect(signals.deliver).toBe(false);
   expect(prepare.schedule).toBe("0 2 * * *");
   expect(prepare.name).toBe("Edge — digest prepare");
-  expect(prepare.promptFile).toBe("prepare.md");
+  expect(prepare.promptFile).toBe("edge-esmeralda/prompts/prepare.md");
   expect(prepare.deliver).toBe(false);
   expect(send.schedule).toBe("0 8 * * *");
   expect(send.name).toBe("Edge — daily digest");
-  expect(send.promptFile).toBe("send.md");
+  expect(send.promptFile).toBe("edge-esmeralda/prompts/send.md");
   expect(send.deliver).toBe(true);
 });
 
-test("signals/prepare cron args omit --deliver; send cron args include --deliver telegram", () => {
+test("heartbeat and send cron args include --deliver telegram; signals/prepare omit it", () => {
   const home = "/home/x/.hermes";
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
+
+  expect(cronCreateArgs(heartbeat, "HEART_BODY", home)).toEqual([
+    "cron", "create", "*/30 * * * *", "HEART_BODY",
+    "--name", "Edge — heartbeat", "--deliver", "telegram", "--workdir", home,
+  ]);
 
   expect(cronCreateArgs(signals, "SIGNALS_BODY", home)).toEqual([
     "cron", "create", "0 1 * * *", "SIGNALS_BODY",
@@ -62,25 +71,30 @@ test("cronEditArgs includes only the provided fields", () => {
 });
 
 test("staggeredSchedule derives a deterministic minute inside the spec's window", () => {
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
 
-  for (const spec of [signals, prepare, send]) {
+  for (const spec of [heartbeat, signals, prepare, send]) {
     const schedule = staggeredSchedule(spec, "ix_tenant_key");
     expect(staggeredSchedule(spec, "ix_tenant_key")).toBe(schedule); // deterministic
     const [minute, ...rest] = schedule.split(" ");
-    expect(Number(minute)).toBeGreaterThanOrEqual(0);
-    expect(Number(minute)).toBeLessThan(spec.staggerWindowMinutes);
+    const firstMinute = Number(minute.split(",")[0]);
+    expect(firstMinute).toBeGreaterThanOrEqual(0);
+    expect(firstMinute).toBeLessThan(spec.staggerWindowMinutes);
+    if (spec.schedule.startsWith("*/30 ")) {
+      expect(minute).toBe(`${firstMinute},${firstMinute + 30}`);
+    }
     expect(rest.join(" ")).toBe(spec.schedule.split(" ").slice(1).join(" "));
     expect(isValidCron(schedule)).toBe(true);
   }
 
   // Different specs hash independently for the same tenant seed.
-  expect(fnv1a(`seed:${prepare.name}`)).not.toBe(fnv1a(`seed:${send.name}`));
   expect(fnv1a(`seed:${signals.name}`)).not.toBe(fnv1a(`seed:${prepare.name}`));
+  expect(fnv1a(`seed:${prepare.name}`)).not.toBe(fnv1a(`seed:${send.name}`));
 });
 
-test("staggered windows keep signals within 01:00–01:49, prepare within 02:00–02:49, send within 08:00–08:24", () => {
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+test("staggered windows keep heartbeat, signals, prepare, and send in bounded windows", () => {
+  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
+  expect(heartbeat.staggerWindowMinutes).toBe(30);
   expect(signals.staggerWindowMinutes).toBe(50);
   expect(prepare.staggerWindowMinutes).toBe(50);
   expect(send.staggerWindowMinutes).toBe(25);
@@ -93,7 +107,7 @@ test("storedSchedule reads hermes jobs.json shapes", () => {
   expect(storedSchedule({ id: "a", name: "x" })).toBe("");
 });
 
-test("index MCP headers include telegram surface and optional handle", () => {
+test("index MCP headers include telegram surface and optional bare handle", () => {
   expect(buildIndexMcpHeaders("ix_test")).toEqual({
     "x-api-key": "ix_test",
     "x-index-surface": "telegram",
@@ -102,12 +116,21 @@ test("index MCP headers include telegram surface and optional handle", () => {
   expect(buildIndexMcpHeaders("ix_test", " @alice ")).toEqual({
     "x-api-key": "ix_test",
     "x-index-surface": "telegram",
-    "x-index-telegram-username": "@alice",
+    "x-index-telegram-username": "alice",
+  });
+});
+
+test("invalid telegram MCP handle is omitted", () => {
+  expect(buildIndexMcpHeaders("ix_test", "Alice Example")).toEqual({
+    "x-api-key": "ix_test",
+    "x-index-surface": "telegram",
   });
 });
 
 test("each spec declares its install-time override flag + env var", () => {
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
+  expect(heartbeat.overrideFlag).toBe("--heartbeat-cron");
+  expect(heartbeat.overrideEnv).toBe("HEARTBEAT_CRON");
   expect(signals.overrideFlag).toBe("--digest-signals-cron");
   expect(signals.overrideEnv).toBe("DIGEST_SIGNALS_CRON");
   expect(prepare.overrideFlag).toBe("--digest-prepare-cron");
@@ -127,15 +150,16 @@ test("isValidCron accepts 5-field expressions and rejects malformed ones", () =>
 });
 
 test("resolveCronSchedule returns the default when no override is set", () => {
-  const [signals, prepare] = DIGEST_CRON_SPECS;
+  const [, signals, prepare] = DIGEST_CRON_SPECS;
   expect(resolveCronSchedule(signals, [], {})).toBe("0 1 * * *");
   expect(resolveCronSchedule(prepare, [], {})).toBe("0 2 * * *");
 });
 
 test("resolveCronSchedule staggers from the seed when no override is set, but override wins", () => {
-  const [, prepare, send] = DIGEST_CRON_SPECS;
+  const [, signals, prepare, send] = DIGEST_CRON_SPECS;
   const seed = "ix_tenant_key";
 
+  expect(resolveCronSchedule(signals, [], {}, seed)).toBe(staggeredSchedule(signals, seed));
   expect(resolveCronSchedule(prepare, [], {}, seed)).toBe(staggeredSchedule(prepare, seed));
   expect(resolveCronSchedule(send, [], {}, seed)).toBe(staggeredSchedule(send, seed));
 
@@ -147,7 +171,7 @@ test("resolveCronSchedule staggers from the seed when no override is set, but ov
 });
 
 test("resolveCronSchedule honors flag, then env, with flag winning over env", () => {
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [, signals, prepare, send] = DIGEST_CRON_SPECS;
 
   expect(
     resolveCronSchedule(signals, ["bun", "install", "--digest-signals-cron", "30 0 * * *"], {}),
@@ -171,7 +195,7 @@ test("resolveCronSchedule honors flag, then env, with flag winning over env", ()
 });
 
 test("resolveCronSchedule ignores an invalid override and uses the default", () => {
-  const [, prepare] = DIGEST_CRON_SPECS;
+  const [, , prepare] = DIGEST_CRON_SPECS;
   expect(resolveCronSchedule(prepare, ["bun", "--digest-prepare-cron", "garbage"], {})).toBe("0 2 * * *");
   expect(resolveCronSchedule(prepare, [], { DIGEST_PREPARE_CRON: "0 2 * *" })).toBe("0 2 * * *");
 });

--- a/install/tests/reconcile_digest_crons.test.ts
+++ b/install/tests/reconcile_digest_crons.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import {
   DIGEST_CRON_SPECS,
@@ -16,7 +16,13 @@ import {
 } from "../install_index";
 
 const SEED = "ix_integration_seed";
-const [SIGNALS, PREPARE, SEND] = DIGEST_CRON_SPECS;
+const [HEARTBEAT, SIGNALS, PREPARE, SEND] = DIGEST_CRON_SPECS;
+const PROMPT_BODIES = new Map([
+  [HEARTBEAT.promptFile, "HEARTBEAT_BODY"],
+  [SIGNALS.promptFile, "SIGNALS_BODY"],
+  [PREPARE.promptFile, "PREPARE_BODY"],
+  [SEND.promptFile, "SEND_BODY"],
+]);
 
 let home: string;
 let stubLog: string;
@@ -31,7 +37,7 @@ function writeStubHermes(dir: string, { rejectScheduleFlag = false } = {}): stri
     bin,
     `#!/usr/bin/env bash
 if [ "$1" = "--version" ]; then echo "stub 0.0.0"; exit 0; fi
-${rejectBlock}printf '%s\\n' "$(printf '%s\\x1f' "$@")" >> "${join(dir, "calls.log")}"
+${rejectBlock}printf '%s\n' "$(printf '%s\x1f' "$@")" >> "${join(dir, "calls.log")}"
 exit 0
 `,
   );
@@ -58,11 +64,12 @@ function cronCalls(): string[][] {
 }
 
 function writePrompts(): void {
-  const prompts = join(home, "skills/edge-esmeralda/prompts");
-  mkdirSync(prompts, { recursive: true });
-  writeFileSync(join(prompts, SIGNALS.promptFile), "SIGNALS_BODY");
-  writeFileSync(join(prompts, PREPARE.promptFile), "PREPARE_BODY");
-  writeFileSync(join(prompts, SEND.promptFile), "SEND_BODY");
+  const skills = join(home, "skills");
+  for (const [promptFile, body] of PROMPT_BODIES) {
+    const promptPath = join(skills, promptFile);
+    mkdirSync(dirname(promptPath), { recursive: true });
+    writeFileSync(promptPath, body);
+  }
 }
 
 function writeJobs(jobs: unknown[]): void {
@@ -70,13 +77,12 @@ function writeJobs(jobs: unknown[]): void {
   writeFileSync(join(home, "cron", "jobs.json"), JSON.stringify({ jobs }));
 }
 
-/** An up-to-date signals job, for tests that only exercise prepare/send paths. */
-function currentSignalsJob() {
+function currentJob(spec: typeof DIGEST_CRON_SPECS[number], id: string): Record<string, unknown> {
   return {
-    id: "g1",
-    name: SIGNALS.name,
-    prompt: "SIGNALS_BODY",
-    schedule: { expr: staggeredSchedule(SIGNALS, SEED) },
+    id,
+    name: spec.name,
+    prompt: PROMPT_BODIES.get(spec.promptFile),
+    schedule: { expr: staggeredSchedule(spec, SEED) },
   };
 }
 
@@ -87,6 +93,7 @@ beforeEach(() => {
     HERMES_HOME: process.env.HERMES_HOME,
     HERMES_BIN: process.env.HERMES_BIN,
     INDEX_API_KEY: process.env.INDEX_API_KEY,
+    HEARTBEAT_CRON: process.env.HEARTBEAT_CRON,
     DIGEST_SIGNALS_CRON: process.env.DIGEST_SIGNALS_CRON,
     DIGEST_PREPARE_CRON: process.env.DIGEST_PREPARE_CRON,
     DIGEST_SEND_CRON: process.env.DIGEST_SEND_CRON,
@@ -94,6 +101,7 @@ beforeEach(() => {
   process.env.HERMES_HOME = home;
   process.env.HERMES_BIN = writeStubHermes(home);
   process.env.INDEX_API_KEY = SEED;
+  delete process.env.HEARTBEAT_CRON;
   delete process.env.DIGEST_SIGNALS_CRON;
   delete process.env.DIGEST_PREPARE_CRON;
   delete process.env.DIGEST_SEND_CRON;
@@ -108,29 +116,34 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
-test("fresh install creates all three crons on their staggered schedules", () => {
+test("fresh install creates heartbeat and digest crons on their staggered schedules", () => {
   reconcileDigestCronJobs({ ...process.env });
 
   const creates = cronCalls().filter((argv) => argv[1] === "create");
-  expect(creates).toHaveLength(3);
+  expect(creates).toHaveLength(4);
 
+  const heartbeat = creates.find((argv) => argv.includes(HEARTBEAT.name))!;
   const signals = creates.find((argv) => argv.includes(SIGNALS.name))!;
   const prepare = creates.find((argv) => argv.includes(PREPARE.name))!;
   const send = creates.find((argv) => argv.includes(SEND.name))!;
+  expect(heartbeat[2]).toBe(staggeredSchedule(HEARTBEAT, SEED));
+  expect(heartbeat[3]).toBe("HEARTBEAT_BODY");
   expect(signals[2]).toBe(staggeredSchedule(SIGNALS, SEED));
   expect(signals[3]).toBe("SIGNALS_BODY");
-  expect(signals).not.toContain("--deliver");
   expect(prepare[2]).toBe(staggeredSchedule(PREPARE, SEED));
   expect(prepare[3]).toBe("PREPARE_BODY");
   expect(send[2]).toBe(staggeredSchedule(SEND, SEED));
   expect(send[3]).toBe("SEND_BODY");
+  expect(heartbeat).toContain("--deliver");
   expect(send).toContain("--deliver");
+  expect(signals).not.toContain("--deliver");
   expect(prepare).not.toContain("--deliver");
 });
 
-test("job still on the old synchronized default gets a schedule-only migration", () => {
+test("jobs still on old synchronized defaults get schedule-only migrations", () => {
   writeJobs([
-    currentSignalsJob(),
+    { id: "h1", name: HEARTBEAT.name, prompt: "HEARTBEAT_BODY", schedule: { expr: HEARTBEAT.schedule } },
+    { id: "g1", name: SIGNALS.name, prompt: "SIGNALS_BODY", schedule: { expr: SIGNALS.schedule } },
     { id: "p1", name: PREPARE.name, prompt: "PREPARE_BODY", schedule: { expr: PREPARE.schedule } },
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: SEND.schedule } },
   ]);
@@ -139,6 +152,8 @@ test("job still on the old synchronized default gets a schedule-only migration",
 
   const calls = cronCalls();
   expect(calls).toEqual([
+    ["cron", "edit", "h1", "--schedule", staggeredSchedule(HEARTBEAT, SEED)],
+    ["cron", "edit", "g1", "--schedule", staggeredSchedule(SIGNALS, SEED)],
     ["cron", "edit", "p1", "--schedule", staggeredSchedule(PREPARE, SEED)],
     ["cron", "edit", "s1", "--schedule", staggeredSchedule(SEND, SEED)],
   ]);
@@ -146,7 +161,8 @@ test("job still on the old synchronized default gets a schedule-only migration",
 
 test("custom schedule is preserved; stale prompt gets a prompt-only edit", () => {
   writeJobs([
-    currentSignalsJob(),
+    currentJob(HEARTBEAT, "h1"),
+    currentJob(SIGNALS, "g1"),
     { id: "p1", name: PREPARE.name, prompt: "OLD_BODY", schedule: { expr: "30 4 * * *" } },
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: "15 9 * * *" } },
   ]);
@@ -160,6 +176,9 @@ test("custom schedule is preserved; stale prompt gets a prompt-only edit", () =>
 
 test("stale prompt + old default schedule produce two independent edit calls", () => {
   writeJobs([
+    currentJob(HEARTBEAT, "h1"),
+    currentJob(SIGNALS, "g1"),
+    currentJob(PREPARE, "p1"),
     { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },
   ]);
 
@@ -174,19 +193,10 @@ test("stale prompt + old default schedule produce two independent edit calls", (
 
 test("up-to-date jobs (staggered schedule + current prompt) trigger no cron calls", () => {
   writeJobs([
-    currentSignalsJob(),
-    {
-      id: "p1",
-      name: PREPARE.name,
-      prompt: "PREPARE_BODY",
-      schedule: { expr: staggeredSchedule(PREPARE, SEED) },
-    },
-    {
-      id: "s1",
-      name: SEND.name,
-      prompt: "SEND_BODY",
-      schedule: { expr: staggeredSchedule(SEND, SEED) },
-    },
+    currentJob(HEARTBEAT, "h1"),
+    currentJob(SIGNALS, "g1"),
+    currentJob(PREPARE, "p1"),
+    currentJob(SEND, "s1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });
@@ -196,7 +206,7 @@ test("up-to-date jobs (staggered schedule + current prompt) trigger no cron call
 
 test("retired Edge-prefixed crons are removed; foreign crons are untouched", () => {
   writeJobs([
-    { id: "old1", name: "Edge — heartbeat", prompt: "X", schedule: { expr: "0 6 * * *" } },
+    { id: "old1", name: "Edge — old heartbeat", prompt: "X", schedule: { expr: "0 6 * * *" } },
     { id: "user1", name: "my own job", prompt: "Y", schedule: { expr: "0 7 * * *" } },
   ]);
 
@@ -209,13 +219,9 @@ test("retired Edge-prefixed crons are removed; foreign crons are untouched", () 
 test("a Hermes that rejects --schedule still gets the prompt update (degraded migration)", () => {
   process.env.HERMES_BIN = writeStubHermes(home, { rejectScheduleFlag: true });
   writeJobs([
-    currentSignalsJob(),
-    {
-      id: "p1",
-      name: PREPARE.name,
-      prompt: "PREPARE_BODY",
-      schedule: { expr: staggeredSchedule(PREPARE, SEED) },
-    },
+    currentJob(HEARTBEAT, "h1"),
+    currentJob(SIGNALS, "g1"),
+    currentJob(PREPARE, "p1"),
     { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },
   ]);
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -93,14 +93,14 @@ mcp_servers:
     headers:
       x-api-key: <YOUR_API_KEY>
       x-index-surface: telegram
-      x-index-telegram-username: @handle  # optional; lets any Telegram-surface MCP call self-heal the public Telegram social
+      x-index-telegram-username: handle  # optional; resident-confirmed bare Telegram handle forwarded on Telegram-surface MCP calls
 ```
 
 For workspace, installer, and cron jobs:
 
 ```bash
 bun install/install.ts --index-api-key <KEY>
-# add --telegram-handle @handle when this runtime serves the user over Telegram
+# add --telegram-handle handle when this runtime serves the user over Telegram and the resident confirmed that handle
 # add --edgeos-bearer-token for Geo knowledge graph access/content writes
 # add --edgeos-api-key for EdgeOS event, RSVP, and venue recipes
 # re-onboard: add --wipe-user

--- a/skills/edgeos/SKILL.md
+++ b/skills/edgeos/SKILL.md
@@ -229,10 +229,10 @@ Returns the human record for the bearer's owner — your own application content
 curl -s -X PATCH -H "Authorization: Bearer <EDGEOS_BEARER_TOKEN>" \
   -H "Content-Type: application/json" \
   "https://api.edgeos.world/api/v1/humans/me" \
-  -d '{"first_name":"...","last_name":"...","telegram":"@handle","residence":"...","picture_url":"https://..."}'
+  -d '{"first_name":"...","last_name":"...","telegram":"handle","residence":"...","picture_url":"https://..."}'
 ```
 
-Patchable fields: `first_name`, `last_name`, `telegram`, `gender`, `age`, `residence`, `picture_url`. All are optional — include only what you want to change. Application-specific fields (dietary preferences, "what I'm building", application answers) are **not** patchable through this endpoint — those live on the popup application form and must be edited in the EdgeOS portal UI.
+Patchable fields: `first_name`, `last_name`, `telegram`, `gender`, `age`, `residence`, `picture_url`. All are optional — include only what you want to change. Store Telegram usernames as bare handles (`handle`, not `@handle`) and only after the resident confirms the value when systems disagree. Application-specific fields (dietary preferences, "what I'm building", application answers) are **not** patchable through this endpoint — those live on the popup application form and must be edited in the EdgeOS portal UI.
 
 ## 9. Attendee directory (`portal:directory_read`)
 

--- a/skills/index-network/bootstrap.md
+++ b/skills/index-network/bootstrap.md
@@ -103,26 +103,22 @@ Once `create_intent` succeeds, briefly acknowledge:
 
 > "Got it — I'll keep an eye out for relevant people."
 
-## Step 4 — Capture chat-channel handle silently
+## Step 4 — Note chat channel and defer Telegram drift
 
-Before closing onboarding, recover the user's platform handle on whichever channel they connected through — but only from a **verifiable source**. A handle that routes an introduction to a stranger or a dead link is worse than no handle at all, so when in doubt, save nothing.
+Before closing onboarding, note which platform the user connected through, but do **not** silently choose between independent Telegram handle sources. AgentVillage spans EdgeOS, Index, the local Hermes runtime, and the control plane; none of those should overwrite another merely because it happened to be read last.
 
-This step is **silent** — produce no user-facing output, do not announce it, do not ask for confirmation. The user already authenticated via this channel; capturing the handle is an implementation detail of being reachable.
-
-**Never fabricate a handle.** Only ever write a handle that appears **verbatim** in a verifiable source. Do **not** derive, guess, or construct one from the user's name, display name, email, or chatId, and do not "tidy" a guess into something plausible. A Telegram username must match `[A-Za-z0-9_]{5,32}` exactly; if what you have doesn't match, it is not a real handle — skip it. When no verifiable handle exists, leave the social **blank** and move on; a later heartbeat tick can fill it.
+**Never fabricate a handle.** Do **not** derive, guess, or construct one from the user's name, display name, email, or chatId, and do not "tidy" a guess into something plausible. A Telegram username must match `[A-Za-z0-9_]{5,32}` exactly after stripping a leading `@`; if what you have doesn't match, it is not a real handle.
 
 Detection by session key:
 
-- `agent:main:telegram:direct:<chatId>` → Telegram. **Do not read or write the Telegram handle yourself.** When the user connected through Telegram, every Index MCP request already carries the verified `x-index-telegram-username` header (set by the host from the handle Portal captured), and the server self-heals the user's public Telegram social from it deterministically — no tool call from you. Do **not** pull `from.username` out of the inbound message and write it: that field is not reliably visible to you, and a guessed value routes introductions to the wrong person. You can't observe whether the host forwarded the header, so don't try to reason about it — instead, check the `read_user_profiles()` result: if the user **still has no Telegram social** by this step, none was captured (Portal had no handle to forward), so fall through to the EdgeOS fallback below.
+- `agent:main:telegram:direct:<chatId>` → Telegram. Note that the user is connected via Telegram. Do not pull `from.username` out of inbound messages and write it: that field is not reliably visible to you, and a guessed value routes introductions to the wrong person.
 - `agent:main:whatsapp:...` → WhatsApp. The phone number is the handle; call `update_user_profile(socials={ whatsapp: "+<E.164>" })` only if a real E.164 number is recoverable **verbatim** from session metadata. If not, skip — do not reconstruct one.
 - `agent:main:discord:...`, `agent:main:slack:...`, etc. → equivalent treatment only when the platform's primary handle is recoverable **verbatim** from session metadata. Otherwise skip.
 - `agent:main:webchat` or any other context where no platform handle exists → skip session-metadata capture.
 
-EdgeOS fallback for Telegram (the only Telegram handle you may write yourself): use it only when the user does **not** already have a Telegram social. Determine this from the `read_user_profiles()` result run in the Intent-trigger gate above (re-call it here if you no longer have that result) — if it already lists a Telegram social, the server captured it from the verified header and that value wins, so leave it untouched (overwriting with a different value would later fail server-side identity verification and break the user's own Telegram requests). Otherwise, if the user granted the Step 1 data-use consent and `EDGEOS_BEARER_TOKEN` is available, read the user's own EdgeOS profile via the `edgeos` skill's `GET /api/v1/humans/me` recipe. Take its `telegram` value only if it is non-empty, is not the hidden sentinel `"*"`, and matches `[A-Za-z0-9_]{5,32}` after stripping a leading `@`; then call `update_user_profile(socials={ telegram: "@<handle>" })` with that exact value. This fallback is still silent. If the bearer token is missing, the EdgeOS call fails, or the EdgeOS profile has no valid Telegram value, skip it without asking the user — never substitute a guess.
+For Telegram, do not run the old silent EdgeOS → Index fallback and do not treat any single system as authoritative when sources disagree. A later `telegram-handle-reconciliation` heartbeat compares EdgeOS, Index, and the local runtime header; if it finds drift or an invalid display-name value, it asks the resident which bare Telegram handle is correct and then updates the wrong systems from that explicit answer.
 
-Also note the platform in `USER.md` under **Notes**, and the handle alongside it only when you have one **verbatim**, so future heartbeat / digest runs have context without re-querying. One short line is enough — e.g. `Connected via Telegram (@yanekyuksel).` when you have the handle, or just `Connected via Telegram.` when you left it to server self-heal. Never write a handle into `USER.md` that you would not write into the profile.
-
-If `update_user_profile` or the EdgeOS fallback returns an error (rate limit, transient failure), log it to `memory/<today>.md` and continue — do not block onboarding on this. The next heartbeat tick can retry.
+Also note the platform in `USER.md` under **Notes** without inventing a handle. One short line is enough — e.g. `Connected via Telegram.` Never write a handle into `USER.md` that came from a display name, email, chatId, or an unresolved system conflict.
 
 ## Step 5 — Close out and populate USER.md
 
@@ -146,7 +142,7 @@ Cron-schedule preferences are not asked about — the morning digest runs at a f
 - Do not call `preview_user_profile` until the consent question has an explicit user answer and both consent calls have succeeded.
 - Do not call `discover_opportunities`, `list_opportunities`, or any other discovery tool during onboarding. Opportunities surface on the first scheduled cron tick after onboarding completes.
 - Do not mention Gmail or email import — they are not available in this flow.
-- Never write a guessed or derived contact handle (Telegram, WhatsApp, Discord, Slack). Persist a handle only when it appears verbatim in a verifiable source — the verified `x-index-telegram-username` header (handled server-side, not by you), real session metadata, or the user's own EdgeOS profile. If none is available, leave it blank; never construct one from the user's name, email, or chatId.
+- Never write a guessed or derived contact handle (Telegram, WhatsApp, Discord, Slack). During onboarding, do not silently reconcile Telegram across EdgeOS, Index, and runtime headers. If sources later disagree, the heartbeat reconciliation process asks the resident and writes only their explicit bare-handle answer.
 - Call `create_intent` at most once per user response.
 - If the user tries to do something else mid-onboarding, complete the current step and offer to pause: "Want to finish setup now, or pick it up later?" — do not block indefinitely. If they choose to defer, append `[gate] index-network: suppressed by user` to `memory/<today>.md` and answer their question. This suppression persists for the rest of the calendar day.
 - Keep your tone calm, direct, concise — no "Great question!", no "I'd be happy to help!", no filler.

--- a/skills/index-network/heartbeat.md
+++ b/skills/index-network/heartbeat.md
@@ -19,6 +19,32 @@ tasks:
     4. Frame the notification warmly — this is good news.
     5. For every opportunity you mention, call `confirm_opportunity_delivery(opportunityId, trigger="accepted")`.
 
+- name: telegram-handle-reconciliation
+  interval: 24h
+  prompt: |
+    Detect drift between the resident's independent Edge systems before Telegram handles route introductions to the wrong person. Do not choose a canonical source silently; when sources disagree, ask the resident which handle is correct and update only after they answer.
+
+    This runs in a fresh session with no memory of past runs — every decision below comes from files, environment, and tool/API reads. Resolve "today" as the calendar day in America/Los_Angeles for `memory/<today>.md`.
+
+    1. Gate on pending/asked state. Read `memory/heartbeat-state.json` and `memory/<today>.md`. Reply silently and stop if either is true:
+       - `telegramHandleReconciliation.pending` exists — the user has already been asked; wait for their answer in a normal conversation turn.
+       - `telegramHandleReconciliation.lastAskedDate` equals today — do not re-ask the same day.
+    2. Read candidate sources without mutating anything:
+       - Index: call `read_user_profiles()` and extract the user's `telegram` social if present.
+       - EdgeOS: if `EDGEOS_BEARER_TOKEN` is available, use the `edgeos` skill recipe `GET /api/v1/humans/me` and read its `telegram` field. If the value is the hidden sentinel `"*"`, treat it as unavailable, not a conflict.
+       - Runtime host: read `INDEX_TELEGRAM_HANDLE` from the environment if available; this is the Telegram handle currently forwarded in Index MCP headers.
+    3. Normalize every non-empty candidate for comparison: trim, strip a leading `@`, strip `https://t.me/` or `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`. Keep both the raw and normalized forms in notes. Values that fail validation (for example `Lauren Tannhauser`) are invalid candidates and should trigger reconciliation if any system stores them.
+    4. Decide:
+       - If there are zero valid candidates and no invalid candidates, reply silently.
+       - If there is exactly one valid normalized handle and no invalid candidates, reply silently. No system is drifting from another known system.
+       - If there are two or more distinct valid normalized handles, or any invalid candidate exists, ask exactly one concise question: "I found conflicting Telegram handles in your Edge setup: EdgeOS: `<x>`, Index: `<y>`, runtime: `<z>`. Which Telegram username should I use? Reply with the handle only, without @."
+         Omit unavailable sources from the sentence; label invalid values as "not a valid Telegram username".
+    5. Record and stop after asking. Update `memory/heartbeat-state.json` preserving all existing keys, under:
+       `telegramHandleReconciliation = { pending: true, lastAskedDate: "YYYY-MM-DD", sources: { edgeos, index, runtime }, askedQuestion: "..." }`.
+       Append `[gate] index-network: telegram-handle-reconciliation asked` to `memory/<today>.md`.
+
+    Do not call `update_user_profile`, patch EdgeOS, rerun the installer, or edit config in this heartbeat task. The user's answer arrives later in a normal conversation turn; handle it using `tools.md`.
+
 - name: signal-freshness
   interval: 7d
   prompt: |

--- a/skills/index-network/heartbeat.md
+++ b/skills/index-network/heartbeat.md
@@ -1,6 +1,14 @@
 # Index Network — Heartbeat Tasks
 
-Per-tick tasks for Index Network. Walked from the heartbeat tick described in `AGENTS.md` (Heartbeat section). Track last-run timestamps and dedup state in `memory/heartbeat-state.json`. If a task isn't due, skip it.
+Per-tick tasks for Index Network. Walked from the heartbeat tick described in `AGENTS.md` (Heartbeat section). This is background maintenance, not a chat check-in. **Silence is the default.** On Hermes, a silent tick ends with exactly `[SILENT]`.
+
+Hard gates for every tick:
+
+1. Read `memory/heartbeat-state.json` once at the start. Track task last-runs under `heartbeatTasks.<taskName>.lastRunAt` as ISO timestamps, plus each task's own dedup state. If the file is missing, treat state as `{}`.
+2. Run only tasks whose interval is due. If no task is due, end with `[SILENT]`.
+3. Run tasks in the order listed below. **At most one user-facing message per tick.** If any task sends or asks the user something, record its state, then stop immediately; do not continue into later tasks.
+4. Never message just to say you checked, synced, found nothing, updated memory, or had an internal problem. If a tool or file read fails and the task cannot safely continue, end with `[SILENT]`.
+5. For tasks that are due but produce no user-facing message, update `heartbeatTasks.<taskName>.lastRunAt` before moving on so the 30-minute heartbeat does not rerun daily/weekly work every tick.
 
 ---
 
@@ -12,12 +20,13 @@ tasks:
     Someone may have accepted a connection on the user's behalf — the user wants to know.
 
     1. Call `list_opportunities(status="accepted_unnotified")` (or the equivalent — read the tool description).
-    2. If empty, reply silently using this host's no-reply marker.
-    3. For each accepted opportunity:
+    2. Filter out any opportunity id already present in `acceptedOpportunities.notifiedIds` in `memory/heartbeat-state.json`; this local dedup prevents repeated Telegram pings if the ledger confirmation call fails.
+    3. If empty after filtering, update `heartbeatTasks.accepted-opportunities.lastRunAt`, write state, and end with `[SILENT]` unless a later due task should run.
+    4. For each accepted opportunity you will mention:
        - Embed `acceptUrl` on a verb phrase like "send {Name} a message". The URL is a short backend redirect — paste it verbatim, do not append query parameters, do not compose a `t.me` URL. The greeting and Telegram handle resolution happen server-side.
        - If `acceptUrl` is missing, embed `conversationUrl` on "continue the conversation".
-    4. Frame the notification warmly — this is good news.
-    5. For every opportunity you mention, call `confirm_opportunity_delivery(opportunityId, trigger="accepted")`.
+    5. Frame the notification warmly — this is good news. This is the only 30-minute task allowed to proactively message, and only for newly accepted, unnotified opportunities.
+    6. For every opportunity you mention, call `confirm_opportunity_delivery(opportunityId, trigger="accepted")` once. Regardless of confirmation success, append its id to `acceptedOpportunities.notifiedIds` (keep the last 100), update `heartbeatTasks.accepted-opportunities.lastRunAt`, write state, and stop.
 
 - name: telegram-handle-reconciliation
   interval: 24h
@@ -51,9 +60,10 @@ tasks:
     Once a week, prune.
 
     1. Call `read_intents()` for the user.
-    2. For each signal older than 60 days with no recent matches: ask the user (in their last-active channel) whether it's still active. If they say no, call `update_intent(id, status="archived")`. If they say yes, leave it. If they ignore, leave it — re-ask next cycle.
+    2. If any signal older than 60 days has no recent matches, ask about **one** stale signal only: whether it's still active. If they say no later, call `update_intent(id, status="archived")`. If they say yes, leave it. If they ignore, leave it — re-ask next cycle.
+    3. Record the asked signal id/date under `signalFreshness` and update `heartbeatTasks.signal-freshness.lastRunAt` before stopping.
 
-    Skip silently if nothing is stale. Do not invent things to ask about.
+    Skip silently if nothing is stale. Do not invent things to ask about. Never ask more than one freshness question in a tick.
 
 - name: signal-elicitation
   interval: 24h

--- a/skills/index-network/tools.md
+++ b/skills/index-network/tools.md
@@ -44,6 +44,21 @@ Onboarding captures one signal; after that, the graph only thickens if you captu
 
 Do not do this during onboarding — the bootstrap ritual owns signal capture there (`create_intent` at most once, under its own rules). This guidance is for users who have already completed onboarding.
 
+## Telegram handle reconciliation replies
+
+The `telegram-handle-reconciliation` heartbeat task may ask the resident which Telegram username is correct when EdgeOS, Index, and the local runtime disagree. If `memory/heartbeat-state.json` contains `telegramHandleReconciliation.pending=true`, handle the user's next handle-like answer before ordinary signal capture.
+
+1. Normalize the reply: trim, strip a leading `@`, strip `https://t.me/` / `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`. Store and write bare handles only — e.g. `alice_tg`, never `@alice_tg`.
+2. If the reply is not a valid Telegram username, ask one short follow-up: "What's your Telegram username? Send just the handle, without @." Do not write anything.
+3. If valid, update the independent systems that are available from this runtime:
+   - Index: call `update_user_profile(socials={ telegram: "<bare-handle>" })`.
+   - EdgeOS: if `EDGEOS_BEARER_TOKEN` is available, use the `edgeos` skill's `PATCH /api/v1/humans/me` recipe with `{ "telegram": "<bare-handle>" }`. Do not patch application-form fields; only the own-profile `telegram` field.
+   - Local runtime header: if `INDEX_API_KEY` and `edge-src/install/install.ts` are available in the Hermes home, run the installer in no-restart mode with `--telegram-handle <bare-handle>` so future Index MCP calls forward the same user-confirmed handle. If that script is unavailable, skip this and note it in memory; do not hand-edit secrets in chat.
+4. Update `memory/heartbeat-state.json`: remove `telegramHandleReconciliation.pending`, set `telegramHandleReconciliation.resolvedAt` to today's date/time, set `telegramHandleReconciliation.confirmedHandle` to the bare handle, and preserve the recorded source snapshot for audit.
+5. Reply briefly: "Got it — I'll use `<bare-handle>` for your Telegram handle." Do not mention internal system names unless the user asks.
+
+Do not infer the correct handle from display name, email, chat id, or a conflict between sources. The resident's explicit answer is the authority for this Edge Esmeralda reconciliation process.
+
 ## `scrape_url` — when to use it
 
 Call `scrape_url(url, objective)` whenever the user shares a URL and you need its content:


### PR DESCRIPTION
## Summary\n- cap Hermes model.max_tokens to 4096 during AgentVillage install/update (override with HERMES_MAX_TOKENS)\n- harden the Index heartbeat prompt so silence is the default, task intervals are recorded, at most one user-facing message can be sent per tick, and accepted-opportunity notifications are locally deduped\n- include the pending AgentVillage heartbeat/Telegram drift reconciliation changes from the current Index submodule pointer\n\n## Why\nOpenRouter can reject hosted tenant cron turns when Hermes inherits a large model output default (e.g. 65536). Heartbeat should be background maintenance, not a 30-minute check-in.\n\n## Tests\n- bun test install/tests