### PR TITLE
fix(index-network): strip digest markers when LLM drops the id= prefix

### DIFF
--- a/skills/index-network/scripts/tests/validate-digest-urls.test.ts
+++ b/skills/index-network/scripts/tests/validate-digest-urls.test.ts
@@ -202,3 +202,71 @@ describe("sanitizeDigestUrls", () => {
     expect(sanitizeDigestUrls(md, { stripDigestMetadata: true }).output).toBe("**One for you:** Anything new?");
   });
 });
+
+describe("digest markers without the id= prefix (LLM composer drift)", () => {
+  // The composer sometimes emits the marker without the canonical `id=` prefix,
+  // e.g. `<!-- digest-opportunity:<uuid> -->`. Before the fix this form was neither
+  // stripped (so it leaked into delivered prose) nor extracted (so the opportunity
+  // was silently lost from bookkeeping). Both forms must now behave identically.
+  const OPP_UUID = "d3f5ea4d-2171-46e2-9e1f-0effd4d13956";
+
+  test("stripDigestMetadata removes a bare opportunity marker (no id=)", () => {
+    const md = `- <!-- digest-opportunity:${OPP_UUID} -->Timour Kosters is looking at governance`;
+
+    const stripped = stripDigestMetadata(md);
+
+    expect(stripped).toBe("- Timour Kosters is looking at governance");
+    expect(stripped).not.toContain("digest-opportunity");
+  });
+
+  test("stripDigestMetadata removes a bare question marker (no id=)", () => {
+    const md = "<!-- digest-question:daily-identity-2026-06-21 -->**One for you:** Who are you today?";
+
+    const stripped = stripDigestMetadata(md);
+
+    expect(stripped).toBe("**One for you:** Who are you today?");
+    expect(stripped).not.toContain("digest-question");
+  });
+
+  test("sanitizeDigestUrls strips bare markers on final delivery, preserves them by default", () => {
+    const md = `- <!-- digest-opportunity:${OPP_UUID} -->Timour Kosters is looking at governance`;
+
+    expect(sanitizeDigestUrls(md).output).toBe(md);
+    expect(sanitizeDigestUrls(md, { stripDigestMetadata: true }).output).toBe(
+      "- Timour Kosters is looking at governance",
+    );
+  });
+
+  test("extractDigestOpportunityIds reads the uuid from a bare marker (no id= captured)", () => {
+    const md = `- <!-- digest-opportunity:${OPP_UUID} -->Timour`;
+
+    expect(extractDigestOpportunityIds(md)).toEqual([OPP_UUID]);
+  });
+
+  test("extractDigestQuestionIds reads the id from a bare question marker", () => {
+    const md = "<!-- digest-question:q-bare -->**One for you:** Anything new?";
+
+    expect(extractDigestQuestionIds(md)).toEqual(["q-bare"]);
+  });
+
+  test("id= and bare forms extract to the same id (canonical prefix is stripped, not captured)", () => {
+    expect(extractDigestOpportunityIds(`<!-- digest-opportunity:id=${OPP_UUID} -->x`)).toEqual([OPP_UUID]);
+    expect(extractDigestOpportunityIds(`<!-- digest-opportunity:${OPP_UUID} -->x`)).toEqual([OPP_UUID]);
+  });
+
+  test("mixed id= and bare markers in one body all strip and extract", () => {
+    const md = [
+      "- <!-- digest-opportunity:id=opp-1 -->Maya",
+      `- <!-- digest-opportunity:${OPP_UUID} -->Timour`,
+      "<!-- digest-question:id=q-1 -->**One for you:** A?",
+      "<!-- digest-question:q-2 -->**One for you:** B?",
+    ].join("\n");
+
+    expect(extractDigestOpportunityIds(md)).toEqual(["opp-1", OPP_UUID]);
+    expect(extractDigestQuestionIds(md)).toEqual(["q-1", "q-2"]);
+
+    const stripped = stripDigestMetadata(md);
+    expect(stripped).not.toContain("digest-opportunity");
+    expect(stripped).not.toContain("digest-question");
+  });
+});

