### PR TITLE
fix(agentvillage): lowercase Telegram handles for case-insensitive matching

### DIFF
--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -64,7 +64,12 @@ function normalizeTelegramHandle(raw: string): string {
     .replace(/^(?:https?:\/\/)?(?:t\.me|telegram\.me)\//i, "")
     .replace(/^@/, "")
     .split(/[/?#]/)[0];
-  return /^[A-Za-z0-9_]{5,32}$/.test(bare) ? bare : "";
+  // Telegram usernames are case-insensitive (@Seref and @seref are the same
+  // account), so fold case to a canonical lowercase handle. Without this, a
+  // case-only difference between sources (e.g. EdgeOS "seref" vs runtime
+  // "@Seref") registers as a false-positive conflict in telegram-handle
+  // reconciliation.
+  return /^[A-Za-z0-9_]{5,32}$/.test(bare) ? bare.toLowerCase() : "";
 }
 
 export function buildIndexMcpHeaders(apiKey: string, telegramHandle = ""): Record<string, string> {
@@ -403,7 +408,10 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
 
 export function installIndex(): void {
   const apiKey = readApiKey();
-  const telegramHandle = readTelegramHandle();
+  // Persist the canonical (bare, lowercase) handle so the runtime source
+  // (INDEX_TELEGRAM_HANDLE / MCP headers) never drifts from other systems by
+  // a leading @ or letter case alone.
+  const telegramHandle = normalizeTelegramHandle(readTelegramHandle());
   console.log(
     `→ index network: target=${IS_DEV ? "dev" : "production"} (${PROTOCOL_MCP_URL})`,
   );

--- a/skills/index-network/bootstrap.md
+++ b/skills/index-network/bootstrap.md
@@ -107,7 +107,7 @@ Once `create_intent` succeeds, briefly acknowledge:
 
 Before closing onboarding, note which platform the user connected through, but do **not** silently choose between independent Telegram handle sources. AgentVillage spans EdgeOS, Index, the local Hermes runtime, and the control plane; none of those should overwrite another merely because it happened to be read last.
 
-**Never fabricate a handle.** Do **not** derive, guess, or construct one from the user's name, display name, email, or chatId, and do not "tidy" a guess into something plausible. A Telegram username must match `[A-Za-z0-9_]{5,32}` exactly after stripping a leading `@`; if what you have doesn't match, it is not a real handle.
+**Never fabricate a handle.** Do **not** derive, guess, or construct one from the user's name, display name, email, or chatId, and do not "tidy" a guess into something plausible. A Telegram username must match `[A-Za-z0-9_]{5,32}` exactly after stripping a leading `@` (and is case-insensitive, so store it lowercased); if what you have doesn't match, it is not a real handle.
 
 Detection by session key:
 

--- a/skills/index-network/heartbeat.md
+++ b/skills/index-network/heartbeat.md
@@ -42,7 +42,7 @@ tasks:
        - Index: call `read_user_profiles()` and extract the user's `telegram` social if present.
        - EdgeOS: if `EDGEOS_BEARER_TOKEN` is available, use the `edgeos` skill recipe `GET /api/v1/humans/me` and read its `telegram` field. If the value is the hidden sentinel `"*"`, treat it as unavailable, not a conflict.
        - Runtime host: read `INDEX_TELEGRAM_HANDLE` from the environment if available; this is the Telegram handle currently forwarded in Index MCP headers.
-    3. Normalize every non-empty candidate for comparison: trim, strip a leading `@`, strip `https://t.me/` or `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`. Keep both the raw and normalized forms in notes. Values that fail validation (for example `Lauren Tannhauser`) are invalid candidates and should trigger reconciliation if any system stores them.
+    3. Normalize every non-empty candidate for comparison: trim, strip a leading `@`, strip `https://t.me/` or `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`, then lowercase the result (Telegram usernames are case-insensitive, so a case-only difference such as `seref` vs `@Seref` is the same handle and must not count as drift). Keep both the raw and normalized forms in notes. Values that fail validation (for example `Lauren Tannhauser`) are invalid candidates and should trigger reconciliation if any system stores them.
     4. Decide:
        - If there are zero valid candidates and no invalid candidates, reply silently.
        - If there is exactly one valid normalized handle and no invalid candidates, reply silently. No system is drifting from another known system.
@@ -68,7 +68,7 @@ tasks:
        - Index: call `read_user_profiles()` and extract the user's `telegram` social if present.
        - EdgeOS: if `EDGEOS_BEARER_TOKEN` is available, use the `edgeos` skill recipe `GET /api/v1/humans/me` and read its `telegram` field. If the value is the hidden sentinel `"*"`, treat it as unavailable, not a conflict.
        - Runtime host: read `INDEX_TELEGRAM_HANDLE` from the environment if available; this is the Telegram handle currently forwarded in Index MCP headers.
-    3. Normalize every non-empty candidate for comparison: trim, strip a leading `@`, strip `https://t.me/` or `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`. Keep both the raw and normalized forms in notes. Values that fail validation (for example `Lauren Tannhauser`) are invalid candidates and should trigger reconciliation if any system stores them.
+    3. Normalize every non-empty candidate for comparison: trim, strip a leading `@`, strip `https://t.me/` or `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`, then lowercase the result (Telegram usernames are case-insensitive, so a case-only difference such as `seref` vs `@Seref` is the same handle and must not count as drift). Keep both the raw and normalized forms in notes. Values that fail validation (for example `Lauren Tannhauser`) are invalid candidates and should trigger reconciliation if any system stores them.
     4. Decide:
        - If there are zero valid candidates and no invalid candidates, reply silently.
        - If there is exactly one valid normalized handle and no invalid candidates, reply silently. No system is drifting from another known system.

--- a/skills/index-network/tools.md
+++ b/skills/index-network/tools.md
@@ -48,7 +48,7 @@ Do not do this during onboarding — the bootstrap ritual owns signal capture th
 
 The `telegram-handle-reconciliation` heartbeat task may ask the resident which Telegram username is correct when EdgeOS, Index, and the local runtime disagree. If `memory/heartbeat-state.json` contains `telegramHandleReconciliation.pending=true`, handle the user's next handle-like answer before ordinary signal capture.
 
-1. Normalize the reply: trim, strip a leading `@`, strip `https://t.me/` / `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`. Store and write bare handles only — e.g. `alice_tg`, never `@alice_tg`.
+1. Normalize the reply: trim, strip a leading `@`, strip `https://t.me/` / `https://telegram.me/`, drop query/hash/path suffixes, and require `[A-Za-z0-9_]{5,32}`, then lowercase it (Telegram usernames are case-insensitive). Store and write bare, lowercase handles only — e.g. `alice_tg`, never `@alice_tg`.
 2. If the reply is not a valid Telegram username, ask one short follow-up: "What's your Telegram username? Send just the handle, without @." Do not write anything.
 3. If valid, update the independent systems that are available from this runtime:
    - Index: call `update_user_profile(socials={ telegram: "<bare-handle>" })`.


### PR DESCRIPTION
## What

Lowercase Telegram handles to a canonical **bare + lowercase** form on the AgentVillage runtime/source side. Telegram usernames are case-insensitive (`@Seref` and `seref` are the same account).

## Why

The `telegram-handle-reconciliation` heartbeat was firing a false positive:
> `RuntimeError: I found conflicting Telegram handles … EdgeOS has seref while the runtime system is using @Seref`

The backend write-path half shipped in **indexnetwork/index#967** (canonicalizes the Index profile source), but two things live here in AgentVillage and were still case-sensitive:

1. **`INDEX_TELEGRAM_HANDLE` / MCP headers** are produced by `install_index.ts` `normalizeTelegramHandle()`, which returned mixed case.
2. The **comparison logic** in the `index-network` reconciliation skills (`heartbeat.md`, plus `bootstrap.md`/`tools.md`) stripped a leading `@` but did not lowercase, so `Seref` ≠ `seref` still counted as drift.

This aligns the AgentVillage source + skills with the backend, so a case-only difference no longer registers as a conflict.

## Changes

- **`install/install_index.ts`** — `normalizeTelegramHandle()` lowercases the validated handle; `installIndex()` persists the normalized handle into `INDEX_TELEGRAM_HANDLE`.
- **`skills/index-network/{bootstrap,heartbeat,tools}.md`** — normalize rules now lowercase the result and store bare, lowercase handles only.

## Verification

- Patch applied against `Edge-City/agentvillage@main` (`6113db8`); resulting blob hashes match the intended diff exactly (`install_index.ts` `72123ef`, `bootstrap.md` `0bed973`, `heartbeat.md` `020c20d`, `tools.md` `10ee4fc`).
- Backend counterpart already merged to `indexnetwork/index` dev via #967.