### PR TITLE
feat(digest): surface negotiation-trace link in daily brief (EDG-50/EDG-51)

### DIFF
--- a/skills/edge-esmeralda/prompts/prepare.md
+++ b/skills/edge-esmeralda/prompts/prepare.md
@@ -31,7 +31,8 @@ Also avoid emotional interpretations, status/ambition assumptions, personal-life
 - Use **America/Los_Angeles** for all date boundaries and displayed event times.
 - Render event times from each event's `timePacific` value exactly; do not derive times yourself.
 - Deterministic context comes only from `skills/index-network/scripts/stage-daily-brief.ts --prepare-context`. It builds admin announcements, RSVPs, today's EdgeOS calendar selection, weather, Index people/community cards, pending questions, and compact user-model context. Do not manually re-fetch announcements, RSVPs, calendar, people/community cards, pending questions, or profile context.
-- Use `profileUrl` and `acceptUrl` exactly as provided in the context. Never construct, shorten, or modify URLs.
+- Use `profileUrl`, `acceptUrl`, and `negotiationUrl` exactly as provided in the context. Never construct, shorten, or modify URLs.
+- When a person/community item has a `negotiationUrl`, you may attach it to a short, plain phrase that lets the user see *why* this connection surfaced (for example, link "see how this came up" or "the back-and-forth behind this" to the `negotiationUrl`). Use it at most once per item, only when it strengthens the throughline, and never alongside banned words like "negotiation", "match", or "opportunity" in visible prose. Omit it when absent.
 - Organizer announcements come only from `announcements[]`.
 - Frame the user model as provisional and correctable. Do not infer emotions, personal life, ambitions, needs, or desire for social exposure.
 

