### PR TITLE
Make memory signal sync Enzyme-first and source-authority gated

### DIFF
--- a/skills/edge-esmeralda/prompts/memory-signals.md
+++ b/skills/edge-esmeralda/prompts/memory-signals.md
@@ -4,16 +4,25 @@ Silent turns use the current host's no-reply marker exactly: Hermes → `[SILENT
 
 # Job
 
-Build source-typed memory candidates, compare them against what the Index already has, and create only the grounded records that are missing. This runs in a fresh main session with no recall of past runs — every decision comes from tool calls and files. Track dedup state in `memory/heartbeat-state.json` under `memorySignals`.
+Understand what the user durably is and currently wants, compare that against what the Index already has and against what was already tried and rejected, and create only the small set of grounded records that are genuinely missing. This runs in a fresh main session with no recall of past runs — every decision comes from tool calls and files. Track dedup state in `memory/heartbeat-state.json` under `memorySignals`.
 
-Enzyme is the preferred broad memory read gateway when available, but it is not canonical truth. Use it to find evidence across typed sources, then open or verify the cited canonical file before any Index write. Do not use keyword extraction or line classification as permission to write; every candidate must come from direct reading of canonical memory and source-authority verification.
+This pass is **read-first, write-rarely**. You are not extracting keywords from text; you are reasoning about a person from their own canonical memory, using semantic retrieval to explore and using past traces to learn what *not* to create.
 
-Source authority for this pass:
+## Source authority
 
-- **Writable grounding:** `USER.md` and `MEMORY.md` can ground `create_premise` and `create_intent` when the text plainly supports the record.
-- **Corroboration only:** daily notes and rendered session provenance can corroborate recency or user wording, but do not promote transcript fragments by themselves unless they clearly quote or preserve a direct user statement.
-- **Context only:** forum and IRL observations can improve ranking, copy, and future questions. They cannot create Index records unless the same fact or want is corroborated by user-authored or curated memory.
-- **Operational only:** `memory/*.json` controls gates and dedup. Do not treat it as semantic memory.
+Enzyme is a retrieval gateway, not truth. It routes you to evidence across the typed memory sources; it never grounds a write on its own. Two canonical anchors outrank everything else:
+
+- **`USER.md`** — the user's own notebook. Highest authority for who they are and what they want.
+- **`MEMORY.md`** — curated long-term memory. High authority, curated from real interactions.
+
+Authority tiers for this pass:
+
+- **Writable grounding:** `USER.md` and `MEMORY.md`, when the text plainly supports the record, can ground `create_premise` and `create_intent`.
+- **Corroboration only:** daily notes (`memory/*.md`) and rendered session provenance (`memory/hermes/sessions/`) can confirm recency or the user's own wording, but a transcript fragment does not promote a record by itself unless it clearly quotes or preserves a direct user statement.
+- **Context only:** forum (`memory/forum/`) and IRL (`memory/irl/`) observations are agent-written. They can improve ranking, copy, and future questions, and they can *suggest* an ambiguous desire worth clarifying later — but they cannot create an Index record unless the same fact or want is corroborated by user-authored or curated memory.
+- **Operational only:** `memory/*.json` controls gates and dedup. It is never semantic memory.
+
+A want you observed at the forum, an introduction someone suggested IRL, or an inference from a session is a *question to ask later*, never a silent `create_intent`.
 
 ## Steps
 
@@ -22,27 +31,56 @@ Source authority for this pass:
    - The user has not completed onboarding (you will normally know this from session context; if genuinely unsure, check via `read_user_profiles` and stop silently if onboarding is incomplete).
    - `memorySignals.lastRunDate` in `memory/heartbeat-state.json` already equals today's date in America/Los_Angeles (you have already run today).
 
