### PR TITLE
fix: retire heartbeat cron (drains OpenRouter budget)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,23 +216,24 @@ bun install/install.ts \
 
 ### Overriding the Index cron times
 
-Index background work is installed as three Hermes/OpenClaw cron jobs: **heartbeat at `*/30 * * * *`**, **digest prepare at `0 2 * * *`**, and **digest send at `0 8 * * *`** (host-local). To install them at different times (a different timezone, a test window, etc.), pass full 5-field cron expressions. A flag wins over the matching env var; an invalid expression is ignored with a warning and the default is kept.
+Index background work is installed as three Hermes/OpenClaw cron jobs: **memory signal sync at `0 1 * * *`**, **digest prepare at `0 2 * * *`**, and **digest send at `0 8 * * *`** (host-local). To install them at different times (a different timezone, a test window, etc.), pass full 5-field cron expressions. A flag wins over the matching env var; an invalid expression is ignored with a warning and the default is kept.
+
+> **Note:** the former 30-minute `Edge — heartbeat` cron was **retired** — it loaded the full agent context + Index MCP tool surface (~57k input tokens) every 30 minutes and exhausted the per-tenant OpenRouter key budgets fleet-wide (HTTP 402). `reconcileDigestCronJobs` removes any existing heartbeat cron on the next install/update. Accepted-opportunity notifications now surface through the morning digest; see #100 for richer replacements.
 
 ```bash
 # via flags
 bun install/install.ts --index-api-key <YOUR_API_KEY> \
-  --heartbeat-cron      "*/30 * * * *" \
   --digest-prepare-cron "0 3 * * *" \
   --digest-send-cron    "0 9 * * *"
 
 # or via environment
-HEARTBEAT_CRON="*/30 * * * *" DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="0 9 * * *" \
+DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="0 9 * * *" \
   bun install/install.ts --index-api-key <YOUR_API_KEY>
 ```
 
 | Cron | Flag | Env var | Default |
 |---|---|---|---|
-| Heartbeat | `--heartbeat-cron "<expr>"` | `HEARTBEAT_CRON` | `*/30 * * * *` |
+| Memory signal sync | `--digest-signals-cron "<expr>"` | `DIGEST_SIGNALS_CRON` | `0 1 * * *` |
 | Prepare pass | `--digest-prepare-cron "<expr>"` | `DIGEST_PREPARE_CRON` | `0 2 * * *` |
 | Send pass | `--digest-send-cron "<expr>"` | `DIGEST_SEND_CRON` | `0 8 * * *` |
 
@@ -248,7 +249,7 @@ The installer:
 4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
-7. Installs the Index cron jobs: a heartbeat (`*/30 * * * *`) that runs `skills/index-network/heartbeat.md`, a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. The prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. The end user can't change the schedule from chat, but the installer can override the cron times via `--heartbeat-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `HEARTBEAT_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the Index cron times" above.
+7. Installs the Index cron jobs: a memory signal sync (`0 1 * * *`), a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. (The 30-minute `Edge — heartbeat` cron was retired — see the note under "Overriding the Index cron times" — and is removed from existing tenants on update.) The prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. The end user can't change the schedule from chat, but the installer can override the cron times via `--digest-signals-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_SIGNALS_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the Index cron times" above.
 8. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent setup gates with different triggers:
@@ -280,9 +281,9 @@ bun install/reset.ts --wipe-user
 
 ## How it runs
 
-Time-sensitive and background prompts run as **Hermes/OpenClaw cron jobs**. There is no separate heartbeat primitive in this repo: `Edge — heartbeat` is a scheduled cron prompt that runs `skills/index-network/heartbeat.md` roughly every 30 minutes, while the morning digest prepare/send prompts run at their own daily cron times. Cron has its own scheduler and runs isolated sessions, so each tick starts fresh from the workspace files. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
+Time-sensitive and background prompts run as **Hermes/OpenClaw cron jobs**. The morning digest prepare/send prompts and the daily memory signal sync run at their own daily cron times. Cron has its own scheduler and runs isolated sessions, so each tick starts fresh from the workspace files. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
 
