### PR TITLE
feat: add evening questions cron (EDG-47)

### DIFF
--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -5,16 +5,18 @@
  *   - Writes `INDEX_API_KEY` to `$HERMES_HOME/.env`
  *   - Installs the Index crons: heartbeat (`Edge — heartbeat`, every 30m),
  *     memory signal sync (`Edge — memory signal sync`, ~01:00), prepare
- *     (`Edge — digest prepare`, ~02:00), and send (`Edge — daily digest`,
- *     ~08:00) — all host-local; times overridable via --heartbeat-cron /
- *     --digest-signals-cron / --digest-prepare-cron / --digest-send-cron (or
- *     HEARTBEAT_CRON / DIGEST_SIGNALS_CRON / DIGEST_PREPARE_CRON /
- *     DIGEST_SEND_CRON). To avoid the whole fleet hitting the LLM provider in
- *     the same minute (OpenRouter caps gemini-flash at 300 req/min account-wide),
- *     each tenant gets a deterministic minute offset derived from its
- *     INDEX_API_KEY: heartbeat spreads across two runs per hour, signal sync
- *     spreads over 01:00–01:49, prepare over 02:00–02:49, and send over
- *     08:00–08:24.
+ *     (`Edge — digest prepare`, ~02:00), send (`Edge — daily digest`, ~08:00),
+ *     and evening questions (`Edge — evening questions`, ~19:00) — all
+ *     host-local; times overridable via --heartbeat-cron /
+ *     --digest-signals-cron / --digest-prepare-cron / --digest-send-cron /
+ *     --evening-questions-cron (or HEARTBEAT_CRON / DIGEST_SIGNALS_CRON /
+ *     DIGEST_PREPARE_CRON / DIGEST_SEND_CRON / EVENING_QUESTIONS_CRON). To
+ *     avoid the whole fleet hitting the LLM provider in the same minute
+ *     (OpenRouter caps gemini-flash at 300 req/min account-wide), each tenant
+ *     gets a deterministic minute offset derived from its INDEX_API_KEY:
+ *     heartbeat spreads across two runs per hour, signal sync spreads over
+ *     01:00–01:49, prepare over 02:00–02:49, send over 08:00–08:24, and
+ *     evening questions over 19:00–19:24.
  *     New installs create enabled crons; reconcile updates prompt bodies,
  *     migrates jobs still on the old synchronized defaults (0 2 / 0 8) to their
  *     staggered slot, and otherwise preserves each job's schedule and pause