-2. **Read memory evidence.** Open `USER.md` and `MEMORY.md` directly as canonical anchors. If Enzyme is available and initialized, use it as an additional read gateway for broad recall before deciding, then open the cited canonical files. If Enzyme is unavailable, continue with direct canonical reads and the typed memory vault. Do not install Enzyme, initialize it, refresh it, or run network setup from this cron.
+2. **Explore with Enzyme first (when it is already available).** If — and only if — the runtime exposes Enzyme shell tooling and the local index already exists, use it silently to explore the memory workspace before deciding anything. Do **not** install, init, or refresh Enzyme from this cron; if it is unavailable, uninitialized, or stale, skip it and rely on the direct canonical reads in step 3. When available, run a few targeted semantic queries around the dimensions that drive good matches, for example:
+   - desired connections, introductions, or kinds of people the user wants to meet;
+   - active projects and goals that need people, collaborators, hiring, funding, or advice;
+   - durable profile facts — role, focus areas, skills, location, affiliations;
+   - privacy and outward-sharing constraints the user has stated;
+   - **negative / dedupe context** — what has already been captured, asked, rejected, or dismissed.
 
-3. **Read the current graph.** Call `read_premises()` and `read_intents()`. These — plus `memorySignals.captured` in `memory/heartbeat-state.json` — are your dedup baseline.
+   Suggested form (only if tooling is exposed and the index exists):
 
-4. **Diff grounded memory against the graph.** Go through the canonical sources and any Enzyme-cited files you verified. Collect candidates:
+   ```bash
+   enzyme catalyze -p memory -n 8 "who does the user want to meet or be introduced to"
+   enzyme catalyze -p memory -n 8 "what is the user actively working on, hiring for, raising, or seeking help with"
+   enzyme catalyze -p memory -n 8 "durable facts about the user's role, focus, skills, and location"
+   enzyme catalyze -p memory -n 8 "what has already been captured, asked, rejected, or declined"
+   enzyme petri -p memory -n 12
+   ```
+
+   Enzyme only points at files. It does not authorize a write. Treat every hit as "go open this and check," not as a fact.
+
+3. **Read the canonical anchors directly — always.** Regardless of whether Enzyme ran, open `USER.md` and `MEMORY.md` and read them as the high-authority source of who the user durably is and what they currently want. These anchor every write you make. If Enzyme surfaced a candidate, verify it against the cited canonical file here before trusting it.
+
+4. **Read the current Index graph.** Call `read_premises()` and `read_intents()`. These are what the network already knows about the user — every existing premise and signal is something you must NOT recreate, even loosely.
+
+5. **Read the negative/dedupe traces.** Before deciding what is missing, learn what has already been tried, so you do not recreate stale, rejected, speculative, or already-represented signals. Pull negative evidence from:
+   - `memorySignals.captured` in `memory/heartbeat-state.json` — prior runs' created and `rejected` fingerprints;
+   - the existing premises/intents from step 4;
+   - recent rendered session/cron provenance under `memory/hermes/sessions/` and recent daily notes, where prior clarification questions, dismissals, or "not interested" responses may be recorded;
+   - any prior questions already queued or asked (e.g. `signalElicitation` / `questionDelivery` state in `memory/heartbeat-state.json`).
+   Anything that appears here as already-asked, already-captured, rejected, dismissed, or time-expired is **off the table** for tonight.
+
+6. **Decide what is genuinely missing.** From the canonical anchors (corroborated by recency where useful), assemble the short list of:
    - **Durable profile facts** (role, skills, focus areas, location, affiliations) that no existing premise covers → candidates for `create_premise`.
-   - **Active wants** (things the user is working on, looking for, hiring for, raising, open to) that no existing signal covers and that are still plausibly current → candidates for `create_intent`.
-   Skip anything that is already represented (even loosely), anything listed in `memorySignals.captured`, anything stale or time-expired, anything speculative, and anything grounded only in forum/IRL/session interpretation. Memory you wrote about the user's plans is not the same as something they asked for. When in doubt, skip. An empty diff is a normal, successful outcome.
+   - **Active wants** (working on, looking for, hiring for, raising, open to) that no existing signal covers and that are still plausibly current → candidates for `create_intent`.
+   Skip anything already represented (even loosely), anything in the negative/dedupe traces from step 5, anything stale or time-expired, anything speculative, and anything grounded only in forum/IRL/session interpretation. Memory you wrote about the user's plans is not the same as something they asked for. When in doubt, skip. An empty diff is a normal, successful outcome.
 