-Accepted-opportunity notifications, freshness audits, memory curation, Telegram-handle reconciliation, and other latency-tolerant background work belong in the heartbeat prompt because 30-minute latency is acceptable for those flows.
+> **Retired:** a 30-minute `Edge — heartbeat` cron used to run `skills/index-network/heartbeat.md` for accepted-opportunity notifications, freshness audits, and Telegram-handle reconciliation. It was removed because each tick loaded ~57k input tokens (full agent context + Index MCP tool surface) and, at 48 runs/day/tenant, drained the per-tenant OpenRouter key budgets fleet-wide (HTTP 402). `skills/index-network/heartbeat.md` is kept for reference only and is no longer scheduled. Latency-tolerant background work should be folded into the daily digest, an event-driven push, or a cheap deterministic (`--no-agent`) cron instead — see Edge-City/agentvillage#100.
 
 ## Workspace layout
 
@@ -333,16 +334,16 @@ AgentVillage's behaviour is markdown-driven. Almost everything you'd want to cha
 | Add, remove, or reorder operating rules (memory contract, opportunity quality bar, red lines, group-chat rules) | `workspace/AGENTS.md` | This file is always injected by OpenClaw on every session — durable, unlike `BOOTSTRAP.md`. |
 | Add a new first-message gate (e.g. another skill needs onboarding) | `workspace/AGENTS.md` "Active skills" section + the new `skills/<name>/bootstrap.md` | Gates loop over the active-skills registry. Add the skill row first, then point its bootstrap at the trigger condition (server flag, local marker, …). |
 | Change the returning-user first-message framing | `workspace/AGENTS.md` "First-message gates" | The digest schedule is fixed (set in `install/install_index.ts`) and not adjustable from chat. |
-| Change heartbeat tick behaviour (what tasks fire, dedup rules) | `workspace/HEARTBEAT.md` for cross-backend rules; `skills/<backend>/heartbeat.md` for backend-specific tasks | The tick cadence is the `Edge — heartbeat` cron in `install/install_index.ts`; override one install with `--heartbeat-cron` / `HEARTBEAT_CRON`. |
+| ~~Change heartbeat tick behaviour~~ | n/a | The 30-minute `Edge — heartbeat` cron was retired (it drained OpenRouter key budgets fleet-wide). `skills/index-network/heartbeat.md` is kept for reference only and is no longer scheduled — see #100 for replacement approaches. |
 | Change how URLs / formatting render per channel (Telegram, WhatsApp, Discord) | `workspace/TOOLS.md` | Cross-backend rule: Telegram is Markdown, not HTML — raw `<…>` tags get escaped. |
 
 ### Schedule & cron
 
-Index background work runs as fixed cron prompts — **heartbeat `*/30 * * * *`, prepare `0 2 * * *`, send `0 8 * * *`** (host-local) — and the end user can't change those schedules from chat. The installer can override any time (see "Overriding the Index cron times" under **Install**).
+Index background work runs as fixed cron prompts — **memory signal sync `0 1 * * *`, prepare `0 2 * * *`, send `0 8 * * *`** (host-local) — and the end user can't change those schedules from chat. The installer can override any time (see "Overriding the Index cron times" under **Install**). The 30-minute heartbeat cron was retired.
 
 | You want to… | Edit | Notes |
 |---|---|---|
