### PR TITLE
refactor(index-network): drop dead status re-filter in Hermes signal fetcher (EDG-53)

### DIFF
--- a/skills/index-network/scripts/summarize-negotiations.ts
+++ b/skills/index-network/scripts/summarize-negotiations.ts
@@ -309,7 +309,6 @@ export function buildMcpSignalFetcher(apiKey: string, mcpUrl: string): SignalFet
     if (!Array.isArray(intents)) return [];
 
     return intents
-      .filter((i) => !i.status || i.status === "active")
       .map((i) => ({ id: i.id ?? "", summary: (i.summary || i.description || "").trim() }))
       .filter((s) => s.summary.length > 0);
   };


### PR DESCRIPTION
Part of EDG-53 (intent count consistency). Removes a dead no-op filter from the Hermes signal fetcher.

## Change
In `skills/index-network/scripts/summarize-negotiations.ts`, `buildMcpSignalFetcher` re-filtered intents with:

```ts
.filter((i) => !i.status || i.status === "active")
```

The `read_intents` graph output never emits a `status` field on its items, so `!i.status` is always true — the filter passed everything through. This removes the dead line; the map/`summary`-length pipeline is unchanged.

The local `IntentListResponse` item `status?` field is intentionally retained as a defensive, now-unread DTO field.

## Behavior preservation
For the current graph output (items carrying no `status`), the emitted signal list (ids + summaries) is byte-identical before and after. The filter only ever excluded items with a present, non-`"active"` status — which the graph never produces.

Counterpart monorepo PR (Index backend + frontend): indexnetwork/index#1017. Control-plane counterpart: Edge-City/agentvillage-controlplane#28.
