### PR TITLE
fix(daypart-prompts): stop reasoning preamble & code fences leaking into delivered cards

### DIFF
--- a/skills/edge-esmeralda/prompts/ask-questions.md
+++ b/skills/edge-esmeralda/prompts/ask-questions.md
@@ -35,6 +35,7 @@ Deliver one pending question to the user in a natural, conversational way.
 > One quick thing before you call it a day — [prompt]
 
 # Hard rules
+- **Output only the brief framing sentence followed by `prompt`.** No preamble, no thinking out loud, no "let me…" drafting, and never wrap the reply in a triple-backtick code fence or any code block. The reply is plain chat text only.
 - One attempt at the script. If it fails, end immediately with `[SILENT]`.
 - If stdout is `[SILENT]`, end your turn with `[SILENT]` and nothing else.
 - Never call MCP tools directly. The script owns all MCP interactions.

--- a/skills/edge-esmeralda/prompts/negotiation-summary.md
+++ b/skills/edge-esmeralda/prompts/negotiation-summary.md
@@ -33,23 +33,23 @@ If the script exits with a non-zero code, end your turn immediately with `[SILEN
 
 ## Step 3 — Write the summary
 
-Compose a single reply with **a clear title and labeled sections**, in this exact order. Use the section headers verbatim (with the leading emoji). Skip any section whose data is empty (except the title and intro, which always appear).
+Compose a single reply with **a clear title and labeled sections**, in this exact order. Use the section headers verbatim (with the leading emoji). Put exactly one blank line between each section. Skip any section whose data is empty (except the title and intro, which always appear).
 
-```
-**Negotiation Summary**
+The template below shows the shape only — it is NOT a code block. Do not wrap your reply in code fences, and do not echo the angle-bracket placeholders. Your reply starts directly with the bold title line:
 
-Hey — here's a rundown of the negotiations I've been running on your behalf across the community.
+    **Negotiation Summary**
 
-🎯 *Your signals*
-• <signal summary 1>
-• <signal summary 2>
+    Hey — here's a rundown of the negotiations I've been running on your behalf across the community.
 
-💬 *Negotiations I've been running*
-• <one line per negotiation: what it's about, grounded in indexContext, and where it stands>
+    🎯 *Your signals*
+    • <signal summary 1>
+    • <signal summary 2>
 
-👤 *People I've been speaking to*
-• <counterpartyName> — <one phrase on the context/community>
-```
+    💬 *Negotiations I've been running*
+    • <one line per negotiation: what it's about, grounded in indexContext, and where it stands>
+
+    👤 *People I've been speaking to*
+    • <counterpartyName> — <one phrase on the context/community>
 
 Rules for each section:
 
@@ -67,6 +67,8 @@ Use the first 6 hex chars of the negotiation `id` field (uppercase, no dashes) a
 Close with one short, natural question inviting the user to prioritise a thread, adjust their approach, or dig into one in more detail.
 
 ## Hard rules
+- **Output ONLY the final message.** No preamble, no thinking out loud, no "Wait, let me…" or "let's complete the list" drafting passes, no restating or pre-listing the people before the answer. The very first characters of your reply must be the `**Negotiation Summary**` title line — nothing may precede it.
+- **Never emit a triple-backtick code fence or any markdown code block** in the reply. The summary is plain chat text with bold/italic headers and bullets only.
 - Keep the whole message tight and scannable. Bullets over prose. No storytelling, no flourishes.
 - Never call `list_negotiations`, `read_intents`, `read_user_contexts`, or any MCP tool — the script owns all data fetching.
 - Never reimplement the fetch or state logic.

--- a/skills/edge-esmeralda/prompts/prepare.md
+++ b/skills/edge-esmeralda/prompts/prepare.md
@@ -123,4 +123,5 @@ cd "${HERMES_HOME:-/opt/data}"
 - Always stage the brief **blocked** for review. It ships only if a human unblocks it before the send pass. Never assign it or move it to Ready.
 - Calendar failures must not block launch: compose from whatever verified context exists. If nothing verified exists, stage a brief pointer saying you couldn't check the live calendar this morning and the user can ask what's on today.
 - Never confirm delivery here. Never write `deliveredToday` here.
+- The composed body is plain brief markdown (prose, bullets, the hidden marker comments). Never wrap it in a triple-backtick code fence or any code block, and never include reasoning or "let me…" drafting text in the body.
 - Never expose internal IDs, raw JSON, internal marker comments, or internal vocabulary in visible prose.


### PR DESCRIPTION
## Problem

The afternoon **negotiation-summary** cron shipped the model's scratch draft on top of the real card. Delivered Telegram messages opened with `Wait, let's complete the list of people:` followed by a literal triple-backtick fence and an unstructured 10-person dump, *then* the actual `**Negotiation Summary**` title / intro / signals. Hermes delivers the whole final assistant message, so the preamble shipped. Reported in-channel as "feels like a wall of text" and "is that an intentional opener?".

## Root cause

Step 3 showed the delivered card **inside a triple-backtick code block**, which (a) taught the model that fences are part of the output format (so it echoed the fence into Telegram, where it renders literally) and (b) left room for a "let me draft the list first" reasoning pass. No hard rule forbade a preamble.

## Fix

- **negotiation-summary.md** — de-fence the Step 3 template (indented, explicitly "not a code block"); add hard rules: output only the final message with the title as the very first characters, never emit code fences/blocks; require one blank line between sections.
- **ask-questions.md / prepare.md** — add matching no-preamble / no-code-fence guards as defense-in-depth (the only other composing prompts).

`send.md` (verbatim-from-script delivery) and `memory-signals.md` (silent pass) are unaffected and needed no change.