-5. **Create, capped.** From the grounded candidates, create at most **2 premises** (`create_premise`) and at most **1 signal** (`create_intent(description=...)`) per run — favor the most specific, most clearly current items. Phrase intent descriptions close to the user's own words from verified memory. If `create_intent` is rejected as too vague, do **not** retry with a paraphrase — record the candidate under `memorySignals.captured` with a `rejected` note and move on.
+7. **Route ambiguous desired connections to a question, not a write.** If a desired connection or want is real but underspecified — you can see the user wants *something* but not precisely what, or it is grounded only in context-tier observation — do not guess it into a `create_intent`. Instead leave it for a future low-frequency clarification prompt: record it as a pending clarification under `memorySignals` (or the existing `signalElicitation` queue if that is where heartbeat reads questions from) so it can be asked later, at most occasionally, rather than silently materialized tonight.
 
-6. **Re-check discovery.** If you created at least one record, call `discover_opportunities` once so the freshly-thickened graph is matched before the morning brief is prepared. If it returns `status="queued"`, that is fine — the run completes server-side; do not poll, do not wait, do not call `list_opportunities`.
+8. **Create, capped.** From the grounded, unambiguous candidates, create at most **2 premises** (`create_premise`) and at most **1 signal** (`create_intent(description=...)`) per run — favor the most specific, most clearly current items. Phrase intent descriptions close to the user's own words from verified canonical memory. If `create_intent` is rejected as too vague, do **not** retry with a paraphrase — record the candidate under `memorySignals.captured` with a `rejected` note and move on.
 
-7. **Record and stop.** Update `memory/heartbeat-state.json`: set `memorySignals.lastRunDate` to today's Pacific date and append a short normalized fingerprint of each item you created (or that was rejected) to `memorySignals.captured`, keeping only the last 20. Preserve every other key in the file (e.g. `prepared`, `deliveredToday`, `signalElicitation`, `questionDelivery`) — read the whole object, add to it, write it back. End your turn with the host-specific no-reply marker.
+9. **Re-check discovery.** If you created at least one record, call `discover_opportunities` once so the freshly-thickened graph is matched before the morning brief is prepared. If it returns `status="queued"`, that is fine — the run completes server-side; do not poll, do not wait, do not call `list_opportunities`.
+
+10. **Record and stop.** Update `memory/heartbeat-state.json`: set `memorySignals.lastRunDate` to today's Pacific date, append a short normalized fingerprint of each item you created (or that was rejected) to `memorySignals.captured`, and append any deferred clarification from step 7. Keep `memorySignals.captured` to the last 20. Preserve every other key in the file (e.g. `prepared`, `deliveredToday`, `signalElicitation`, `questionDelivery`) — read the whole object, add to it, write it back. End your turn with the host-specific no-reply marker.
 
 # Hard rules
-- Never message the user from this pass. No questions, no summaries, no "I noticed…". The only output is the no-reply marker.
-- Never invent facts or wants that are not plainly grounded in direct user-authored or curated memory. Partial matches, adjacent keywords, Enzyme catalyst text, and agent-written observations are not evidence.
+- Never message the user from this pass. No questions, no summaries, no "I noticed…". The only output is the no-reply marker. Clarifications discovered here are *queued* for a future low-frequency prompt, never delivered now.
+- Never invent facts or wants that are not plainly grounded in direct user-authored (`USER.md`) or curated (`MEMORY.md`) memory. Partial matches, adjacent keywords, Enzyme catalyst text, and agent-written forum/IRL/session observations are not evidence.
+- Enzyme is a retrieval gateway only. It never grounds a write. Always open and verify the cited canonical file before any `create_premise` / `create_intent`.
+- Do not run Enzyme install, init, refresh, or any network setup from this cron. Retrieval is allowed only when the local index already exists; otherwise continue with direct canonical reads or skip safely.
 - At most 2 `create_premise` calls and at most 1 `create_intent` call per run. A vague-rejection ends that candidate for tonight — no silent retries.
 - Never delete, archive, or update existing premises/signals here — this pass only adds. Pruning belongs to the weekly signal-freshness task.
 - Do not stage Kanban cards, write digest files, or touch `prepared`/`deliveredToday` state — those belong to the digest passes.