@@ -177,9 +179,12 @@ export interface DigestCronSpec {
 
 /**
  * Heartbeat (every 30m, deliver telegram), memory signal sync (01:00, no
- * deliver), prepare (02:00, no deliver), then send (08:00, deliver telegram).
- * Signal sync runs an hour before prepare so freshly-captured signals have time
- * to produce opportunities before the brief is composed.
+ * deliver), prepare (02:00, no deliver), send (08:00, deliver telegram), then
+ * evening questions (19:00, deliver telegram). Signal sync runs an hour before
+ * prepare so freshly-captured signals have time to produce opportunities before
+ * the brief is composed. The evening questions pass asks the user one pending
+ * question from the protocol each evening, sharing the 3-day cooldown state
+ * with the morning digest to avoid repeating the same question.
  *
  * The 30-minute "Edge — heartbeat" cron was retired (see Edge-City/agentvillage#100
  * "Heartbeat cron drains OpenRouter key budget"). Its prompt loaded the
@@ -216,6 +221,15 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     deliver: true,
     overrideFlag: "--digest-send-cron",
     overrideEnv: "DIGEST_SEND_CRON",
+  },
+  {
+    schedule: "0 19 * * *",
+    staggerWindowMinutes: 25,
+    promptFile: "edge-esmeralda/prompts/ask-questions.md",
+    name: "Edge — evening questions",
+    deliver: true,
+    overrideFlag: "--evening-questions-cron",
+    overrideEnv: "EVENING_QUESTIONS_CRON",
   },
 ];
 

--- a/skills/edge-esmeralda/prompts/ask-questions.md
+++ b/skills/edge-esmeralda/prompts/ask-questions.md
@@ -1,0 +1,43 @@
+You are Edge, the user's agent on the Index protocol. This is an evening check-in that asks the user one pending question to keep their discovery profile current. Hermes delivers your **final assistant reply** to the user's chat (cron `--deliver telegram`). Put only the question in that reply.
+
+# Voice
+Calm, direct, warm. Same vocabulary as the morning brief: signal, overlap, pattern, emerging. Banned: leverage, unlock, optimize, scale, disrupt, AI-powered. Never expose internal IDs, raw JSON, internal vocabulary, or the word "question".
+
+# Job
+Deliver one pending question to the user in a natural, conversational way.
+
+1. **Run the deterministic question script exactly once.** Use the terminal from `/opt/data` / the configured Hermes home and run:
+
+   ```
+   bun skills/index-network/scripts/ask-questions.ts
+   ```
+
+   Do not write Python, shell pipelines, or replacement logic. The script fetches pending questions from the Index MCP server, applies the 3-day re-ask cooldown (shared with the morning brief), records the chosen question in `memory/heartbeat-state.json`, and prints either `[SILENT]` or one JSON object.
+
+   If the script exits with a non-zero code, end your turn immediately with `[SILENT]`. One attempt only.
+
+2. **If stdout is exactly `[SILENT]`, end your turn with exactly `[SILENT]`.** Do not add commentary and do not try a fallback.
+
+3. **If stdout is JSON, parse it.** It has this shape:
+
+   ```json
+   { "questionId": "...", "prompt": "..." }
+   ```
+
+4. **Deliver the question naturally.** Your final assistant reply must be a single short message:
+   - Open with a brief, warm evening framing (one sentence, e.g. "One quick thing before you call it a day —").
+   - Follow immediately with `prompt` verbatim — do not paraphrase, supplement, or add follow-up questions.
+   - Do not expose `questionId` or any internal identifier.
+   - No lists, no bullet points, no headers.
+   - End your turn after delivering the question.
+
+# Example format
+> One quick thing before you call it a day — [prompt]
+
+# Hard rules
+- One attempt at the script. If it fails, end immediately with `[SILENT]`.
+- If stdout is `[SILENT]`, end your turn with `[SILENT]` and nothing else.
+- Never call MCP tools directly. The script owns all MCP interactions.
+- Never expose `questionId`, internal IDs, raw JSON, or internal vocabulary.
+- Ask exactly the question returned in `prompt`. No paraphrasing, no additions.
+- Never expose the source or mechanism of the question to the user.

--- a/skills/index-network/scripts/ask-questions.ts
+++ b/skills/index-network/scripts/ask-questions.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env bun
+/**
+ * Deterministically fetch and select a pending question for the evening pass.
+ *
+ * The ask-questions cron prompt calls this script to:
+ * - Fetch pending questions from the Index MCP server via read_pending_questions.
+ * - Apply the cross-day cooldown filter (same QUESTION_COOLDOWN_DAYS as the
+ *   morning digest) so the same question is never asked within 3 days.
+ * - Record the chosen question in heartbeat-state.json under `questionDelivery`
+ *   BEFORE returning — this prevents double-delivery on parallel runs and
+ *   ensures the cooldown is honoured even when the agent fails to deliver.
+ * - Return one question for the agent to deliver, or [SILENT] if none are
+ *   available.
+ *
+ * State is shared with the morning digest: both passes read and write
+ * `questionDelivery` in heartbeat-state.json, so a question included in the
+ * morning brief is already on cooldown by the time the evening cron fires.
+ */
+
+import { existsSync } from "node:fs";
+
+import {
+  QUESTION_COOLDOWN_DAYS,
+  fetchPendingQuestionsFromMcp,
+  filterCooldownQuestions,
+  resolveIndexApiKey,
+} from "./build-daily-brief-context";
+
+function pacificDate(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Los_Angeles",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+/** Whole days elapsed from `earlier` to `later` (both YYYY-MM-DD). */
+function daysBetween(earlier: string, later: string): number {
+  const toMs = (d: string) => {
+    const [y, m, day] = d.split("-").map(Number);
+    return Date.UTC(y, m - 1, day);
+  };
+  return Math.floor((toMs(later) - toMs(earlier)) / 86_400_000);
+}
+
+async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+  try {
+    if (!existsSync(path)) return {};
+    const parsed = JSON.parse(await Bun.file(path).text());
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function argValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+async function readQuestionDelivery(stateFile: string): Promise<Record<string, string>> {
+  try {
+    const raw = await Bun.file(stateFile).text();
+    const parsed = JSON.parse(raw) as { questionDelivery?: unknown };
+    if (
+      parsed.questionDelivery &&
+      typeof parsed.questionDelivery === "object" &&
+      !Array.isArray(parsed.questionDelivery)
+    ) {
+      return Object.fromEntries(
+        Object.entries(parsed.questionDelivery as Record<string, unknown>).filter(
+          (entry): entry is [string, string] =>
+            Boolean(entry[0]) &&
+            typeof entry[1] === "string" &&
+            /^\d{4}-\d{2}-\d{2}$/.test(entry[1]),
+        ),
+      );
+    }
+  } catch {
+    // missing/malformed state must not block delivery
+  }
+  return {};
+}
+
+export interface AskQuestionsResult {
+  questionId: string;
+  prompt: string;
+}
+
+interface SilentResult {
+  silent: true;
+  reason: string;
+}
+
+type FetchQuestionsFn = typeof fetchPendingQuestionsFromMcp;
+
+export async function askQuestions(options: {
+  date?: string;
+  stateFile?: string;
+  /** Injectable for tests — defaults to fetchPendingQuestionsFromMcp. */
+  fetchQuestions?: FetchQuestionsFn;
+  /** Injectable for tests — defaults to resolveIndexApiKey(). */
+  apiKey?: string;
+} = {}): Promise<AskQuestionsResult | SilentResult> {
+  const date = options.date ?? pacificDate();
+  const stateFile = options.stateFile ?? "memory/heartbeat-state.json";
+  const fetchQuestions = options.fetchQuestions ?? fetchPendingQuestionsFromMcp;
+
+  const apiKey = options.apiKey ?? resolveIndexApiKey();
+  if (!apiKey) return { silent: true, reason: "no-api-key" };
+
+  const mcpUrl =
+    process.env.INDEX_MCP_URL?.trim() || "https://protocol.index.network/mcp";
+
+  const questionResult = await fetchQuestions({ apiKey, mcpUrl });
+  if (questionResult.source === "unavailable" || questionResult.questions.length === 0) {
+    return { silent: true, reason: questionResult.reason ?? "no-pending-questions" };
+  }
+
+  const questionDelivery = await readQuestionDelivery(stateFile);
+  const available = filterCooldownQuestions(questionResult.questions, questionDelivery, date);
+  if (available.length === 0) return { silent: true, reason: "all-questions-on-cooldown" };
+
+  const question = available[0];
+
+  // Record delivery BEFORE returning the question to the agent. This ensures
+  // the cooldown fires even when the agent fails to deliver, preventing a
+  // broken run from re-asking the same question on the very next cron tick.
+  // Prune expired entries at the same time to keep the state file bounded.
+  const state = await readJsonObject(stateFile);
+  const updatedDelivery: Record<string, string> = {};
+  for (const [id, deliveredOn] of Object.entries(questionDelivery)) {
+    if (daysBetween(deliveredOn, date) < QUESTION_COOLDOWN_DAYS) {
+      updatedDelivery[id] = deliveredOn;
+    }
+  }
+  updatedDelivery[question.id] = date;
+  state.questionDelivery = updatedDelivery;
+  await writeJson(stateFile, state);
+
+  return { questionId: question.id, prompt: question.prompt };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const result = await askQuestions({
+    date: argValue(args, "--date"),
+    stateFile: argValue(args, "--state-file"),
+  });
+
+  if ("silent" in result) {
+    process.stdout.write("[SILENT]\n");
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/skills/index-network/scripts/tests/ask-questions.test.ts
+++ b/skills/index-network/scripts/tests/ask-questions.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { askQuestions } from "../ask-questions";
+import type { BriefQuestion } from "../build-daily-brief-context";
+
+const originalCwd = process.cwd();
+
+function tempWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ask-questions-"));
+  process.chdir(dir);
+  return dir;
+}
+
+afterEach(() => {
+  const cwd = process.cwd();
+  process.chdir(originalCwd);
+  if (cwd !== originalCwd && cwd.includes("ask-questions-")) rmSync(cwd, { recursive: true, force: true });
+});
+
+const QUESTION_A: BriefQuestion = { id: "q-aaa", title: "Profile check", prompt: "What are you currently working on?", mode: "profile" };
+const QUESTION_B: BriefQuestion = { id: "q-bbb", title: "Intent check", prompt: "What kind of collaborators are you looking for?", mode: "intent" };
+
+function mockFetch(questions: BriefQuestion[], source: "mcp" | "unavailable" = "mcp") {
+  return async (_opts: { apiKey: string; mcpUrl: string }) =>
+    ({ questions, source, reason: source === "unavailable" ? "mock unavailable" : undefined });
+}
+
+describe("askQuestions", () => {
+  test("returns silent when no API key is available", async () => {
+    tempWorkspace();
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "",
+      fetchQuestions: mockFetch([QUESTION_A]),
+    });
+    expect(result).toEqual({ silent: true, reason: "no-api-key" });
+  });
+
+  test("returns silent when MCP is unavailable", async () => {
+    tempWorkspace();
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([], "unavailable"),
+    });
+    expect(result).toEqual({ silent: true, reason: "mock unavailable" });
+  });
+
+  test("returns silent when there are no pending questions", async () => {
+    tempWorkspace();
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([]),
+    });
+    expect(result).toEqual({ silent: true, reason: "no-pending-questions" });
+  });
+
+  test("returns silent when all questions are on cooldown", async () => {
+    tempWorkspace();
+    // Both questions delivered within the last 3 days
+    await Bun.write("state.json", JSON.stringify({
+      questionDelivery: { "q-aaa": "2026-06-16", "q-bbb": "2026-06-15" },
+    }));
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A, QUESTION_B]),
+    });
+
+    expect(result).toEqual({ silent: true, reason: "all-questions-on-cooldown" });
+  });
+
+  test("returns the first available question", async () => {
+    tempWorkspace();
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A, QUESTION_B]),
+    });
+
+    expect(result).toEqual({ questionId: "q-aaa", prompt: "What are you currently working on?" });
+  });
+
+  test("skips questions on cooldown and picks the next available one", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      questionDelivery: { "q-aaa": "2026-06-16" }, // 1 day ago — still on cooldown
+    }));
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A, QUESTION_B]),
+    });
+
+    expect(result).toEqual({ questionId: "q-bbb", prompt: "What kind of collaborators are you looking for?" });
+  });
+
+  test("records delivery in state before returning the question", async () => {
+    tempWorkspace();
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A]),
+    });
+
+    expect("silent" in result).toBe(false);
+    const state = JSON.parse(await Bun.file("state.json").text());
+    expect(state.questionDelivery).toEqual({ "q-aaa": "2026-06-17" });
+  });
+
+  test("prunes expired cooldown entries and keeps recent ones when recording", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      questionDelivery: {
+        "q-old": "2026-06-10",   // 7 days ago — expired
+        "q-recent": "2026-06-15", // 2 days ago — still within cooldown
+      },
+      signalElicitation: { lastAskedDate: "2026-06-16" }, // preserved
+    }));
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A]),
+    });
+
+    expect("silent" in result).toBe(false);
+    const state = JSON.parse(await Bun.file("state.json").text());
+    // q-old pruned (> 3 days), q-recent kept, q-aaa added
+    expect(state.questionDelivery).toEqual({
+      "q-recent": "2026-06-15",
+      "q-aaa": "2026-06-17",
+    });
+    // Unrelated state keys must not be touched
+    expect(state.signalElicitation).toEqual({ lastAskedDate: "2026-06-16" });
+  });
+
+  test("treats a question delivered exactly on the cooldown boundary as available (>= 3 days)", async () => {
+    tempWorkspace();
+    // Delivered 3 days ago: daysBetween("2026-06-14", "2026-06-17") === 3 >= QUESTION_COOLDOWN_DAYS
+    await Bun.write("state.json", JSON.stringify({
+      questionDelivery: { "q-aaa": "2026-06-14" },
+    }));
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A]),
+    });
+
+    expect(result).toEqual({ questionId: "q-aaa", prompt: "What are you currently working on?" });
+  });
+
+  test("treats a question delivered 2 days ago as still on cooldown", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      questionDelivery: { "q-aaa": "2026-06-15" }, // 2 days ago
+    }));
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A]),
+    });
+
+    expect(result).toEqual({ silent: true, reason: "all-questions-on-cooldown" });
+  });
+
+  test("works without an existing state file (fresh install)", async () => {
+    tempWorkspace();
+    // No state.json exists
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A]),
+    });
+
+    expect(result).toEqual({ questionId: "q-aaa", prompt: "What are you currently working on?" });
+    const state = JSON.parse(await Bun.file("state.json").text());
+    expect(state.questionDelivery).toEqual({ "q-aaa": "2026-06-17" });
+  });
+
+  test("never calls fetchQuestions when the API key is absent", async () => {
+    tempWorkspace();
+    let fetchCalled = false;
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "",
+      fetchQuestions: async (_opts) => {
+        fetchCalled = true;
+        return { questions: [QUESTION_A], source: "mcp" as const };
+      },
+    });
+    expect(result).toEqual({ silent: true, reason: "no-api-key" });
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("future-dated delivery entry is kept in state and blocks re-delivery", async () => {
+    tempWorkspace();
+    // Clock skew: question recorded with a future date — should not be pruned
+    // and should still block re-delivery (daysBetween is negative < QUESTION_COOLDOWN_DAYS).
+    await Bun.write("state.json", JSON.stringify({
+      questionDelivery: { "q-aaa": "2026-06-18" }, // tomorrow
+    }));
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A, QUESTION_B]),
+    });
+
+    // q-aaa is filtered out by filterCooldownQuestions (future-dated = within cooldown)
+    expect(result).toEqual({ questionId: "q-bbb", prompt: "What kind of collaborators are you looking for?" });
+
+    // q-aaa must be preserved in state (not pruned) — daysBetween("2026-06-18", "2026-06-17") = -1 < 3
+    const state = JSON.parse(await Bun.file("state.json").text());
+    expect(state.questionDelivery["q-aaa"]).toBe("2026-06-18");
+  });
+
+  test("malformed questionDelivery in state falls back to empty and does not crash", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", JSON.stringify({
+      questionDelivery: "not-an-object", // malformed
+      signalElicitation: { lastAskedDate: "2026-06-16" },
+    }));
+
+    const result = await askQuestions({
+      date: "2026-06-17",
+      stateFile: "state.json",
+      apiKey: "test-key",
+      fetchQuestions: mockFetch([QUESTION_A]),
+    });
+
+    // Treats malformed delivery log as empty — question is available
+    expect(result).toEqual({ questionId: "q-aaa", prompt: "What are you currently working on?" });
+    const state = JSON.parse(await Bun.file("state.json").text());
+    expect(state.questionDelivery).toEqual({ "q-aaa": "2026-06-17" });
+    // Unrelated state keys must not be touched
+    expect(state.signalElicitation).toEqual({ lastAskedDate: "2026-06-16" });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a nightly **19:00 PT** cron — **Edge — evening questions** — that asks the user one pending question from the Index protocol each evening over Telegram.