--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -136,6 +136,8 @@ export interface BriefOpportunity {
   status?: string;
   profileUrl?: string;
   acceptUrl?: string;
+  /** Deep-link to the A2A negotiation trace that produced this opportunity. */
+  negotiationUrl?: string;
   feedCategory?: string;
   opportunityId?: string;
   confidence?: number;
@@ -452,7 +454,7 @@ export function parseOpportunityTranscript(text: string): BriefOpportunity[] {
       continue;
     }
 
-    const field = line.trim().match(/^(status|profileUrl|acceptUrl|feedCategory|opportunityId|confidence|redelivery):\s*(.+)$/);
+    const field = line.trim().match(/^(status|profileUrl|acceptUrl|negotiationUrl|feedCategory|opportunityId|confidence|redelivery):\s*(.+)$/);
     if (field) {
       const key = field[1] as keyof BriefOpportunity;
       if (key === "confidence") {

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -93,7 +93,7 @@ describe("build-daily-brief-context helpers", () => {
   });
 
   test("parseOpportunityTranscript reads MCP prose cards", () => {
-    const parsed = parseOpportunityTranscript(`Here are your opportunities:\n\n1. Nathan Price\n   <!-- digest-opportunity:id=opp-direct-1 -->\n   builds the intelligence layer for human aging\n   status: pending\n   profileUrl: https://index.network/u/11111111-1111-1111-1111-111111111111\n   acceptUrl: https://index.network/c/abc123\n   feedCategory: connection\n\n2. Remi\n   <!-- digest-opportunity:id=opp-intro-1 -->\n   looking for a systems engineer\n   status: latent\n   profileUrl: https://index.network/u/22222222-2222-2222-2222-222222222222\n   acceptUrl: https://index.network/c/def456\n   feedCategory: connector-flow`);
+    const parsed = parseOpportunityTranscript(`Here are your opportunities:\n\n1. Nathan Price\n   <!-- digest-opportunity:id=opp-direct-1 -->\n   builds the intelligence layer for human aging\n   status: pending\n   profileUrl: https://index.network/u/11111111-1111-1111-1111-111111111111\n   acceptUrl: https://index.network/c/abc123\n   negotiationUrl: https://index.network/chat/99999999-9999-9999-9999-999999999999\n   feedCategory: connection\n\n2. Remi\n   <!-- digest-opportunity:id=opp-intro-1 -->\n   looking for a systems engineer\n   status: latent\n   profileUrl: https://index.network/u/22222222-2222-2222-2222-222222222222\n   acceptUrl: https://index.network/c/def456\n   feedCategory: connector-flow`);
 
     expect(parsed).toEqual([
       {
@@ -103,6 +103,7 @@ describe("build-daily-brief-context helpers", () => {
         status: "pending",
         profileUrl: "https://index.network/u/11111111-1111-1111-1111-111111111111",
         acceptUrl: "https://index.network/c/abc123",
+        negotiationUrl: "https://index.network/chat/99999999-9999-9999-9999-999999999999",
         feedCategory: "connection",
       },
       {

--- a/skills/index-network/scripts/tests/validate-digest-urls.test.ts
+++ b/skills/index-network/scripts/tests/validate-digest-urls.test.ts
@@ -49,6 +49,15 @@ describe("sanitizeDigestUrls", () => {
     expect(stripped).toEqual([]);
   });
 
+  test("preserves a legitimate /chat/<uuid> negotiation-trace link", () => {
+    const md = "[see how this came up](https://index.network/chat/66666666-6666-6666-6666-666666666666?link_preview=false)";
+
+    const { output, stripped } = sanitizeDigestUrls(md);
+
+    expect(output).toBe(md);
+    expect(stripped).toEqual([]);
+  });
+
   test("preserves Edge Esmeralda event links", () => {
     const md = "[GNOSIS Journey](https://edgecity.simplefi.tech/portal/edge-esmeralda-2026/events/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)";
 

--- a/skills/index-network/scripts/validate-digest-urls.ts
+++ b/skills/index-network/scripts/validate-digest-urls.ts
@@ -29,6 +29,8 @@
 const CONNECT_PATH = /^\/c\/[A-Za-z0-9_-]+\/?$/;
 /** Profile link: `/u/<uuid>`, optional trailing slash. */
 const PROFILE_PATH = /^\/u\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/?$/;
+/** Negotiation-trace link: `/chat/<conversationId-uuid>`, optional trailing slash. */
+const CHAT_PATH = /^\/chat\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/?$/;
 /** Edge Esmeralda calendar event link. */
 const EDGE_ESMERALDA_EVENT_PATH = /^\/portal\/edge-esmeralda-2026\/events\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/?$/;
 
@@ -70,6 +72,7 @@ export function isAllowedDigestUrl(url: string): boolean {
   }
   return CONNECT_PATH.test(parsed.pathname)
     || PROFILE_PATH.test(parsed.pathname)
+    || CHAT_PATH.test(parsed.pathname)
     || (parsed.hostname === "edgecity.simplefi.tech" && EDGE_ESMERALDA_EVENT_PATH.test(parsed.pathname));
 }
 


### PR DESCRIPTION
## Summary

Digest-consumer half of EDG-50/EDG-51. The Index protocol now emits a `negotiationUrl` digest marker on opportunity cards (a `/chat/<conversationId>` deep-link to the A2A negotiation trace). This wires the daily brief to carry that link through to the user so they can see *why* a connection surfaced.

Companion to indexnetwork/index PR (protocol-side marker emission + negotiation-grounded digest copy).

## Changes

- **`build-daily-brief-context.ts`** — add `negotiationUrl` to `BriefOpportunity` and the marker field parser.
- **`validate-digest-urls.ts`** — allowlist the `/chat/<uuid>` negotiation-trace path so the sanitizer no longer strips it to plain text (host-agnostic, matching the existing `/c/` and `/u/` rules).
- **`prepare.md`** — let the prepare pass attach the `negotiationUrl` to a short plain phrase ("see how this came up"), at most once per item, without leaking banned words into visible prose.

## Tests
- New cases in `validate-digest-urls.test.ts` (chat link preserved) and `build-daily-brief-context.test.ts` (negotiationUrl parsed).
- 71 affected tests pass.