-- Do not run Enzyme install/init/refresh from this cron. Retrieval is allowed only when the local index already exists.
 - If any tool call fails, end your turn silently. One pass, no diagnosis, no retries beyond the tool's own guidance.
 - Never expose internal IDs, raw JSON, file names, or internal vocabulary anywhere.


### PR DESCRIPTION
## Why this matters

Every attendee's agent is only as useful as the graph behind it. Discovery — "who should I meet?" — only returns good people when the user's durable facts and active wants are actually represented as Index premises and signals. Thin-signal users get nothing.

A nightly pass already exists to keep that graph fresh from each user's own long-term memory, before the morning brief is prepared. The problem is *how* it should decide what to add. We do not want an agent that scrapes keywords out of notes, or that quietly turns something it overheard at the forum into a public-facing "want." That erodes trust: the user never said it, and now their agent is broadcasting it.

This PR makes that pass reason about a person from their own canonical memory, with clear authority boundaries about what is allowed to ground a graph write.

## How the pieces relate

- **Memory/Enzyme is the read side.** It is an internal retrieval layer over the user's local typed memory — a way to *explore* and *route to evidence*. It is never the source of truth and never authorizes a write on its own.
- **Index is the write/discovery side.** Premises and signals are created through Index tools; discovery matches the thickened graph. This pass only feeds Index; Index does the matching.
- **The handoff is verification.** Anything retrieval surfaces must be confirmed against the cited canonical file before it becomes an Index record.

## Authority boundaries (the safety story)

- **Writable grounding:** `USER.md` and `MEMORY.md` — the user's own notebook and curated long-term memory — can ground `create_premise` / `create_intent`.
- **Corroboration only:** daily notes and rendered session provenance can confirm recency or the user's own wording, but do not promote a record on their own.
- **Context only:** agent-written forum/IRL observations can sharpen ranking, copy, and *future questions*, but can never create an Index record unless user-authored or curated memory says the same thing.
- **Negative evidence:** the existing graph, prior rejected fingerprints, past clarification questions, and dismissals tell the pass what *not* to recreate or re-suggest.
- An ambiguous desire becomes a future clarifying question, never a silent `create_intent`.

## Safety invariants

- Silent / no-delivery pass; it never messages the user.
- Does **not** install, initialize, or refresh Enzyme; it only reads, and only when the local index already exists.
- Forum/IRL/session-only observations cannot ground a write.
- Caps: at most 2 premises and 1 signal per run; one run per Pacific day (`memorySignals.lastRunDate`).
- A vague `create_intent` rejection ends that candidate — no silent paraphrase retries.
- Adds only — never deletes/updates premises or signals, never touches digest/Kanban delivery state. (Pruning stays in the weekly signal-freshness task.)

## What changed

- Rewrites `skills/edge-esmeralda/prompts/memory-signals.md` into a read-first, write-rarely pass: Enzyme-first exploration (when available), canonical anchors read directly, existing graph + past traces as the dedupe/negative baseline, ambiguity routed to a question.
- Cron name/path and schedule are unchanged (`Edge — memory signal sync`, ~01:00, before digest prepare ~02:00 and send ~08:00), so installer wiring stays stable.
- The deterministic keyword candidate script was removed in the base PR; this stacked PR is purely the cron-prompt architecture.

## Validation

- `git diff --check` — clean.
- `bun test install/tests/cron_specs.test.ts install/tests/reconcile_digest_crons.test.ts` — 23 pass / 0 fail.
- Repo-wide search confirms no remaining references to `build-memory-signal-candidates.ts` or `memory-signal-candidates.json`.

## Residual risks / open questions

- The deferred-clarification queue points at `memorySignals` / existing `signalElicitation` state. Confirm the exact schema the heartbeat question-delivery path expects before relying on queued clarifications to surface.
- Thin-memory users produce empty diffs and skip silently — intended.
