### PR TITLE
feat(voice): transcribe voice notes via OpenRouter Whisper (command STT provider)

### DIFF
--- a/install/config.ts
+++ b/install/config.ts
@@ -37,24 +37,45 @@ export function setTerminalCwd(): void {
 
 /**
  * Configure Hermes speech-to-text so inbound voice notes are auto-transcribed
- * to text before reaching the agent. Uses Groq Whisper by default (fast, free
- * tier); the gateway reads the `GROQ_API_KEY` env var at runtime. The provider
- * is overridable via `STT_PROVIDER` for operators who prefer openai/local.
+ * to text before reaching the agent.
+ *
+ * Default is `openrouter-whisper`: a `command`-type STT provider that shells out
+ * to install/stt/openrouter_transcribe.py, which transcribes the cached audio
+ * via OpenRouter's /audio/transcriptions endpoint using the tenant's own
+ * OPENROUTER_API_KEY (already in $HERMES_HOME/.env). This reuses the per-tenant
+ * OpenRouter key — no extra vendor key to provision fleet-wide.
+ *
+ * Override with `STT_PROVIDER` (e.g. `groq`, `openai`, `local`) to use a
+ * built-in provider instead; the command block is only written for the
+ * openrouter-whisper default.
  *
  * Note: Hermes v2026.5.16 does NOT hand the agent a raw audio file path when
  * STT is disabled (it just refuses), so a real STT provider is required for
  * voice notes to work. Idempotent.
+ *
+ * @param scriptPath absolute path to openrouter_transcribe.py on disk (passed
+ *   by the installer; defaults to the cloned edge-src location at runtime).
  */
-export function configureStt(): void {
-  const provider = process.env.STT_PROVIDER?.trim() || "groq";
+export function configureStt(scriptPath?: string): void {
+  const provider = process.env.STT_PROVIDER?.trim() || "openrouter-whisper";
   const doc = readConfig();
   const stt = { ...((doc.stt as Record<string, unknown>) ?? {}) };
-  if (stt.enabled === true && stt.provider === provider) {
-    console.log(`→ stt already enabled with provider "${provider}"`);
-    return;
-  }
   stt.enabled = true;
   stt.provider = provider;
+
+  if (provider === "openrouter-whisper") {
+    const script =
+      scriptPath || join(hermesHome(), "edge-src", "install", "stt", "openrouter_transcribe.py");
+    const providers = { ...((stt.providers as Record<string, unknown>) ?? {}) };
+    providers["openrouter-whisper"] = {
+      type: "command",
+      command: `python3 ${script} {input_path} {output_path}`,
+      format: "txt",
+      timeout: 120,
+    };
+    stt.providers = providers;
+  }
+
   doc.stt = stt;
   writeConfig(doc);
   console.log(`→ enabled stt with provider "${provider}" (voice notes auto-transcribed)`);

--- a/install/install.ts
+++ b/install/install.ts
@@ -8,7 +8,7 @@
  *   - `AGENTS.md`, `USER.md` → `$HERMES_HOME/`
  *   - Edge skill bundles → `$HERMES_HOME/skills/{index-network,edgeos,edge-esmeralda,geo-esmeralda}/`
  *   - `terminal.cwd` in config.yaml → `$HERMES_HOME`
- *   - STT enabled with Groq Whisper so voice notes are auto-transcribed
+ *   - STT enabled with OpenRouter Whisper (command provider) for voice notes
  *   - Index MCP + morning digest cron (`install_index.ts`)
  *   - Geo CLI runtime note (`install_geo.ts`)
  *
@@ -199,7 +199,7 @@ function main(): void {
   copySkillFiles();
   setTerminalCwd();
   capModelMaxTokens();
-  configureStt();
+  configureStt(join(SCRIPT_DIR, "stt", "openrouter_transcribe.py"));
 
   installIndex();
   installEdgeos();

--- a/install/stt/openrouter_transcribe.py
+++ b/install/stt/openrouter_transcribe.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""OpenRouter Whisper STT backend for Hermes' command-type STT provider.
+
+Invoked by the gateway as:
+
+    python3 openrouter_transcribe.py <input_audio_path> <output_transcript_path>
+
+Reads the cached inbound voice note, base64-encodes it, and POSTs it to
+OpenRouter's /audio/transcriptions endpoint using the tenant's own
+OPENROUTER_API_KEY (already present in $HERMES_HOME/.env). Writes the plain
+transcript to the output path (Hermes reads it back with `format: txt`).
+
+Stdlib-only (urllib) so it carries no dependency beyond the Hermes image.
+Exits non-zero on failure so Hermes treats the transcription as failed rather
+than injecting a partial/empty transcript.
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/audio/transcriptions"
+DEFAULT_MODEL = "openai/whisper-large-v3-turbo"
+REQUEST_TIMEOUT_SECONDS = 110  # under the provider's 120s command timeout
+
+# Telegram voice notes are Opus-in-Ogg (.oga/.ogg). Map extension -> the
+# `format` token OpenRouter expects.
+_FORMAT_BY_EXT = {
+    ".oga": "ogg",
+    ".ogg": "ogg",
+    ".opus": "ogg",
+    ".mp3": "mp3",
+    ".m4a": "m4a",
+    ".wav": "wav",
+    ".flac": "flac",
+    ".aac": "aac",
+    ".webm": "webm",
+}
+
+
+def _fail(message: str) -> "NoReturn":  # type: ignore[name-defined]
+    sys.stderr.write(f"openrouter_transcribe: {message}\n")
+    sys.exit(1)
+
+
+def _audio_format(path: str) -> str:
+    _, ext = os.path.splitext(path.lower())
+    return _FORMAT_BY_EXT.get(ext, "ogg")
+
+
+def transcribe(input_path: str) -> str:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        _fail("OPENROUTER_API_KEY is not set")
+    if not input_path or not os.path.isfile(input_path):
+        _fail(f"audio file not found: {input_path!r}")
+
+    try:
+        with open(input_path, "rb") as handle:
+            encoded = base64.b64encode(handle.read()).decode("ascii")
+    except OSError as exc:
+        _fail(f"could not read audio file: {exc}")
+
+    model = os.getenv("OPENROUTER_STT_MODEL", DEFAULT_MODEL)
+    payload = json.dumps(
+        {
+            "model": model,
+            "input_audio": {"data": encoded, "format": _audio_format(input_path)},
+        }
+    ).encode("utf-8")
+
+    request = urllib.request.Request(
+        OPENROUTER_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        _fail(f"openrouter http {exc.code}: {detail}")
+    except (urllib.error.URLError, TimeoutError) as exc:
+        _fail(f"openrouter request failed: {exc}")
+    except json.JSONDecodeError as exc:
+        _fail(f"openrouter returned non-JSON: {exc}")
+
+    text = body.get("text") if isinstance(body, dict) else None
+    if not isinstance(text, str):
+        _fail(f"unexpected openrouter response shape: {json.dumps(body)[:300]}")
+    return text.strip()
+
+
+def main(argv: list) -> None:
+    if len(argv) < 3:
+        _fail("usage: openrouter_transcribe.py <input_audio> <output_transcript>")
+    transcript = transcribe(argv[1])
+    try:
+        with open(argv[2], "w", encoding="utf-8") as out:
+            out.write(transcript)
+    except OSError as exc:
+        _fail(f"could not write transcript: {exc}")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/install/stt/tests/test_openrouter_transcribe.py
+++ b/install/stt/tests/test_openrouter_transcribe.py
@@ -1,0 +1,138 @@
+"""Tests for the OpenRouter Whisper STT command backend.
+
+Stdlib unittest only. Run:
+
+    python3 -m unittest discover -s install/stt/tests
+"""
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = str(Path(__file__).resolve().parent.parent)
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+import openrouter_transcribe as ot  # noqa: E402
+
+
+def _fake_response(payload: dict):
+    cm = mock.MagicMock()
+    cm.__enter__.return_value = io.BytesIO(json.dumps(payload).encode("utf-8"))
+    cm.__exit__.return_value = False
+    return cm
+
+
+class FormatTests(unittest.TestCase):
+    def test_telegram_opus_maps_to_ogg(self):
+        for p in ("/x/a.ogg", "/x/a.oga", "/x/a.opus"):
+            self.assertEqual(ot._audio_format(p), "ogg")
+
+    def test_unknown_defaults_to_ogg(self):
+        self.assertEqual(ot._audio_format("/x/a.bin"), "ogg")
+
+
+class TranscribeTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="or-stt-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.audio = self.tmp / "note.ogg"
+        self.audio.write_bytes(b"fake-opus")
+
+    def test_success_returns_text_and_sends_expected_request(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["headers"] = dict(request.header_items())
+            captured["body"] = json.loads(request.data.decode("utf-8"))
+            return _fake_response({"text": "  hello there  "})
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "secret"}, clear=True):
+            with mock.patch.object(ot.urllib.request, "urlopen", fake_urlopen):
+                text = ot.transcribe(str(self.audio))
+
+        self.assertEqual(text, "hello there")
+        self.assertEqual(captured["url"], ot.OPENROUTER_URL)
+        self.assertEqual(captured["headers"].get("Authorization"), "Bearer secret")
+        self.assertEqual(captured["body"]["model"], ot.DEFAULT_MODEL)
+        self.assertEqual(captured["body"]["input_audio"]["format"], "ogg")
+        self.assertTrue(captured["body"]["input_audio"]["data"])
+
+    def test_model_override_env(self):
+        def fake_urlopen(request, timeout=None):
+            return _fake_response({"text": "x"})
+
+        env = {"OPENROUTER_API_KEY": "k", "OPENROUTER_STT_MODEL": "openai/whisper-1"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(ot.urllib.request, "urlopen", fake_urlopen):
+                # capture by re-reading inside a wrapper
+                captured = {}
+
+                def cap(request, timeout=None):
+                    captured["model"] = json.loads(request.data.decode())["model"]
+                    return _fake_response({"text": "x"})
+
+                with mock.patch.object(ot.urllib.request, "urlopen", cap):
+                    ot.transcribe(str(self.audio))
+        self.assertEqual(captured["model"], "openai/whisper-1")
+
+    def test_missing_key_exits_nonzero(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit) as cm:
+                ot.transcribe(str(self.audio))
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_missing_file_exits_nonzero(self):
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with self.assertRaises(SystemExit):
+                ot.transcribe("/tmp/does-not-exist.ogg")
+
+    def test_http_error_exits_nonzero(self):
+        def fake_urlopen(request, timeout=None):
+            raise urllib.error.HTTPError(
+                ot.OPENROUTER_URL, 429, "Too Many Requests", {}, io.BytesIO(b'{"error":"x"}')
+            )
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with mock.patch.object(ot.urllib.request, "urlopen", fake_urlopen):
+                with self.assertRaises(SystemExit):
+                    ot.transcribe(str(self.audio))
+
+    def test_bad_shape_exits_nonzero(self):
+        def fake_urlopen(request, timeout=None):
+            return _fake_response({"unexpected": True})
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with mock.patch.object(ot.urllib.request, "urlopen", fake_urlopen):
+                with self.assertRaises(SystemExit):
+                    ot.transcribe(str(self.audio))
+
+
+class MainTests(unittest.TestCase):
+    def test_main_writes_transcript_to_output(self):
+        tmp = Path(tempfile.mkdtemp(prefix="or-stt-main-"))
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        audio = tmp / "in.ogg"
+        audio.write_bytes(b"audio")
+        out = tmp / "out.txt"
+
+        def fake_urlopen(request, timeout=None):
+            return _fake_response({"text": "transcribed words"})
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "k"}, clear=True):
+            with mock.patch.object(ot.urllib.request, "urlopen", fake_urlopen):
+                ot.main(["prog", str(audio), str(out)])
+
+        self.assertEqual(out.read_text(encoding="utf-8"), "transcribed words")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/install/tests/config.test.ts
+++ b/install/tests/config.test.ts
@@ -71,38 +71,54 @@ test("capModelMaxTokens honors the operator cap override", () => {
   expect((readConfig(configPath).model as Record<string, unknown>).max_tokens).toBe(8192);
 });
 
-test("configureStt enables groq by default on a fresh config", () => {
+test("configureStt writes the openrouter-whisper command provider by default", () => {
   delete process.env.STT_PROVIDER;
   const configPath = withConfig({ model: { default: "google/gemini-3.5-flash" } });
 
-  configureStt();
+  configureStt("/abs/install/stt/openrouter_transcribe.py");
 
-  expect(readConfig(configPath).stt).toEqual({ enabled: true, provider: "groq" });
+  expect(readConfig(configPath).stt).toEqual({
+    enabled: true,
+    provider: "openrouter-whisper",
+    providers: {
+      "openrouter-whisper": {
+        type: "command",
+        command: "python3 /abs/install/stt/openrouter_transcribe.py {input_path} {output_path}",
+        format: "txt",
+        timeout: 120,
+      },
+    },
+  });
 });
 
-test("configureStt flips a disabled stt block to enabled groq", () => {
+test("configureStt flips a disabled stt block to the command provider", () => {
   delete process.env.STT_PROVIDER;
   const configPath = withConfig({ stt: { enabled: false } });
 
-  configureStt();
+  configureStt("/abs/x.py");
 
-  expect(readConfig(configPath).stt).toEqual({ enabled: true, provider: "groq" });
+  const stt = readConfig(configPath).stt as Record<string, unknown>;
+  expect(stt.enabled).toBe(true);
+  expect(stt.provider).toBe("openrouter-whisper");
 });
 
-test("configureStt honors the STT_PROVIDER override", () => {
-  process.env.STT_PROVIDER = "openai";
+test("configureStt honors the STT_PROVIDER override without a command block", () => {
+  process.env.STT_PROVIDER = "groq";
   const configPath = withConfig({});
 
   configureStt();
 
-  expect(readConfig(configPath).stt).toEqual({ enabled: true, provider: "openai" });
+  expect(readConfig(configPath).stt).toEqual({ enabled: true, provider: "groq" });
 });
 
-test("configureStt is idempotent", () => {
+test("configureStt is idempotent for the command provider", () => {
   delete process.env.STT_PROVIDER;
-  const configPath = withConfig({ stt: { enabled: true, provider: "groq" } });
+  const configPath = withConfig({});
 
-  configureStt();
+  configureStt("/abs/x.py");
+  const first = JSON.stringify(readConfig(configPath).stt);
+  configureStt("/abs/x.py");
+  const second = JSON.stringify(readConfig(configPath).stt);
 
-  expect(readConfig(configPath).stt).toEqual({ enabled: true, provider: "groq" });
+  expect(second).toBe(first);
 });


### PR DESCRIPTION
## What

Transcribe inbound Telegram voice notes via **OpenRouter Whisper**, using Hermes' `command`-type STT provider, reusing each tenant's existing **per-tenant `OPENROUTER_API_KEY`**.

## Why this over Groq

The Groq path works but needs a **shared** Groq key provisioned to every sidecar (control-plane change + fleet backfill) and adds a vendor. OpenRouter Whisper reuses the per-tenant key already in `$HERMES_HOME/.env` — **zero fleet key-provisioning, per-tenant billing/limits preserved**. The built-in `openai` STT provider can't target OpenRouter (its `/audio/transcriptions` uses base64-JSON, not OpenAI multipart), so we use the `command` provider, which also avoids any Python-plugin auto-load / `register_transcription_provider` dependency.

## How

```yaml
stt:
  enabled: true
  provider: openrouter-whisper
  providers:
    openrouter-whisper:
      type: command
      command: "python3 <edge-src>/install/stt/openrouter_transcribe.py {input_path} {output_path}"
      format: txt
      timeout: 120
```
`openrouter_transcribe.py` (stdlib only) base64-encodes the cached audio, POSTs to OpenRouter `/audio/transcriptions` (default `openai/whisper-large-v3-turbo`, override `OPENROUTER_STT_MODEL`), writes the transcript, exits non-zero on failure. Provider overridable via `STT_PROVIDER` to fall back to a built-in (groq/openai/local).

## Tests
- `bun test install/tests/` → 36 pass.
- `python3 -m unittest discover -s install/stt/tests` → 9 pass (request shape, model override, all error paths, main writes output).

## Risk
Depends on the `command` STT provider type existing in the deployed `v2026.5.16` image — validated on a single tenant before fleet use; Groq remains the fallback.
