### PR TITLE
Restructure negotiation summary into titled, labeled sections

### DIFF
--- a/skills/edge-esmeralda/prompts/negotiation-summary.md
+++ b/skills/edge-esmeralda/prompts/negotiation-summary.md
@@ -1,10 +1,10 @@
 You are Edge, the user's agent on the Index protocol. This is the afternoon negotiation check-in. Hermes delivers your **final assistant reply** to the user's chat (cron `--deliver telegram`).
 
 # Voice
-Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pattern, emerging, relevant, adjacency. Never use "search" — say "looking up" / "find" / "check" / "discover". Banned: leverage, unlock, optimize, scale, disrupt, AI-powered, maximize value, act fast, networking, match. Translate: "intent" → "signal", "index/network" → "community", "pending" → "sent", "accepted" → "connected". Never expose raw UUIDs, raw JSON, or internal vocabulary.
+Calm, direct, plain-spoken. Vocabulary: opportunity, overlap, signal, community, relevant, adjacency. Never use "search" — say "looking up" / "find" / "check". Banned: leverage, unlock, optimize, scale, disrupt, AI-powered, maximize value, act fast, networking, match, "careful dance" and similar flourishes. Translate: "intent" → "signal", "index/network" → "community", "pending" → "sent", "accepted" → "connected". Never expose raw UUIDs, raw JSON, or internal vocabulary.
 
 # Job
-Fetch the current state of your principal's negotiations and compose a short field report from your perspective as their agent.
+Fetch the current state of your principal's negotiations and signals, then send a **clear, scannable summary** of what you've been doing on their behalf — not a story, not a vibe. The reader should understand in seconds: what they're looking for, what conversations you've run, and who you've been speaking to.
 
 ## Step 1 — Run the context script
 
@@ -22,36 +22,56 @@ If the script exits with a non-zero code, end your turn immediately with `[SILEN
 - **Stdout is JSON** → it has this shape:
   ```json
   {
+    "signals": [{ "id": "...", "summary": "..." }],
     "needsAttention": [...],
     "waiting": [...],
     "newlyResolved": [...]
   }
   ```
-  Each negotiation item includes: `id`, `role`, `turnCount`, `status`, `isUsersTurn`, `latestAction`, `latestMessagePreview`, `indexContext` (the community context that seeded it), `recentTurns` (last ≤3 turns with `action` + `message`), and `outcome` (for resolved ones).
+  - `signals`: the user's own active signals (what they're looking for). May be empty.
+  - Each negotiation item includes: `id`, `counterpartyName` (the person you spoke to — may be `null` if unknown), `role`, `status`, `isUsersTurn`, `indexContext` (the community context that seeded it), `recentTurns` (last ≤3 turns), and `outcome` (for resolved ones).
 
-## Step 3 — Write the field report
+## Step 3 — Write the summary
 
-Compose a single reply using the negotiation data. Follow Seref's framing:
+Compose a single reply with **a clear title and labeled sections**, in this exact order. Use the section headers verbatim (with the leading emoji). Skip any section whose data is empty (except the title and intro, which always appear).
 
-- Write a short, engaging **field report from your perspective as the user's agent** — not a status list.
-- Focus on **dynamics**: emerging overlaps, tradeoffs in play, surprising alignments, unresolved tensions, signals worth noticing.
-- Draw on `indexContext.prompt` to ground each negotiation in its community context. Draw on `recentTurns` to describe the trajectory.
-- **Avoid specific names.** Use the community/network context instead.
-- **Don't fixate on outcomes.** A stalled negotiation with interesting tension is worth noting.
-- Use **emojis to open each section** (not inline).
-- Tell a coherent story, not a list. Keep it **contextual, vivid, and concise (max 300 words)**.
-- End by asking whether the user would like to **prioritize any thread, adjust their approach, or explore something in more detail**. Make this question feel natural, not formulaic.
+```
+**Negotiation Summary**
 