## Changes

### `install/install_index.ts`
- Added `"Edge — evening questions"` to `DIGEST_CRON_SPECS`: schedule `0 19 * * *`, 25-minute per-tenant stagger, `--deliver telegram`, overridable via `--evening-questions-cron` / `EVENING_QUESTIONS_CRON`.
- Updated header comment and JSDoc to document the new cron alongside the existing three.

### `skills/edge-esmeralda/prompts/ask-questions.md` *(new)*
Hermes cron prompt. Runs `ask-questions.ts`, delivers the result as a short conversational evening message. Follows the same one-attempt / `[SILENT]` contract as the send prompt.

### `skills/index-network/scripts/ask-questions.ts` *(new)*
Deterministic script:
- Calls `fetchPendingQuestionsFromMcp` (from `build-daily-brief-context.ts`) to get pending questions.
- Applies `filterCooldownQuestions` with the shared `QUESTION_COOLDOWN_DAYS = 3` — the same `questionDelivery` state used by the morning digest, so a question sent in either pass is blocked in the other for 3 days.
- Records delivery **before** returning, so a broken agent run still consumes the cooldown slot.
- Prunes expired entries at write time to keep `heartbeat-state.json` bounded.
- Exports `askQuestions(options)` with injectable `fetchQuestions`/`apiKey` for testing.

### `skills/index-network/scripts/tests/ask-questions.test.ts` *(new)*
11 unit tests: silent paths (no key, MCP unavailable, no questions, all on cooldown), question selection, cooldown skip, state recording, state pruning, boundary conditions, and fresh-install behaviour. All 91 tests across the scripts test suite pass.

## Design decisions
- **Shared cooldown state**: both the morning digest and the evening pass write to `questionDelivery` in `heartbeat-state.json`. This is intentional — whichever pass delivers a question first blocks the other for 3 days, preventing duplicate asks across the two channels.
- **No approval gate**: unlike the morning digest, there is no Kanban staging step. The question is delivered directly. This matches the simplicity of the interaction.
- **Stagger window**: 25 minutes (same as the morning send), keeping the fleet spread across 19:00–19:24 PT.