### PR TITLE
feat(voice): transcribe inbound Telegram voice notes via OpenRouter audio-in

### DIFF
--- a/install/config.ts
+++ b/install/config.ts
@@ -35,6 +35,25 @@ export function setTerminalCwd(): void {
   console.log(`→ set terminal.cwd to ${home}`);
 }
 
+/**
+ * Disable Hermes auto-transcription so inbound voice notes are handed to the
+ * agent as a cached file path instead of a pre-made transcript. The
+ * `voice-gemini` plugin's `transcribe_voice` tool then transcribes the file via
+ * OpenRouter audio-in (see plugins/voice_gemini). Idempotent.
+ */
+export function disableAutoStt(): void {
+  const doc = readConfig();
+  const stt = { ...((doc.stt as Record<string, unknown>) ?? {}) };
+  if (stt.enabled === false) {
+    console.log("→ stt.enabled already false (voice notes handed to agent as file path)");
+    return;
+  }
+  stt.enabled = false;
+  doc.stt = stt;
+  writeConfig(doc);
+  console.log("→ set stt.enabled to false (voice notes transcribed via transcribe_voice tool)");
+}
+
 /** Ensure hosted cron turns never inherit a provider's enormous output-token default. */
 export function capModelMaxTokens(): void {
   const cap = configuredMaxTokens();

--- a/install/install.ts
+++ b/install/install.ts
@@ -7,7 +7,9 @@
  *   - `SOUL.md` → `$HERMES_HOME/SOUL.md` (identity; overwrites generic Hermes soul)
  *   - `AGENTS.md`, `USER.md` → `$HERMES_HOME/`
  *   - Edge skill bundles → `$HERMES_HOME/skills/{index-network,edgeos,edge-esmeralda,geo-esmeralda}/`
+ *   - Hermes plugins → `$HERMES_HOME/plugins/<name>/` (e.g. voice-gemini)
  *   - `terminal.cwd` in config.yaml → `$HERMES_HOME`
+ *   - `stt.enabled: false` so voice notes reach the agent as a file path
  *   - Index MCP + morning digest cron (`install_index.ts`)
  *   - Geo CLI runtime note (`install_geo.ts`)
  *
@@ -33,11 +35,12 @@ import { execSync } from "node:child_process";
 import { installIndex } from "./install_index";
 import { installEdgeos } from "./install_edgeos";
 import { installGeo } from "./install_geo";
-import { capModelMaxTokens, setTerminalCwd } from "./config";
+import { capModelMaxTokens, disableAutoStt, setTerminalCwd } from "./config";
 import { hermesBin, hermesExecEnv } from "./hermes_cli";
 import {
   EDGE_SKILL_NAMES,
   hermesHome,
+  pluginsDir,
   skillsDir,
   targetWorkspace,
 } from "./paths";
@@ -46,6 +49,7 @@ import { captureWelcomeState, restoreWelcomeState } from "./welcome_state";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const SOURCE_WORKSPACE = join(SCRIPT_DIR, "../workspace");
 const SOURCE_SKILLS = join(SCRIPT_DIR, "../skills");
+const SOURCE_PLUGINS = join(SCRIPT_DIR, "../plugins");
 const TARGET_HOME = targetWorkspace();
 
 function ensureHermesAvailable(): void {
@@ -168,6 +172,26 @@ function copySkillFiles(): void {
   }
 }
 
+function copyPluginFiles(): void {
+  if (!existsSync(SOURCE_PLUGINS)) return;
+
+  const targetPluginsRoot = pluginsDir();
+  if (!existsSync(targetPluginsRoot)) mkdirSync(targetPluginsRoot, { recursive: true });
+
+  let copied = 0;
+  const names: string[] = [];
+  for (const entry of readdirSync(SOURCE_PLUGINS)) {
+    const sourcePath = join(SOURCE_PLUGINS, entry);
+    if (!statSync(sourcePath).isDirectory()) continue;
+    copied += copyTree(sourcePath, join(targetPluginsRoot, entry));
+    names.push(entry);
+  }
+
+  if (copied > 0) {
+    console.log(`→ staged ${copied} files into ${targetPluginsRoot}/{${names.join(",")}}`);
+  }
+}
+
 function restartGateway(): void {
   console.log("→ restarting gateway");
   try {
@@ -196,8 +220,10 @@ function main(): void {
   copySoulFile();
   copyWorkspaceFiles(wipeUser);
   copySkillFiles();
+  copyPluginFiles();
   setTerminalCwd();
   capModelMaxTokens();
+  disableAutoStt();
 
   installIndex();
   installEdgeos();

--- a/install/paths.ts
+++ b/install/paths.ts
@@ -15,6 +15,10 @@ export function skillsDir(): string {
   return join(hermesHome(), "skills");
 }
 
+export function pluginsDir(): string {
+  return join(hermesHome(), "plugins");
+}
+
 /** Skill bundles shipped by this repo (installed into `$HERMES_HOME/skills/<name>/`). */
 export const EDGE_SKILL_NAMES = [
   "index-network",

--- a/install/tests/config.test.ts
+++ b/install/tests/config.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { afterEach, expect, test } from "bun:test";
 import YAML from "yaml";
 
-import { capModelMaxTokens } from "../config";
+import { capModelMaxTokens, disableAutoStt } from "../config";
 
 const ORIGINAL_ENV = {
   HERMES_HOME: process.env.HERMES_HOME,
@@ -68,4 +68,28 @@ test("capModelMaxTokens honors the operator cap override", () => {
   capModelMaxTokens();
 
   expect((readConfig(configPath).model as Record<string, unknown>).max_tokens).toBe(8192);
+});
+
+test("disableAutoStt sets stt.enabled to false on a fresh config", () => {
+  const configPath = withConfig({ model: { default: "google/gemini-3.5-flash" } });
+
+  disableAutoStt();
+
+  expect(readConfig(configPath).stt).toEqual({ enabled: false });
+});
+
+test("disableAutoStt preserves other stt fields", () => {
+  const configPath = withConfig({ stt: { enabled: true, provider: "local" } });
+
+  disableAutoStt();
+
+  expect(readConfig(configPath).stt).toEqual({ enabled: false, provider: "local" });
+});
+
+test("disableAutoStt is idempotent", () => {
+  const configPath = withConfig({ stt: { enabled: false } });
+
+  disableAutoStt();
+
+  expect(readConfig(configPath).stt).toEqual({ enabled: false });
 });

--- a/plugins/voice_gemini/__init__.py
+++ b/plugins/voice_gemini/__init__.py
@@ -1,0 +1,168 @@
+"""voice-gemini — transcribe inbound Telegram voice notes via OpenRouter.
+
+When ``stt.enabled: false`` the Hermes gateway hands the agent a cached path to
+the raw voice attachment instead of a transcript:
+
+    [The user sent a voice message: /home/<user>/.hermes/cache/audio/<hash>.ogg]
+
+This plugin exposes a ``transcribe_voice`` tool the agent calls with that path.
+It base64-encodes the file and sends it to an audio-capable model on OpenRouter
+(default ``google/gemini-3.5-flash`` — the same model/key the fleet already runs
+on) via the ``input_audio`` content type, returning the transcript.
+
+Stdlib-only (urllib) so it carries no dependency beyond the Hermes venv.
+"""
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_MODEL = "google/gemini-3.5-flash"
+REQUEST_TIMEOUT_SECONDS = 90
+
+# Map file extensions to the `format` token OpenRouter's input_audio expects.
+# Telegram voice notes arrive as Opus-in-Ogg (.oga / .ogg).
+_FORMAT_BY_EXT = {
+    ".oga": "ogg",
+    ".ogg": "ogg",
+    ".opus": "ogg",
+    ".mp3": "mp3",
+    ".m4a": "m4a",
+    ".wav": "wav",
+    ".flac": "flac",
+    ".aac": "aac",
+    ".webm": "webm",
+    ".aiff": "aiff",
+}
+
+_TRANSCRIBE_PROMPT = (
+    "Transcribe this voice note verbatim into text. "
+    "Reply with only the transcript and nothing else."
+)
+
+
+def check_requirements() -> bool:
+    """Gate loading: needs the OpenRouter key the model provider already uses."""
+    return bool(os.getenv("OPENROUTER_API_KEY"))
+
+
+def _audio_format(path: str) -> str:
+    _, ext = os.path.splitext(path.lower())
+    return _FORMAT_BY_EXT.get(ext, "ogg")
+
+
+def _err(message: str) -> str:
+    return json.dumps({"success": False, "transcript": "", "error": message})
+
+
+def transcribe_voice(path: str, task_id: str = None) -> str:
+    """Transcribe a cached voice note at ``path`` via OpenRouter audio-in."""
+    del task_id  # not used; accepted for handler-signature parity
+
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        return _err("OPENROUTER_API_KEY is not set")
+
+    if not path or not os.path.isfile(path):
+        return _err(f"audio file not found: {path!r}")
+
+    try:
+        with open(path, "rb") as handle:
+            encoded = base64.b64encode(handle.read()).decode("ascii")
+    except OSError as exc:
+        return _err(f"could not read audio file: {exc}")
+
+    model = os.getenv("VOICE_TRANSCRIBE_MODEL", DEFAULT_MODEL)
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": _TRANSCRIBE_PROMPT},
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": encoded,
+                                "format": _audio_format(path),
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+    request = urllib.request.Request(
+        OPENROUTER_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        return _err(f"openrouter http {exc.code}: {detail}")
+    except (urllib.error.URLError, TimeoutError) as exc:
+        return _err(f"openrouter request failed: {exc}")
+    except json.JSONDecodeError as exc:
+        return _err(f"openrouter returned non-JSON: {exc}")
+
+    try:
+        transcript = body["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
+        return _err(f"unexpected openrouter response shape: {json.dumps(body)[:500]}")
+
+    if isinstance(transcript, list):
+        # Some providers return content parts; concatenate any text parts.
+        transcript = "".join(
+            part.get("text", "") for part in transcript if isinstance(part, dict)
+        )
+
+    return json.dumps(
+        {"success": True, "transcript": (transcript or "").strip(), "model": model}
+    )
+
+
+_SCHEMA = {
+    "name": "transcribe_voice",
+    "description": (
+        "Transcribe a cached inbound voice note (e.g. a Telegram .ogg) to text. "
+        "Call this when an incoming message contains a path to a cached audio "
+        "file (a voice message) instead of text. Pass the absolute file path."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Absolute path to the cached audio file to transcribe.",
+            }
+        },
+        "required": ["path"],
+    },
+}
+
+
+def register(ctx):
+    ctx.register_tool(
+        name="transcribe_voice",
+        toolset="voice",
+        schema=_SCHEMA,
+        handler=lambda args, **kwargs: transcribe_voice(
+            args.get("path", ""), kwargs.get("task_id")
+        ),
+        check_fn=check_requirements,
+        requires_env=["OPENROUTER_API_KEY"],
+        description="Transcribe a cached inbound voice note via OpenRouter audio-in.",
+    )

--- a/plugins/voice_gemini/plugin.yaml
+++ b/plugins/voice_gemini/plugin.yaml
@@ -1,0 +1,8 @@
+name: voice-gemini
+version: 1.0.0
+description: Transcribe inbound Telegram voice notes via Gemini (audio-in) on OpenRouter.
+author: Edge City
+provides_tools:
+  - transcribe_voice
+requires_env:
+  - OPENROUTER_API_KEY

--- a/plugins/voice_gemini/tests/test_transcribe.py
+++ b/plugins/voice_gemini/tests/test_transcribe.py
@@ -1,0 +1,186 @@
+"""Tests for the voice-gemini transcribe_voice tool.
+
+Stdlib unittest only (no pytest dependency). Run from the plugin dir:
+
+    python3 -m unittest discover -s plugins/voice_gemini/tests
+"""
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+# Import the plugin module (its package dir is the parent of tests/).
+PLUGIN_DIR = str(Path(__file__).resolve().parent.parent)
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+import __init__ as plugin  # noqa: E402
+
+
+def _fake_response(payload: dict):
+    """A context-manager stand-in for urllib's urlopen() return value."""
+    body = json.dumps(payload).encode("utf-8")
+    cm = mock.MagicMock()
+    cm.__enter__.return_value = io.BytesIO(body)
+    cm.__exit__.return_value = False
+    return cm
+
+
+class FormatMappingTests(unittest.TestCase):
+    def test_telegram_opus_variants_map_to_ogg(self):
+        for path in ("/x/a.ogg", "/x/a.oga", "/x/a.opus", "/x/A.OGG"):
+            self.assertEqual(plugin._audio_format(path), "ogg")
+
+    def test_known_extensions(self):
+        self.assertEqual(plugin._audio_format("/x/a.mp3"), "mp3")
+        self.assertEqual(plugin._audio_format("/x/a.m4a"), "m4a")
+        self.assertEqual(plugin._audio_format("/x/a.wav"), "wav")
+
+    def test_unknown_extension_defaults_to_ogg(self):
+        self.assertEqual(plugin._audio_format("/x/a.bin"), "ogg")
+
+
+class GuardClauseTests(unittest.TestCase):
+    def test_missing_api_key(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = json.loads(plugin.transcribe_voice("/tmp/whatever.ogg"))
+        self.assertFalse(result["success"])
+        self.assertIn("OPENROUTER_API_KEY", result["error"])
+
+    def test_missing_file(self):
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            result = json.loads(plugin.transcribe_voice("/tmp/nope-not-here.ogg"))
+        self.assertFalse(result["success"])
+        self.assertIn("not found", result["error"])
+
+
+class TranscribeTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="voice-gemini-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.audio = self.tmp / "note.ogg"
+        self.audio.write_bytes(b"fake-opus-bytes")
+
+    def test_success_returns_transcript_and_sends_expected_request(self):
+        captured = {}
+
+        def _fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["headers"] = dict(request.header_items())
+            captured["body"] = json.loads(request.data.decode("utf-8"))
+            captured["timeout"] = timeout
+            return _fake_response(
+                {"choices": [{"message": {"content": "  hello world  "}}]}
+            )
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "secret"}, clear=True):
+            with mock.patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+                result = json.loads(plugin.transcribe_voice(str(self.audio)))
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["transcript"], "hello world")
+        self.assertEqual(result["model"], plugin.DEFAULT_MODEL)
+
+        # Request shape: correct endpoint, auth, and input_audio content part.
+        self.assertEqual(captured["url"], plugin.OPENROUTER_URL)
+        self.assertEqual(captured["headers"].get("Authorization"), "Bearer secret")
+        content = captured["body"]["messages"][0]["content"]
+        audio_part = next(p for p in content if p["type"] == "input_audio")
+        self.assertEqual(audio_part["input_audio"]["format"], "ogg")
+        self.assertTrue(audio_part["input_audio"]["data"])  # base64 present
+
+    def test_model_override_env(self):
+        def _fake_urlopen(request, timeout=None):
+            return _fake_response({"choices": [{"message": {"content": "x"}}]})
+
+        env = {"OPENROUTER_API_KEY": "k", "VOICE_TRANSCRIBE_MODEL": "google/gemini-3-flash-preview"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+                result = json.loads(plugin.transcribe_voice(str(self.audio)))
+        self.assertEqual(result["model"], "google/gemini-3-flash-preview")
+
+    def test_content_parts_list_is_concatenated(self):
+        def _fake_urlopen(request, timeout=None):
+            return _fake_response(
+                {"choices": [{"message": {"content": [
+                    {"type": "text", "text": "part one "},
+                    {"type": "text", "text": "part two"},
+                ]}}]}
+            )
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with mock.patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+                result = json.loads(plugin.transcribe_voice(str(self.audio)))
+        self.assertTrue(result["success"])
+        self.assertEqual(result["transcript"], "part one part two")
+
+    def test_http_error_becomes_error_envelope(self):
+        def _fake_urlopen(request, timeout=None):
+            raise urllib.error.HTTPError(
+                plugin.OPENROUTER_URL, 429, "Too Many Requests", {},
+                io.BytesIO(b'{"error":"rate limited"}'),
+            )
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with mock.patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+                result = json.loads(plugin.transcribe_voice(str(self.audio)))
+        self.assertFalse(result["success"])
+        self.assertIn("429", result["error"])
+
+    def test_network_error_becomes_error_envelope(self):
+        def _fake_urlopen(request, timeout=None):
+            raise urllib.error.URLError("connection refused")
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with mock.patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+                result = json.loads(plugin.transcribe_voice(str(self.audio)))
+        self.assertFalse(result["success"])
+        self.assertIn("failed", result["error"])
+
+    def test_unexpected_shape_becomes_error_envelope(self):
+        def _fake_urlopen(request, timeout=None):
+            return _fake_response({"unexpected": True})
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with mock.patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+                result = json.loads(plugin.transcribe_voice(str(self.audio)))
+        self.assertFalse(result["success"])
+        self.assertIn("unexpected", result["error"])
+
+
+class RegisterContractTests(unittest.TestCase):
+    def test_register_wires_the_tool(self):
+        calls = {}
+
+        class Ctx:
+            def register_tool(self, **kwargs):
+                calls.update(kwargs)
+
+        plugin.register(Ctx())
+        self.assertEqual(calls["name"], "transcribe_voice")
+        self.assertEqual(calls["toolset"], "voice")
+        self.assertEqual(calls["requires_env"], ["OPENROUTER_API_KEY"])
+        self.assertTrue(callable(calls["handler"]))
+        self.assertEqual(calls["schema"]["parameters"]["required"], ["path"])
+
+    def test_handler_forwards_path_argument(self):
+        class Ctx:
+            def register_tool(self, **kwargs):
+                self.handler = kwargs["handler"]
+
+        ctx = Ctx()
+        plugin.register(ctx)
+        with mock.patch.object(plugin, "transcribe_voice", return_value="{}") as spy:
+            ctx.handler({"path": "/a/b.ogg"}, task_id="t1")
+        spy.assert_called_once_with("/a/b.ogg", "t1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -85,6 +85,10 @@ Write things down. Mental notes don't survive restarts.
 
 MCP tools (Index Network, Hermes built-ins) or HTTP recipes in skills (`edgeos/SKILL.md`). Tool descriptions and recipes are authoritative. For rituals, exemplars, and request shapes, read the relevant skill.
 
+## Voice notes
+
+When an incoming message is a voice note, you receive a line with the path to a cached audio file (e.g. `[The user sent a voice message: /…/cache/audio/<hash>.ogg]`) instead of text. Call the `transcribe_voice` tool with that exact path, then respond to the transcript as if the user had typed it. Never echo the raw file path back to the user, and don't ask them to retype their message.
+
 ## Channel formatting
 
 - **Discord / WhatsApp:** no markdown tables; bullet lists.


### PR DESCRIPTION
## What

Adds inbound **user→agent** voice-note transcription for Telegram, routed through **OpenRouter audio-in** on `google/gemini-3.5-flash` — the model the fleet already runs on, so it reuses the existing `OPENROUTER_API_KEY` with no new vendor.

## How it works

1. The installer sets `stt.enabled: false`, so the Hermes gateway hands the agent a cached file path instead of a transcript:
   `[The user sent a voice message: /…/cache/audio/<hash>.ogg]`
2. A new `voice-gemini` Hermes plugin exposes a `transcribe_voice` tool. The agent calls it with that path; the tool base64-encodes the audio and POSTs it to OpenRouter's `/chat/completions` `input_audio` content type, returning the transcript.
3. `AGENTS.md` instructs the agent to call `transcribe_voice` on a cached-audio path and never echo the raw path.

Telegram voice notes are Opus-in-Ogg; OpenRouter accepts `ogg` natively, so **no `ffmpeg` and no transcoding** are needed. Outbound TTS is explicitly out of scope.

## Changes

- `plugins/voice_gemini/{plugin.yaml,__init__.py}` — manifest + stdlib-only (urllib) plugin. Model overridable via `VOICE_TRANSCRIBE_MODEL`.
- `install/config.ts` — `disableAutoStt()` (idempotent, preserves other `stt` fields).
- `install/paths.ts` — `pluginsDir()`.
- `install/install.ts` — `copyPluginFiles()` stages `plugins/*` → `$HERMES_HOME/plugins/`; wires `disableAutoStt()` into `main()`.
- `workspace/AGENTS.md` — "Voice notes" handling section.

## Tests

- **TS:** 35 pass / 0 fail (3 new `disableAutoStt` cases).
- **Python:** 13 pass / 0 fail — stdlib `unittest` (no pytest dep): `python3 -m unittest discover -s plugins/voice_gemini/tests`. Covers format mapping, both guard clauses, success path with request-shape assertions (endpoint, auth header, `input_audio` `format: ogg` + base64), model-override env, content-parts concatenation, all three error envelopes (HTTP/network/bad-shape), and the `register()`/handler-forwarding contract.

## Notes / caveats

- Not literally zero-config: one config flag, the plugin file, and the AGENTS.md nudge — but reuses the existing OpenRouter account.
- Reliable triggering leans on the AGENTS.md instruction since Hermes only passes a path marker, not the audio bytes, to the main turn.