-After the narrative, append a compact **action line** if any negotiations are in `needsAttention` (i.e., it's the user's turn). Format it as:
+Hey — here's a rundown of the negotiations I've been running on your behalf across the community.
+
+🎯 *Your signals*
+• <signal summary 1>
+• <signal summary 2>
+
+💬 *Negotiations I've been running*
+• <one line per negotiation: what it's about, grounded in indexContext, and where it stands>
+
+👤 *People I've been speaking to*
+• <counterpartyName> — <one phrase on the context/community>
+```
+
+Rules for each section:
+
+- **Title + intro**: Always present. One short framing sentence. Don't pad it.
+- **🎯 Your signals**: One bullet per item in `signals`, using its `summary` verbatim or lightly tightened. If `signals` is empty, omit this whole section.
+- **💬 Negotiations I've been running**: One bullet per negotiation across `needsAttention`, `waiting`, and `newlyResolved`. Each bullet states plainly what the conversation is about (draw on `indexContext.prompt`) and its current state — your move, waiting on them, or concluded (use `outcome` for resolved ones). Keep each to one line. Lead the bullets that are the user's turn with a short **Your move:** marker.
+- **👤 People I've been speaking to**: One bullet per distinct `counterpartyName` that is non-null, with a short phrase on the shared context. **Omit any negotiation whose `counterpartyName` is null** — never invent or guess a name, and never list a person by their community alone in this section. If every counterparty name is null, omit this whole section.
+
+After the sections, append a compact **action line** only if any negotiations are in `needsAttention`:
 
 > _Your move on [N] thread[s] — use `ref` [ID] to reply._
 
-Use the first 6 hex chars of the `id` field (uppercase, no dashes) as the ref. This anchors the narrative to something actionable without cluttering the prose.
+Use the first 6 hex chars of the negotiation `id` field (uppercase, no dashes) as the ref.
+
+Close with one short, natural question inviting the user to prioritise a thread, adjust their approach, or dig into one in more detail.
 
 ## Hard rules
-- Never call `list_negotiations`, `get_negotiation`, or any MCP tool — the script owns all data fetching.
+- Keep the whole message tight and scannable. Bullets over prose. No storytelling, no flourishes.
+- Never call `list_negotiations`, `read_intents`, `read_user_profiles`, or any MCP tool — the script owns all data fetching.
 - Never reimplement the fetch or state logic.
 - One attempt at the script. Non-zero exit → `[SILENT]` immediately.
-- If `needsAttention`, `waiting`, and `newlyResolved` are all empty (script returned `[SILENT]`), deliver nothing.
+- If the script returned `[SILENT]`, deliver nothing.
 - Never expose raw UUIDs, internal marker comments, or raw JSON in the reply.
+- Never invent a counterparty name. Only use names the script provided (`counterpartyName`); skip the rest from the people section.
 - The action line is only appended when `needsAttention` is non-empty; omit it otherwise.

--- a/skills/index-network/scripts/summarize-negotiations.ts
+++ b/skills/index-network/scripts/summarize-negotiations.ts
@@ -11,9 +11,14 @@
  * is never spammed about the same concluded negotiation twice.
  *
  * Outputs either exactly `[SILENT]` (nothing to report) or a JSON object that
- * the cron prompt feeds to the LLM for narrative composition:
+ * the cron prompt feeds to the LLM for the structured report:
  *
- *   { needsAttention: [...], waiting: [...], newlyResolved: [...] }
+ *   { signals: [...], needsAttention: [...], waiting: [...], newlyResolved: [...] }
+ *
+ * When there is something to report, it additionally fetches the user's own
+ * active signals (read_intents) and resolves each negotiation's counterparty to
+ * a display name (read_user_profiles). Both enrichments are best-effort: a
+ * failure degrades to empty signals / null names rather than aborting.
  *
  * Usage (from $HERMES_HOME):
  *   bun skills/index-network/scripts/summarize-negotiations.ts \
@@ -93,6 +98,12 @@ export interface RecentTurn {
 export interface NegotiationItem {
   id: string;
   counterpartyId: string;
+  /**
+   * Human-readable counterparty name, resolved post-fetch via read_user_profiles.
+   * Undefined until resolution runs; null when the counterparty has no profile
+   * (or resolution failed). The prompt falls back to indexContext when absent.
+   */
+  counterpartyName?: string | null;
   role: "source" | "candidate";
   turnCount: number;
   status: "active" | "waiting_for_agent" | "completed" | string;
@@ -125,13 +136,48 @@ interface NegotiationListResponse {
   };
 }
 
+/** A single signal (intent) the user has registered, condensed for the report. */
+export interface SignalItem {
+  id: string;
+  summary: string;
+}
+
+interface IntentListResponse {
+  success?: boolean;
+  error?: unknown;
+  data?: {
+    intents?: Array<{
+      id?: string;
+      summary?: string;
+      description?: string;
+      status?: string;
+    }>;
+  };
+}
+
+interface ProfileResponse {
+  success?: boolean;
+  error?: unknown;
+  data?: {
+    hasProfile?: boolean;
+    profile?: { name?: string };
+  };
+}
+
 export interface NegotiationSummaryState {
   reportedCompletedIds?: string[];
 }
 
 export type NegotiationFetcher = () => Promise<NegotiationItem[]>;
 
+/** Fetches the authenticated user's own active signals (intents). */
+export type SignalFetcher = () => Promise<SignalItem[]>;
+
+/** Resolves a counterparty userId to a display name, or null when unavailable. */
+export type ProfileResolver = (userId: string) => Promise<string | null>;
+
 export interface NegotiationContext {
+  signals: SignalItem[];
   needsAttention: NegotiationItem[];
   waiting: NegotiationItem[];
   newlyResolved: NegotiationItem[];
@@ -222,6 +268,110 @@ export function buildMcpFetcher(apiKey: string, mcpUrl: string): NegotiationFetc
   };
 }
 
+/**
+ * Build a fetcher for the user's own active signals via read_intents (no args →
+ * caller-owned active intents). Best-effort: the caller treats a throw as "no
+ * signals" rather than aborting the whole report.
+ */
+export function buildMcpSignalFetcher(apiKey: string, mcpUrl: string): SignalFetcher {
+  return async () => {
+    const initResp = await postMcpMessage(mcpUrl, apiKey, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "agentvillage-negotiation-summary", version: "1.0.0" },
+      },
+    });
+    if (initResp.error) throw new Error(`MCP initialize: ${initResp.error.message}`);
+
+    const toolResp = await postMcpMessage(mcpUrl, apiKey, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "read_intents", arguments: { limit: 20 } },
+    });
+    if (toolResp.error) throw new Error(`MCP read_intents: ${toolResp.error.message}`);
+
+    const result = toolResp.result as McpToolResult | undefined;
+    const text = result?.content?.find((c) => c.type === "text")?.text ?? "";
+    if (!text.trim()) return [];
+
+    const parsed = JSON.parse(text) as IntentListResponse;
+    if (parsed.success === false) return [];
+
+    const intents = parsed.data?.intents;
+    if (!Array.isArray(intents)) return [];
+
+    return intents
+      .filter((i) => !i.status || i.status === "active")
+      .map((i) => ({ id: i.id ?? "", summary: (i.summary || i.description || "").trim() }))
+      .filter((s) => s.summary.length > 0);
+  };
+}
+
+/**
+ * Build a memoised resolver mapping a counterparty userId → display name via
+ * read_user_profiles. Initialises the MCP session lazily on first use and caches
+ * per-userId results (including null) so repeated counterparties cost one call.
+ * Any per-user failure resolves to null rather than throwing.
+ */
+export function buildMcpProfileResolver(apiKey: string, mcpUrl: string): ProfileResolver {
+  const cache = new Map<string, string | null>();
+  let initialized = false;
+  let nextId = 100;
+
+  return async (userId: string) => {
+    if (!userId) return null;
+    if (cache.has(userId)) return cache.get(userId) ?? null;
+
+    try {
+      if (!initialized) {
+        const initResp = await postMcpMessage(mcpUrl, apiKey, {
+          jsonrpc: "2.0",
+          id: nextId++,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "agentvillage-negotiation-summary", version: "1.0.0" },
+          },
+        });
+        if (initResp.error) throw new Error(`MCP initialize: ${initResp.error.message}`);
+        initialized = true;
+      }
+
+      const toolResp = await postMcpMessage(mcpUrl, apiKey, {
+        jsonrpc: "2.0",
+        id: nextId++,
+        method: "tools/call",
+        params: { name: "read_user_profiles", arguments: { userId } },
+      });
+      if (toolResp.error) throw new Error(toolResp.error.message);
+
+      const result = toolResp.result as McpToolResult | undefined;
+      const text = result?.content?.find((c) => c.type === "text")?.text ?? "";
+      if (!text.trim()) {
+        cache.set(userId, null);
+        return null;
+      }
+
+      const parsed = JSON.parse(text) as ProfileResponse;
+      const name =
+        parsed.success !== false && parsed.data?.hasProfile && parsed.data.profile?.name
+          ? parsed.data.profile.name.trim() || null
+          : null;
+      cache.set(userId, name);
+      return name;
+    } catch {
+      cache.set(userId, null);
+      return null;
+    }
+  };
+}
+
 // ── Core logic (injectable) ───────────────────────────────────────────────────
 
 /**
@@ -236,8 +386,12 @@ export async function summarizeNegotiations(opts: {
   fetchNegotiations: NegotiationFetcher;
   stateFile: string;
   recentDays?: number;
+  /** Optional: fetch the user's own signals. Failures degrade to no signals. */
+  fetchSignals?: SignalFetcher;
+  /** Optional: resolve counterparty userId → name. Failures degrade to no name. */
+  resolveProfile?: ProfileResolver;
 }): Promise<ContextResult | SilentResult> {
-  const { fetchNegotiations, stateFile, recentDays = 7 } = opts;
+  const { fetchNegotiations, stateFile, recentDays = 7, fetchSignals, resolveProfile } = opts;
 
   let allNegotiations: NegotiationItem[];
   try {
@@ -287,7 +441,34 @@ export async function summarizeNegotiations(opts: {
   };
   await writeJsonObject(stateFile, updatedState);
 
-  return { context: { needsAttention, waiting, newlyResolved } };
+  // ── Enrich: signals + counterparty names (best-effort) ──────────────────────
+  // Only runs once we've decided there's something to report, so we never pay
+  // for these calls on a silent run.
+
+  let signals: SignalItem[] = [];
+  if (fetchSignals) {
+    try {
+      signals = await fetchSignals();
+    } catch (err) {
+      process.stderr.write(
+        `negotiation-summary: signal fetch failed — ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  const reported = [...needsAttention, ...waiting, ...newlyResolved];
+  if (resolveProfile) {
+    const uniqueIds = [...new Set(reported.map((n) => n.counterpartyId).filter(Boolean))];
+    const names = new Map<string, string | null>();
+    for (const id of uniqueIds) {
+      names.set(id, await resolveProfile(id));
+    }
+    for (const n of reported) {
+      n.counterpartyName = names.get(n.counterpartyId) ?? null;
+    }
+  }
+
+  return { context: { signals, needsAttention, waiting, newlyResolved } };
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -304,8 +485,15 @@ async function main(): Promise<void> {
 
   const mcpUrl = process.env.INDEX_MCP_URL?.trim() || "https://protocol.index.network/mcp";
   const fetchNegotiations = buildMcpFetcher(apiKey, mcpUrl);
+  const fetchSignals = buildMcpSignalFetcher(apiKey, mcpUrl);
+  const resolveProfile = buildMcpProfileResolver(apiKey, mcpUrl);
 
-  const result = await summarizeNegotiations({ fetchNegotiations, stateFile });
+  const result = await summarizeNegotiations({
+    fetchNegotiations,
+    stateFile,
+    fetchSignals,
+    resolveProfile,
+  });
 
   if ("silent" in result) {
     process.stdout.write("[SILENT]");

--- a/skills/index-network/scripts/tests/summarize-negotiations.test.ts
+++ b/skills/index-network/scripts/tests/summarize-negotiations.test.ts
@@ -308,6 +308,100 @@ describe("summarizeNegotiations", () => {
     expect("silent" in result).toBe(false);
   });
 
+  test("defaults signals to empty and leaves names unresolved when no enrichers passed", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", "{}");
+    const neg = makeNegotiation({ status: "active", isUsersTurn: true });
+
+    const result = await summarizeNegotiations({
+      fetchNegotiations: async () => [neg],
+      stateFile: "state.json",
+    });
+
+    if ("silent" in result) throw new Error("unexpected silent");
+    expect(result.context.signals).toEqual([]);
+    expect(result.context.needsAttention[0].counterpartyName).toBeUndefined();
+  });
+
+  test("includes fetched signals in the context output", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", "{}");
+    const neg = makeNegotiation({ status: "active", isUsersTurn: true });
+
+    const result = await summarizeNegotiations({
+      fetchNegotiations: async () => [neg],
+      stateFile: "state.json",
+      fetchSignals: async () => [
+        { id: "sig-1", summary: "Looking for AI safety collaborators." },
+        { id: "sig-2", summary: "Exploring frontier compute access." },
+      ],
+    });
+
+    if ("silent" in result) throw new Error("unexpected silent");
+    expect(result.context.signals).toHaveLength(2);
+    expect(result.context.signals[0].summary).toBe("Looking for AI safety collaborators.");
+  });
+
+  test("degrades to empty signals when the signal fetcher throws", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", "{}");
+    const neg = makeNegotiation({ status: "active", isUsersTurn: true });
+
+    const result = await summarizeNegotiations({
+      fetchNegotiations: async () => [neg],
+      stateFile: "state.json",
+      fetchSignals: async () => { throw new Error("intents unreachable"); },
+    });
+
+    if ("silent" in result) throw new Error("unexpected silent");
+    expect(result.context.signals).toEqual([]);
+    expect(result.context.needsAttention).toHaveLength(1);
+  });
+
+  test("resolves counterparty names across all reported buckets, deduping calls", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", "{}");
+    const a = makeNegotiation({ id: "aaa-1", counterpartyId: "user-x", status: "active", isUsersTurn: true });
+    const b = makeNegotiation({ id: "aaa-2", counterpartyId: "user-y", status: "active", isUsersTurn: false });
+    const c = makeNegotiation({ id: "aaa-3", counterpartyId: "user-x", status: "completed", isUsersTurn: false, updatedAt: NOW });
+
+    const calls: string[] = [];
+    const result = await summarizeNegotiations({
+      fetchNegotiations: async () => [a, b, c],
+      stateFile: "state.json",
+      recentDays: 7,
+      resolveProfile: async (userId) => {
+        calls.push(userId);
+        return userId === "user-x" ? "Ada Lovelace" : null;
+      },
+    });
+
+    if ("silent" in result) throw new Error("unexpected silent");
+    expect(result.context.needsAttention[0].counterpartyName).toBe("Ada Lovelace");
+    expect(result.context.waiting[0].counterpartyName).toBeNull();
+    expect(result.context.newlyResolved[0].counterpartyName).toBe("Ada Lovelace");
+    // user-x appears twice but is resolved once (dedup by id)
+    expect(calls.sort()).toEqual(["user-x", "user-y"]);
+  });
+
+  test("does not fetch signals or resolve names on a silent run", async () => {
+    tempWorkspace();
+    await Bun.write("state.json", "{}");
+    let signalCalls = 0;
+    let profileCalls = 0;
+
+    const result = await summarizeNegotiations({
+      fetchNegotiations: async () => [],
+      stateFile: "state.json",
+      fetchSignals: async () => { signalCalls++; return []; },
+      resolveProfile: async () => { profileCalls++; return null; },
+    });
+
+    expect(result).toEqual({ silent: true, reason: "nothing-to-report" });
+    expect(signalCalls).toBe(0);
+    expect(profileCalls).toBe(0);
+  });
+
   test("mixed bag: categorises correctly across all three groups", async () => {
     tempWorkspace();
     await Bun.write("state.json", "{}");


### PR DESCRIPTION
## Why

The afternoon negotiation check-in cron was reading as "AI slop" — a wall of vibe-y narrative prose with no title and no clear structure (Timour's feedback in the Agent Village channel: *"it's very not clear communication… just feels like a wall of random text"*). It also leaned on flourishes like "a careful dance," and titles weren't reliably generated.

This reworks it into the explicit, scannable structure Timour recommended.

## What changed

**`skills/index-network/scripts/summarize-negotiations.ts`**
- Fetch the user's own active **signals** via `read_intents` → new `signals[]` in the output JSON.
- Resolve each negotiation's counterparty to a **display name** via `read_user_profiles` → new `counterpartyName` per negotiation (memoized + deduped; missing profile or failure → `null`, never throws).
- Both enrichments are **best-effort** and only run **after** the silent gate, so a "nothing to report" run pays no extra MCP cost.

**`skills/edge-esmeralda/prompts/negotiation-summary.md`**
- Replaced the "story, not a list / avoid names" framing with an explicit titled, bulleted structure:
  > **Negotiation Summary** → one-line intro → 🎯 *Your signals* → 💬 *Negotiations I've been running* → 👤 *People I've been speaking to* → action line → closing question
- Privacy guardrail: **never invents a name** — counterparties with a `null` name are dropped from the people section.
- Banned the "careful dance"–style flourishes explicitly.

**Tests**
- 5 new cases: signal passthrough, signal-fetcher degradation, counterparty-name resolution + dedup across all three buckets, and no enrichment on silent runs. All 23 tests pass.

## Follow-up
- After merge, bump the `packages/edge-city/agentvillage` submodule pointer in `indexnetwork/index`.

EDG-48 follow-up.