-| Override the Index cron times for one install | `--heartbeat-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `HEARTBEAT_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the default. |
+| Override the Index cron times for one install | `--digest-signals-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_SIGNALS_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the default. |
 | Change the default Index cron schedule for everyone | `install/install_index.ts` (`DIGEST_CRON_SPECS`) | The installer writes the cron entries from this table. Existing installs pick up changes on the next `install.ts` run. |
 | Change a cron prompt without changing the schedule | the matching prompt file (`skills/index-network/heartbeat.md` or `skills/edge-esmeralda/prompts/<name>.md`) | Hermes stores prompt copies in cron jobs. Hosted residents are refreshed by the control-plane post-merge sync, which calls each sidecar's `/update` endpoint and reruns the installer. For non-control-plane installs or recovery, run `HERMES_HOME=<resident-home> bun install/reconcile_digest_crons.ts` after updated skill files are copied. |
 

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -175,17 +175,16 @@ export interface DigestCronSpec {
  * deliver), prepare (02:00, no deliver), then send (08:00, deliver telegram).
  * Signal sync runs an hour before prepare so freshly-captured signals have time
  * to produce opportunities before the brief is composed.
+ *
+ * The 30-minute "Edge — heartbeat" cron was retired (see Edge-City/agentvillage#100
+ * "Heartbeat cron drains OpenRouter key budget"). Its prompt loaded the
+ * full agent context + Index MCP tool surface (~57k input tokens) every 30 min,
+ * which exhausted the per-tenant OpenRouter keys fleet-wide (HTTP 402). It is no
+ * longer in this list, so `reconcileDigestCronJobs` removes it from existing
+ * tenants on the next install/update (Edge-prefixed crons not in this list are
+ * retired). `index-network/heartbeat.md` is kept for reference/history only.
  */
 export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
-  {
-    schedule: "*/30 * * * *",
-    staggerWindowMinutes: 30,
-    promptFile: "index-network/heartbeat.md",
-    name: "Edge — heartbeat",
-    deliver: true,
-    overrideFlag: "--heartbeat-cron",
-    overrideEnv: "HEARTBEAT_CRON",
-  },
   {
     schedule: "0 1 * * *",
     staggerWindowMinutes: 50,

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -12,13 +12,12 @@ import {
   storedSchedule,
 } from "../install_index";
 
-test("four Index cron specs: heartbeat, signals, prepare, then send", () => {
-  expect(DIGEST_CRON_SPECS).toHaveLength(4);
-  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
-  expect(heartbeat.schedule).toBe("*/30 * * * *");
-  expect(heartbeat.name).toBe("Edge — heartbeat");
-  expect(heartbeat.promptFile).toBe("index-network/heartbeat.md");
-  expect(heartbeat.deliver).toBe(true);
+test("three Index cron specs: signals, prepare, then send (heartbeat retired)", () => {
+  expect(DIGEST_CRON_SPECS).toHaveLength(3);
+  // The 30-minute "Edge — heartbeat" cron was retired (it drained OpenRouter
+  // key budget fleet-wide); it must no longer be installed.
+  expect(DIGEST_CRON_SPECS.some((s) => s.name === "Edge — heartbeat")).toBe(false);
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
   expect(signals.schedule).toBe("0 1 * * *");
   expect(signals.name).toBe("Edge — memory signal sync");
   expect(signals.promptFile).toBe("edge-esmeralda/prompts/memory-signals.md");
@@ -33,14 +32,9 @@ test("four Index cron specs: heartbeat, signals, prepare, then send", () => {
   expect(send.deliver).toBe(true);
 });
 
-test("heartbeat and send cron args include --deliver telegram; signals/prepare omit it", () => {
+test("send cron args include --deliver telegram; signals/prepare omit it", () => {
   const home = "/home/x/.hermes";
-  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
-
-  expect(cronCreateArgs(heartbeat, "HEART_BODY", home)).toEqual([
-    "cron", "create", "*/30 * * * *", "HEART_BODY",
-    "--name", "Edge — heartbeat", "--deliver", "telegram", "--workdir", home,
-  ]);
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
 
   expect(cronCreateArgs(signals, "SIGNALS_BODY", home)).toEqual([
     "cron", "create", "0 1 * * *", "SIGNALS_BODY",
@@ -71,9 +65,9 @@ test("cronEditArgs includes only the provided fields", () => {
 });
 
 test("staggeredSchedule derives a deterministic minute inside the spec's window", () => {
-  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
 
-  for (const spec of [heartbeat, signals, prepare, send]) {
+  for (const spec of [signals, prepare, send]) {
     const schedule = staggeredSchedule(spec, "ix_tenant_key");
     expect(staggeredSchedule(spec, "ix_tenant_key")).toBe(schedule); // deterministic
     const [minute, ...rest] = schedule.split(" ");
@@ -92,9 +86,8 @@ test("staggeredSchedule derives a deterministic minute inside the spec's window"
   expect(fnv1a(`seed:${prepare.name}`)).not.toBe(fnv1a(`seed:${send.name}`));
 });
 
-test("staggered windows keep heartbeat, signals, prepare, and send in bounded windows", () => {
-  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
-  expect(heartbeat.staggerWindowMinutes).toBe(30);
+test("staggered windows keep signals, prepare, and send in bounded windows", () => {
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
   expect(signals.staggerWindowMinutes).toBe(50);
   expect(prepare.staggerWindowMinutes).toBe(50);
   expect(send.staggerWindowMinutes).toBe(25);
@@ -128,9 +121,7 @@ test("invalid telegram MCP handle is omitted", () => {
 });
 
 test("each spec declares its install-time override flag + env var", () => {
-  const [heartbeat, signals, prepare, send] = DIGEST_CRON_SPECS;
-  expect(heartbeat.overrideFlag).toBe("--heartbeat-cron");
-  expect(heartbeat.overrideEnv).toBe("HEARTBEAT_CRON");
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
   expect(signals.overrideFlag).toBe("--digest-signals-cron");
   expect(signals.overrideEnv).toBe("DIGEST_SIGNALS_CRON");
   expect(prepare.overrideFlag).toBe("--digest-prepare-cron");
@@ -150,13 +141,13 @@ test("isValidCron accepts 5-field expressions and rejects malformed ones", () =>
 });
 
 test("resolveCronSchedule returns the default when no override is set", () => {
-  const [, signals, prepare] = DIGEST_CRON_SPECS;
+  const [signals, prepare] = DIGEST_CRON_SPECS;
   expect(resolveCronSchedule(signals, [], {})).toBe("0 1 * * *");
   expect(resolveCronSchedule(prepare, [], {})).toBe("0 2 * * *");
 });
 
 test("resolveCronSchedule staggers from the seed when no override is set, but override wins", () => {
-  const [, signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
   const seed = "ix_tenant_key";
 
   expect(resolveCronSchedule(signals, [], {}, seed)).toBe(staggeredSchedule(signals, seed));
@@ -171,7 +162,7 @@ test("resolveCronSchedule staggers from the seed when no override is set, but ov
 });
 
 test("resolveCronSchedule honors flag, then env, with flag winning over env", () => {
-  const [, signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send] = DIGEST_CRON_SPECS;
 
   expect(
     resolveCronSchedule(signals, ["bun", "install", "--digest-signals-cron", "30 0 * * *"], {}),
@@ -195,7 +186,7 @@ test("resolveCronSchedule honors flag, then env, with flag winning over env", ()
 });
 
 test("resolveCronSchedule ignores an invalid override and uses the default", () => {
-  const [, , prepare] = DIGEST_CRON_SPECS;
+  const [, prepare] = DIGEST_CRON_SPECS;
   expect(resolveCronSchedule(prepare, ["bun", "--digest-prepare-cron", "garbage"], {})).toBe("0 2 * * *");
   expect(resolveCronSchedule(prepare, [], { DIGEST_PREPARE_CRON: "0 2 * *" })).toBe("0 2 * * *");
 });

--- a/install/tests/reconcile_digest_crons.test.ts
+++ b/install/tests/reconcile_digest_crons.test.ts
@@ -16,9 +16,10 @@ import {
 } from "../install_index";
 
 const SEED = "ix_integration_seed";
-const [HEARTBEAT, SIGNALS, PREPARE, SEND] = DIGEST_CRON_SPECS;
+const [SIGNALS, PREPARE, SEND] = DIGEST_CRON_SPECS;
+// The retired "Edge — heartbeat" cron name — used to assert it is torn down.
+const RETIRED_HEARTBEAT_NAME = "Edge — heartbeat";
 const PROMPT_BODIES = new Map([
-  [HEARTBEAT.promptFile, "HEARTBEAT_BODY"],
   [SIGNALS.promptFile, "SIGNALS_BODY"],
   [PREPARE.promptFile, "PREPARE_BODY"],
   [SEND.promptFile, "SEND_BODY"],
@@ -116,33 +117,42 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
-test("fresh install creates heartbeat and digest crons on their staggered schedules", () => {
+test("fresh install creates digest crons (no heartbeat) on their staggered schedules", () => {
   reconcileDigestCronJobs({ ...process.env });
 
   const creates = cronCalls().filter((argv) => argv[1] === "create");
-  expect(creates).toHaveLength(4);
+  expect(creates).toHaveLength(3);
+  expect(creates.some((argv) => argv.includes(RETIRED_HEARTBEAT_NAME))).toBe(false);
 
-  const heartbeat = creates.find((argv) => argv.includes(HEARTBEAT.name))!;
   const signals = creates.find((argv) => argv.includes(SIGNALS.name))!;
   const prepare = creates.find((argv) => argv.includes(PREPARE.name))!;
   const send = creates.find((argv) => argv.includes(SEND.name))!;
-  expect(heartbeat[2]).toBe(staggeredSchedule(HEARTBEAT, SEED));
-  expect(heartbeat[3]).toBe("HEARTBEAT_BODY");
   expect(signals[2]).toBe(staggeredSchedule(SIGNALS, SEED));
   expect(signals[3]).toBe("SIGNALS_BODY");
   expect(prepare[2]).toBe(staggeredSchedule(PREPARE, SEED));
   expect(prepare[3]).toBe("PREPARE_BODY");
   expect(send[2]).toBe(staggeredSchedule(SEND, SEED));
   expect(send[3]).toBe("SEND_BODY");
-  expect(heartbeat).toContain("--deliver");
   expect(send).toContain("--deliver");
   expect(signals).not.toContain("--deliver");
   expect(prepare).not.toContain("--deliver");
 });
 
+test("an existing Edge — heartbeat cron is retired on reconcile", () => {
+  writeJobs([
+    { id: "h1", name: RETIRED_HEARTBEAT_NAME, prompt: "HEARTBEAT_BODY", schedule: { expr: "*/30 * * * *" } },
+    currentJob(SIGNALS, "g1"),
+    currentJob(PREPARE, "p1"),
+    currentJob(SEND, "s1"),
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  expect(cronCalls()).toEqual([["cron", "remove", "h1"]]);
+});
+
 test("jobs still on old synchronized defaults get schedule-only migrations", () => {
   writeJobs([
-    { id: "h1", name: HEARTBEAT.name, prompt: "HEARTBEAT_BODY", schedule: { expr: HEARTBEAT.schedule } },
     { id: "g1", name: SIGNALS.name, prompt: "SIGNALS_BODY", schedule: { expr: SIGNALS.schedule } },
     { id: "p1", name: PREPARE.name, prompt: "PREPARE_BODY", schedule: { expr: PREPARE.schedule } },
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: SEND.schedule } },
@@ -152,7 +162,6 @@ test("jobs still on old synchronized defaults get schedule-only migrations", () 
 
   const calls = cronCalls();
   expect(calls).toEqual([
-    ["cron", "edit", "h1", "--schedule", staggeredSchedule(HEARTBEAT, SEED)],
     ["cron", "edit", "g1", "--schedule", staggeredSchedule(SIGNALS, SEED)],
     ["cron", "edit", "p1", "--schedule", staggeredSchedule(PREPARE, SEED)],
     ["cron", "edit", "s1", "--schedule", staggeredSchedule(SEND, SEED)],
@@ -161,7 +170,6 @@ test("jobs still on old synchronized defaults get schedule-only migrations", () 
 
 test("custom schedule is preserved; stale prompt gets a prompt-only edit", () => {
   writeJobs([
-    currentJob(HEARTBEAT, "h1"),
     currentJob(SIGNALS, "g1"),
     { id: "p1", name: PREPARE.name, prompt: "OLD_BODY", schedule: { expr: "30 4 * * *" } },
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: "15 9 * * *" } },
@@ -176,7 +184,6 @@ test("custom schedule is preserved; stale prompt gets a prompt-only edit", () =>
 
 test("stale prompt + old default schedule produce two independent edit calls", () => {
   writeJobs([
-    currentJob(HEARTBEAT, "h1"),
     currentJob(SIGNALS, "g1"),
     currentJob(PREPARE, "p1"),
     { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },
@@ -193,7 +200,6 @@ test("stale prompt + old default schedule produce two independent edit calls", (
 
 test("up-to-date jobs (staggered schedule + current prompt) trigger no cron calls", () => {
   writeJobs([
-    currentJob(HEARTBEAT, "h1"),
     currentJob(SIGNALS, "g1"),
     currentJob(PREPARE, "p1"),
     currentJob(SEND, "s1"),
@@ -219,7 +225,6 @@ test("retired Edge-prefixed crons are removed; foreign crons are untouched", () 
 test("a Hermes that rejects --schedule still gets the prompt update (degraded migration)", () => {
   process.env.HERMES_BIN = writeStubHermes(home, { rejectScheduleFlag: true });
   writeJobs([
-    currentJob(HEARTBEAT, "h1"),
     currentJob(SIGNALS, "g1"),
     currentJob(PREPARE, "p1"),
     { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },


### PR DESCRIPTION
## Summary
Retire the 30-minute `Edge — heartbeat` cron. It ran a full LLM agent turn loading ~57k input tokens (agent context + Index MCP tool surface) every 30 min, draining per-tenant OpenRouter key budgets fleet-wide (HTTP 402: prompt tokens limit exceeded).

- Removed the heartbeat entry from `DIGEST_CRON_SPECS`; `reconcileDigestCronJobs` now retires any existing `Edge — heartbeat` cron on the next install/update (Edge-prefixed crons not in the spec list are removed).
- Kept `skills/index-network/heartbeat.md` for reference/history only.
- Updated install tests (cron specs + reconcile integration) and README cron docs.

Tracking issue: #100 (what the heartbeat did, why it's needed, and replacement options — event-driven push / deterministic `--no-agent` cron / fold into daily digest).

## Tests
- `bun test install/tests` (32 pass)