--- a/skills/index-network/scripts/validate-digest-urls.ts
+++ b/skills/index-network/scripts/validate-digest-urls.ts
@@ -44,12 +44,18 @@ const MARKDOWN_LINK = /\[([^\]]*)\]\(([^)]*)\)/g;
 const AUTOLINK = /<((?:https?:\/\/)[^>\s]+)>/g;
 const BARE_URL = /https?:\/\/[^\s<>)]+/g;
 
-/** Hidden marker that ties an editable digest fragment to the opportunity it represents. */
-const DIGEST_OPPORTUNITY_MARKER = /<!--\s*digest-opportunity:id=([^\s>]+)\s*-->/g;
-/** Hidden marker that ties a digest question fragment to the question it represents. */
-const DIGEST_QUESTION_MARKER = /<!--\s*digest-question:id=([^\s>]+)\s*-->/g;
-/** Any internal digest metadata marker (opportunity or question) — the strip set. */
-const DIGEST_METADATA_MARKER = /<!--\s*digest-(?:opportunity|question):id=[^\s>]+\s*-->/g;
+/**
+ * Hidden marker that ties an editable digest fragment to the opportunity it represents.
+ * The `id=` prefix is canonical (see prepare.md) but optional here: the LLM composer
+ * occasionally drops it, and an unmatched marker would both leak into delivered prose
+ * and silently lose the opportunity from extraction. The optional group is greedy, so
+ * `id=UUID` still captures just `UUID` and a bare `UUID` is captured verbatim.
+ */
+const DIGEST_OPPORTUNITY_MARKER = /<!--\s*digest-opportunity:(?:id=)?([^\s>]+)\s*-->/g;
+/** Hidden marker that ties a digest question fragment to the question it represents. `id=` optional — see above. */
+const DIGEST_QUESTION_MARKER = /<!--\s*digest-question:(?:id=)?([^\s>]+)\s*-->/g;
+/** Any internal digest metadata marker (opportunity or question) — the strip set. `id=` optional — see above. */
+const DIGEST_METADATA_MARKER = /<!--\s*digest-(?:opportunity|question):(?:id=)?[^\s>]+\s*-->/g;
 
 export interface SanitizeDigestOptions {
   /** Strip internal digest metadata comments before user-facing delivery. */


### PR DESCRIPTION
## Problem

Internal digest markers (`<!-- digest-opportunity:id=<uuid> -->` / `<!-- digest-question:id=<id> -->`) leaked verbatim into a delivered daily digest, e.g.:

```
<!-- digest-opportunity:d3f5ea4d-2171-46e2-9e1f-0effd4d13956 -->Timour Kosters is looking at…
```

## Root cause

All three marker regexes in `skills/index-network/scripts/validate-digest-urls.ts` hard-required the literal `id=`:

```js
const DIGEST_METADATA_MARKER = /<!--\s*digest-(?:opportunity|question):id=[^\s>]+\s*-->/g;
```

The digest composer (an LLM, per `edge-esmeralda/prompts/prepare.md`) sometimes emits the marker **without** the `id=` prefix. Such a marker:
1. **isn't stripped** on final delivery → the raw comment leaks into the user-facing brief, and
2. **isn't extracted** by `extractDigestOpportunityIds()` → the opportunity is silently dropped from URL-injection/validation bookkeeping.

So one over-strict regex caused both a visible leak and a quiet metadata loss.

## Fix

Make the `id=` prefix an optional non-capturing group `(?:id=)?` in all three patterns (opportunity, question, combined strip set). It stays greedy, so the canonical `id=UUID` form still captures just the UUID and bare `UUID` markers now match too — **no behavior change for existing markers**. `prepare.md` remains the canonical `id=` format; hardening the regex defends against LLM drift since the composer will keep occasionally dropping the prefix.

## Tests

New describe block in `tests/validate-digest-urls.test.ts` (7 cases) asserting both `id=` and bare forms strip + extract identically — including the exact real-world leaked marker and a mixed-body case.

- `bun test tests/validate-digest-urls.test.ts` → **27 pass** (7 new)
- full scripts suite → **120 pass, 0 fail**

## Follow-up

After merge, bump the monorepo submodule pointer for `packages/edge-city/agentvillage`.