### PR TITLE
Add tenant token usage audit cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Today, capabilities come from **Index Network** (discovery + intent negotiation)
 - **Prepares a morning brief for 08:00 host-local time** with admin-set village announcements, today's EdgeOS calendar highlights, the connections worth your attention, and the asks where you can help. Each night's brief is staged and held for review; it is delivered at 08:00 only after an operator approves it by unblocking the staged card on the board.
 - **Notifies you when someone accepts** a connection on your behalf.
 - **Curates memory** every few days — distills daily notes into long-term `MEMORY.md`.
+- **Audits token usage quietly** with a deterministic local script. It only wakes the agent when meaningful spend has a clear actionable driver, such as scheduled background work dominating the last day.
 
 AgentVillage never names the plumbing in chat. You see AgentVillage and (when relevant) your community.
 
@@ -30,6 +31,7 @@ See the project hub for the full diagram and decisions.
   - `skills/edgeos/` — backend-generic EdgeOS API recipes (events, RSVPs, venues, attendee directory, own profile). Reads `EDGEOS_BEARER_TOKEN` and `EDGEOS_API_KEY` from env; popup id is supplied by the active operator skill.
   - `skills/edge-esmeralda/` — Edge Esmeralda 2026 popup knowledge: popup constants (popup id, week dates, themes), attendee field semantics, the curated wiki/website/newsletter references (vendored from `Edge-City/agentvillage-skills`; refreshed by upstream CI every 15 min), and the onboarding pointer for obtaining EdgeOS tokens.
   - `skills/geo-esmeralda/` — Geo knowledge graph recipes and write guidance for attendee-authored content, relations, ontology, and media.
+  - `skills/token-usage-audit/` — deterministic tenant-local token usage audit script and cron contract. It reads local usage summaries and cron metadata, never calls an LLM, and emits only sanitized aggregate facts.
 - `install/` — bootstrap scripts for plugging AgentVillage into a runtime
 
 ## Getting an agent connected
@@ -236,6 +238,9 @@ DIGEST_PREPARE_CRON="0 3 * * *" DIGEST_SEND_CRON="0 9 * * *" \
 | Memory signal sync | `--digest-signals-cron "<expr>"` | `DIGEST_SIGNALS_CRON` | `0 1 * * *` |
 | Prepare pass | `--digest-prepare-cron "<expr>"` | `DIGEST_PREPARE_CRON` | `0 2 * * *` |
 | Send pass | `--digest-send-cron "<expr>"` | `DIGEST_SEND_CRON` | `0 8 * * *` |
+| Token usage audit | `--token-usage-audit-cron "<expr>"` | `TOKEN_USAGE_AUDIT_CRON` | `0 9 * * *` |
+
+To disable the token usage audit cron for an install, pass `--skip-token-usage-audit-cron` or set `TOKEN_USAGE_AUDIT_CRON=off`.
 
 The installer also caps `model.max_tokens` in Hermes `config.yaml` at `4096` by default so background cron turns do not inherit large provider defaults (for example `65536`). Operators can raise or lower that cap for an install by setting `HERMES_MAX_TOKENS`.
 
@@ -249,7 +254,7 @@ The installer:
 4. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 5. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 6. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
-7. Installs the Index cron jobs: a memory signal sync (`0 1 * * *`), a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. (The 30-minute `Edge — heartbeat` cron was retired — see the note under "Overriding the Index cron times" — and is removed from existing tenants on update.) The prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. The end user can't change the schedule from chat, but the installer can override the cron times via `--digest-signals-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_SIGNALS_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) — see "Overriding the Index cron times" above.
+7. Installs the Index cron jobs: a memory signal sync (`0 1 * * *`), a prepare pass (`0 2 * * *`) that composes the morning brief and stages it as an editable Kanban task, and a send pass (`0 8 * * *`) that delivers the staged brief. It also installs the deterministic token usage audit script cron (`0 9 * * *`) with Telegram delivery gated by the script. (The 30-minute `Edge — heartbeat` cron was retired — see the note under "Overriding the Index cron times" — and is removed from existing tenants on update.) The prepare pass stages each brief as a **blocked** Kanban task; the send pass delivers it only after an operator approves it by unblocking that task (`hermes kanban unblock <id>` or the board's unblock control), so accidental delivery is prevented without pausing the cron. The token audit wakes the agent only when local aggregate usage shows a meaningful actionable driver; quiet runs end with `{"wakeAgent":false}` and skip the agent entirely. The end user can't change schedules from chat, but the installer can override the cron times via the flags/env vars above.
 8. Restarts the gateway so all config changes take effect.
 
 Send any message in your chat to bring AgentVillage online. AgentVillage has two independent setup gates with different triggers:
@@ -281,7 +286,7 @@ bun install/reset.ts --wipe-user
 
 ## How it runs
 
-Time-sensitive and background prompts run as **Hermes/OpenClaw cron jobs**. The morning digest prepare/send prompts and the daily memory signal sync run at their own daily cron times. Cron has its own scheduler and runs isolated sessions, so each tick starts fresh from the workspace files. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
+Time-sensitive and background prompts run as **Hermes/OpenClaw cron jobs**. The morning digest prepare/send prompts and the daily memory signal sync run at their own daily cron times. The token usage audit is different: it is a script cron, non-LLM by default, with delivery gated by the script's final `wakeAgent` line. It inspects local dashboard session summaries, `cron/jobs.json`, and metadata fallback only when useful; it writes cooldown state to `memory/token-usage-audit.json` and emits sanitized aggregate facts only when it wakes the agent. Cron has its own scheduler and runs isolated sessions, so each tick starts fresh from the workspace files. Cron jobs are installed by `install/install.ts` and restart with the gateway. Future per-backend skills can add their own cron prompts the same way.
 
 > **Retired:** a 30-minute `Edge — heartbeat` cron used to run `skills/index-network/heartbeat.md` for accepted-opportunity notifications, freshness audits, and Telegram-handle reconciliation. It was removed because each tick loaded ~57k input tokens (full agent context + Index MCP tool surface) and, at 48 runs/day/tenant, drained the per-tenant OpenRouter key budgets fleet-wide (HTTP 402). `skills/index-network/heartbeat.md` is kept for reference only and is no longer scheduled. Latency-tolerant background work should be folded into the daily digest, an event-driven push, or a cheap deterministic (`--no-agent`) cron instead — see Edge-City/agentvillage#100.
 
@@ -346,6 +351,7 @@ Index background work runs as fixed cron prompts — **memory signal sync `0 1 *
 | Override the Index cron times for one install | `--digest-signals-cron` / `--digest-prepare-cron` / `--digest-send-cron` (or `DIGEST_SIGNALS_CRON` / `DIGEST_PREPARE_CRON` / `DIGEST_SEND_CRON`) | Optional, full 5-field cron expressions. Flag wins over env; invalid values fall back to the default. |
 | Change the default Index cron schedule for everyone | `install/install_index.ts` (`DIGEST_CRON_SPECS`) | The installer writes the cron entries from this table. Existing installs pick up changes on the next `install.ts` run. |
 | Change a cron prompt without changing the schedule | the matching prompt file (`skills/index-network/heartbeat.md` or `skills/edge-esmeralda/prompts/<name>.md`) | Hermes stores prompt copies in cron jobs. Hosted residents are refreshed by the control-plane post-merge sync, which calls each sidecar's `/update` endpoint and reruns the installer. For non-control-plane installs or recovery, run `HERMES_HOME=<resident-home> bun install/reconcile_digest_crons.ts` after updated skill files are copied. |
+| Disable the token usage audit cron | `--skip-token-usage-audit-cron` or `TOKEN_USAGE_AUDIT_CRON=off` | The reconciler removes the managed audit cron when opted out. Quiet is the default; alerts require meaningful usage plus an actionable driver and respect a 72-hour per-driver cooldown. |
 
 ### Backends & skills
 

--- a/install/install_index.ts
+++ b/install/install_index.ts
@@ -26,7 +26,7 @@
  *     state (user-customized schedules are never touched).
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import YAML from "yaml";
@@ -142,6 +142,7 @@ interface StoredCronJob {
   id: string;
   name: string;
   prompt?: string;
+  script?: string;
   schedule?: { expr?: string } | string;
   schedule_display?: string;
 }
@@ -169,7 +170,15 @@ export interface DigestCronSpec {
   /** Width of the per-tenant stagger window, in minutes from the default hour. */
   staggerWindowMinutes: number;
   /** Prompt file under skills/. */
-  promptFile: string;
+  promptFile?: string;
+  /** Script file under skills/. for Hermes script crons. */
+  scriptFile?: string;
+  /** Installed script filename under $HERMES_HOME/scripts/. */
+  scriptInstallName?: string;
+  /** Skill name passed to Hermes for script crons. */
+  skill?: string;
+  /** Inline prompt used with script crons. */
+  promptBody?: string;
   /** Full Hermes cron name (kept under the CRON_NAME_PREFIX). */
   name: string;
   /** Whether to attach --deliver telegram. */
@@ -243,6 +252,23 @@ export const DIGEST_CRON_SPECS: DigestCronSpec[] = [
     overrideFlag: "--evening-questions-cron",
     overrideEnv: "EVENING_QUESTIONS_CRON",
   },
+  {
+    schedule: "0 9 * * *",
+    staggerWindowMinutes: 50,
+    scriptFile: "token-usage-audit/scripts/audit_token_usage.py",
+    scriptInstallName: "agentvillage_token_usage_audit.py",
+    skill: "token-usage-audit",
+    promptBody: [
+      "A deterministic local token usage audit found an actionable driver.",
+      "Use the sanitized facts emitted by the script. Do not mention raw session ids, prompts, transcripts, private hosts, env values, or secrets.",
+      "If user-facing delivery is warranted, keep it brief: explain whether scheduled background work drove spend, name the likely cron only when confidence is high or medium, and suggest pausing or reporting the driver.",
+      "If the script emitted wakeAgent:false, return [SILENT].",
+    ].join(" "),
+    name: "Edge — token usage audit",
+    deliver: true,
+    overrideFlag: "--token-usage-audit-cron",
+    overrideEnv: "TOKEN_USAGE_AUDIT_CRON",
+  },
 ];
 
 /** FNV-1a 32-bit hash — deterministic, dependency-free. */
@@ -274,6 +300,8 @@ export function staggeredSchedule(spec: DigestCronSpec, seed: string): string {
 export function cronCreateArgs(spec: DigestCronSpec, promptBody: string, home: string): string[] {
   const args = ["cron", "create", spec.schedule, promptBody, "--name", spec.name];
   if (spec.deliver) args.push("--deliver", "telegram");
+  if (spec.skill) args.push("--skill", spec.skill);
+  if (spec.scriptFile) args.push("--script", expectedCronScriptPath(spec, home)!);
   args.push("--workdir", home);
   return args;
 }
@@ -322,6 +350,50 @@ export function resolveCronSchedule(
   return override;
 }
 
+export function tokenUsageAuditCronDisabled(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env.TOKEN_USAGE_AUDIT_CRON?.trim().toLowerCase();
+  return argv.includes("--skip-token-usage-audit-cron")
+    || raw === "off"
+    || raw === "false"
+    || raw === "0"
+    || raw === "disabled";
+}
+
+function readCronPromptBody(spec: DigestCronSpec, promptsDir: string): string {
+  if (spec.promptFile) {
+    const promptPath = join(promptsDir, spec.promptFile);
+    if (!existsSync(promptPath)) {
+      console.error(`error: prompt missing at ${promptPath} — run install.ts first`);
+      process.exit(1);
+    }
+    return readFileSync(promptPath, "utf8");
+  }
+  if (spec.promptBody !== undefined) return spec.promptBody;
+  console.error(`error: cron "${spec.name}" has neither promptFile nor promptBody`);
+  process.exit(1);
+}
+
+function expectedCronScriptPath(spec: DigestCronSpec, home: string): string | undefined {
+  if (!spec.scriptFile) return undefined;
+  return join(home, "scripts", spec.scriptInstallName || spec.scriptFile.split("/").pop() || "agentvillage_cron.py");
+}
+
+function ensureCronScriptInstalled(spec: DigestCronSpec, home: string, promptsDir: string): string | undefined {
+  const expectedScript = expectedCronScriptPath(spec, home);
+  if (!expectedScript || !spec.scriptFile) return undefined;
+  const sourceScript = join(promptsDir, spec.scriptFile);
+  if (!existsSync(sourceScript)) {
+    console.error(`error: script missing at ${sourceScript} — run install.ts first`);
+    process.exit(1);
+  }
+  mkdirSync(join(home, "scripts"), { recursive: true });
+  copyFileSync(sourceScript, expectedScript);
+  return expectedScript;
+}
+
 /**
  * Probe whether the Hermes CLI can actually run. `hermesBin()` falls back to the
  * bare name `"hermes"` when it finds no fixed-path binary, but that name still
@@ -337,7 +409,10 @@ function hermesAvailable(bin: string): boolean {
   }
 }
 
-export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()): void {
+export function reconcileDigestCronJobs(
+  env: NodeJS.ProcessEnv = hermesExecEnv(),
+  argv: string[] = process.argv,
+): void {
   const home = hermesHome();
   const promptsDir = join(home, "skills");
 
@@ -348,7 +423,10 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
   }
 
   const existing = readCronJobs();
-  const specNames = new Set(DIGEST_CRON_SPECS.map((s) => s.name));
+  const activeSpecs = DIGEST_CRON_SPECS.filter(
+    (spec) => spec.name !== "Edge — token usage audit" || !tokenUsageAuditCronDisabled(argv, env),
+  );
+  const specNames = new Set(activeSpecs.map((s) => s.name));
   // Stable per-tenant seed for schedule staggering. The tenant's own Index
   // API key never changes across reinstalls, so the derived minute is stable.
   const staggerSeed = process.env.INDEX_API_KEY?.trim() || readPersistedEnvVar("INDEX_API_KEY");
@@ -370,22 +448,32 @@ export function reconcileDigestCronJobs(env: NodeJS.ProcessEnv = hermesExecEnv()
     console.warn("  warning: could not run `hermes kanban init` — board may auto-init on first use");
   }
 
-  for (const spec of DIGEST_CRON_SPECS) {
-    const promptPath = join(promptsDir, spec.promptFile);
-    if (!existsSync(promptPath)) {
-      console.error(`error: prompt missing at ${promptPath} — run install.ts first`);
-      process.exit(1);
-    }
-    const promptBody = readFileSync(promptPath, "utf8");
+  for (const spec of activeSpecs) {
+    const expectedScript = ensureCronScriptInstalled(spec, home, promptsDir);
+    const promptBody = readCronPromptBody(spec, promptsDir);
     const job = existing.find((entry) => entry.name === spec.name);
     const schedule = resolveCronSchedule(spec, process.argv, process.env, staggerSeed);
 
     if (job) {
       const promptStale = job.prompt !== promptBody;
+      const scriptStale = expectedScript !== undefined && job.script !== expectedScript;
       // Migrate only jobs still sitting on the old synchronized default
       // (e.g. "0 8 * * *") to their staggered slot. Anything else is a
       // deliberate per-tenant schedule and is preserved.
       const scheduleStale = storedSchedule(job) === spec.schedule && schedule !== spec.schedule;
+      if (scriptStale) {
+        console.log(`→ recreating cron "${spec.name}" with current script`);
+        try {
+          execFileSync(bin, ["cron", "remove", job.id], { stdio: "ignore", env });
+          execFileSync(bin, cronCreateArgs({ ...spec, schedule }, promptBody, home), {
+            stdio: ["ignore", "ignore", "inherit"],
+            env,
+          });
+        } catch {
+          console.warn(`  warning: could not recreate cron "${spec.name}" — gateway may still run`);
+        }
+        continue;
+      }
       if (!promptStale && !scheduleStale) {
         console.log(`→ cron "${spec.name}" up to date`);
         continue;

--- a/install/paths.ts
+++ b/install/paths.ts
@@ -21,6 +21,7 @@ export const EDGE_SKILL_NAMES = [
   "edgeos",
   "edge-esmeralda",
   "geo-esmeralda",
+  "token-usage-audit",
 ] as const;
 
 export const CRON_NAME_PREFIX = "Edge —";

--- a/install/tests/cron_specs.test.ts
+++ b/install/tests/cron_specs.test.ts
@@ -10,14 +10,15 @@ import {
   resolveCronSchedule,
   staggeredSchedule,
   storedSchedule,
+  tokenUsageAuditCronDisabled,
 } from "../install_index";
 
-test("five Index cron specs: signals, prepare, send, negotiation, evening (heartbeat retired)", () => {
-  expect(DIGEST_CRON_SPECS).toHaveLength(5);
+test("six Index cron specs: digest jobs plus token audit (heartbeat retired)", () => {
+  expect(DIGEST_CRON_SPECS).toHaveLength(6);
   // The 30-minute "Edge — heartbeat" cron was retired (it drained OpenRouter
   // key budget fleet-wide); it must no longer be installed.
   expect(DIGEST_CRON_SPECS.some((s) => s.name === "Edge — heartbeat")).toBe(false);
-  const [signals, prepare, send, negotiation, evening] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send, negotiation, evening, tokenAudit] = DIGEST_CRON_SPECS;
   expect(signals.schedule).toBe("0 1 * * *");
   expect(signals.name).toBe("Edge — memory signal sync");
   expect(signals.promptFile).toBe("edge-esmeralda/prompts/memory-signals.md");
@@ -38,11 +39,17 @@ test("five Index cron specs: signals, prepare, send, negotiation, evening (heart
   expect(evening.name).toBe("Edge — evening questions");
   expect(evening.promptFile).toBe("edge-esmeralda/prompts/ask-questions.md");
   expect(evening.deliver).toBe(true);
+  expect(tokenAudit.schedule).toBe("0 9 * * *");
+  expect(tokenAudit.name).toBe("Edge — token usage audit");
+  expect(tokenAudit.scriptFile).toBe("token-usage-audit/scripts/audit_token_usage.py");
+  expect(tokenAudit.scriptInstallName).toBe("agentvillage_token_usage_audit.py");
+  expect(tokenAudit.skill).toBe("token-usage-audit");
+  expect(tokenAudit.deliver).toBe(true);
 });
 
-test("send cron args include --deliver telegram; signals/prepare omit it", () => {
+test("cron create args handle delivered and scripted specs", () => {
   const home = "/home/x/.hermes";
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send, , , tokenAudit] = DIGEST_CRON_SPECS;
 
   expect(cronCreateArgs(signals, "SIGNALS_BODY", home)).toEqual([
     "cron", "create", "0 1 * * *", "SIGNALS_BODY",
@@ -58,6 +65,13 @@ test("send cron args include --deliver telegram; signals/prepare omit it", () =>
     "cron", "create", "0 8 * * *", "SEND_BODY",
     "--name", "Edge — daily digest", "--deliver", "telegram", "--workdir", home,
   ]);
+
+  const tokenAuditArgs = cronCreateArgs(tokenAudit, "AUDIT_PROMPT", home);
+  expect(tokenAuditArgs).toContain("--deliver");
+  expect(tokenAuditArgs).toContain("--skill");
+  expect(tokenAuditArgs).toContain("token-usage-audit");
+  expect(tokenAuditArgs).toContain("--script");
+  expect(tokenAuditArgs).toContain("/home/x/.hermes/scripts/agentvillage_token_usage_audit.py");
 });
 
 test("cronEditArgs includes only the provided fields", () => {
@@ -129,13 +143,22 @@ test("invalid telegram MCP handle is omitted", () => {
 });
 
 test("each spec declares its install-time override flag + env var", () => {
-  const [signals, prepare, send] = DIGEST_CRON_SPECS;
+  const [signals, prepare, send, , , tokenAudit] = DIGEST_CRON_SPECS;
   expect(signals.overrideFlag).toBe("--digest-signals-cron");
   expect(signals.overrideEnv).toBe("DIGEST_SIGNALS_CRON");
   expect(prepare.overrideFlag).toBe("--digest-prepare-cron");
   expect(prepare.overrideEnv).toBe("DIGEST_PREPARE_CRON");
   expect(send.overrideFlag).toBe("--digest-send-cron");
   expect(send.overrideEnv).toBe("DIGEST_SEND_CRON");
+  expect(tokenAudit.overrideFlag).toBe("--token-usage-audit-cron");
+  expect(tokenAudit.overrideEnv).toBe("TOKEN_USAGE_AUDIT_CRON");
+});
+
+test("token usage audit cron opt-out accepts flag and env values", () => {
+  expect(tokenUsageAuditCronDisabled(["bun", "--skip-token-usage-audit-cron"], {})).toBe(true);
+  expect(tokenUsageAuditCronDisabled([], { TOKEN_USAGE_AUDIT_CRON: "off" })).toBe(true);
+  expect(tokenUsageAuditCronDisabled([], { TOKEN_USAGE_AUDIT_CRON: "disabled" })).toBe(true);
+  expect(tokenUsageAuditCronDisabled([], { TOKEN_USAGE_AUDIT_CRON: "15 4 * * *" })).toBe(false);
 });
 
 test("isValidCron accepts 5-field expressions and rejects malformed ones", () => {

--- a/install/tests/reconcile_digest_crons.test.ts
+++ b/install/tests/reconcile_digest_crons.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../install_index";
 
 const SEED = "ix_integration_seed";
-const [SIGNALS, PREPARE, SEND, NEGOTIATION, EVENING] = DIGEST_CRON_SPECS;
+const [SIGNALS, PREPARE, SEND, NEGOTIATION, EVENING, TOKEN_AUDIT] = DIGEST_CRON_SPECS;
 // The retired "Edge — heartbeat" cron name — used to assert it is torn down.
 const RETIRED_HEARTBEAT_NAME = "Edge — heartbeat";
 const PROMPT_BODIES = new Map([
@@ -69,10 +69,14 @@ function cronCalls(): string[][] {
 function writePrompts(): void {
   const skills = join(home, "skills");
   for (const [promptFile, body] of PROMPT_BODIES) {
+    if (!promptFile) continue;
     const promptPath = join(skills, promptFile);
     mkdirSync(dirname(promptPath), { recursive: true });
     writeFileSync(promptPath, body);
   }
+  const scriptPath = join(skills, TOKEN_AUDIT.scriptFile!);
+  mkdirSync(dirname(scriptPath), { recursive: true });
+  writeFileSync(scriptPath, "#!/usr/bin/env python3\nprint('{\"wakeAgent\":false}')\n");
 }
 
 function writeJobs(jobs: unknown[]): void {
@@ -80,13 +84,19 @@ function writeJobs(jobs: unknown[]): void {
   writeFileSync(join(home, "cron", "jobs.json"), JSON.stringify({ jobs }));
 }
 
+function installedTokenAuditScript(): string {
+  return join(home, "scripts", TOKEN_AUDIT.scriptInstallName!);
+}
+
 function currentJob(spec: typeof DIGEST_CRON_SPECS[number], id: string): Record<string, unknown> {
-  return {
+  const job: Record<string, unknown> = {
     id,
     name: spec.name,
-    prompt: PROMPT_BODIES.get(spec.promptFile),
+    prompt: spec.promptFile ? PROMPT_BODIES.get(spec.promptFile) : spec.promptBody,
     schedule: { expr: staggeredSchedule(spec, SEED) },
   };
+  if (spec.scriptFile) job.script = installedTokenAuditScript();
+  return job;
 }
 
 beforeEach(() => {
@@ -100,6 +110,7 @@ beforeEach(() => {
     DIGEST_SIGNALS_CRON: process.env.DIGEST_SIGNALS_CRON,
     DIGEST_PREPARE_CRON: process.env.DIGEST_PREPARE_CRON,
     DIGEST_SEND_CRON: process.env.DIGEST_SEND_CRON,
+    TOKEN_USAGE_AUDIT_CRON: process.env.TOKEN_USAGE_AUDIT_CRON,
   };
   process.env.HERMES_HOME = home;
   process.env.HERMES_BIN = writeStubHermes(home);
@@ -108,6 +119,7 @@ beforeEach(() => {
   delete process.env.DIGEST_SIGNALS_CRON;
   delete process.env.DIGEST_PREPARE_CRON;
   delete process.env.DIGEST_SEND_CRON;
+  delete process.env.TOKEN_USAGE_AUDIT_CRON;
   writePrompts();
 });
 
@@ -131,6 +143,7 @@ test("fresh install creates digest crons (no heartbeat) on their staggered sched
   const send = creates.find((argv) => argv.includes(SEND.name))!;
   const negotiation = creates.find((argv) => argv.includes(NEGOTIATION.name))!;
   const evening = creates.find((argv) => argv.includes(EVENING.name))!;
+  const audit = creates.find((argv) => argv.includes(TOKEN_AUDIT.name))!;
   expect(signals[2]).toBe(staggeredSchedule(SIGNALS, SEED));
   expect(signals[3]).toBe("SIGNALS_BODY");
   expect(prepare[2]).toBe(staggeredSchedule(PREPARE, SEED));
@@ -141,9 +154,17 @@ test("fresh install creates digest crons (no heartbeat) on their staggered sched
   expect(negotiation[3]).toBe("NEGOTIATION_BODY");
   expect(evening[2]).toBe(staggeredSchedule(EVENING, SEED));
   expect(evening[3]).toBe("EVENING_BODY");
+  expect(audit[2]).toBe(staggeredSchedule(TOKEN_AUDIT, SEED));
+  expect(audit[3]).toContain("deterministic local token usage audit");
+  expect(audit).toContain("--skill");
+  expect(audit).toContain("token-usage-audit");
+  expect(audit).toContain("--script");
+  expect(audit).toContain(installedTokenAuditScript());
+  expect(readFileSync(installedTokenAuditScript(), "utf8")).toContain("wakeAgent");
   expect(send).toContain("--deliver");
   expect(negotiation).toContain("--deliver");
   expect(evening).toContain("--deliver");
+  expect(audit).toContain("--deliver");
   expect(signals).not.toContain("--deliver");
   expect(prepare).not.toContain("--deliver");
 });
@@ -156,6 +177,7 @@ test("an existing Edge — heartbeat cron is retired on reconcile", () => {
     currentJob(SEND, "s1"),
     currentJob(NEGOTIATION, "n1"),
     currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });
@@ -170,6 +192,7 @@ test("jobs still on old synchronized defaults get schedule-only migrations", () 
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: SEND.schedule } },
     currentJob(NEGOTIATION, "n1"),
     currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });
@@ -189,6 +212,7 @@ test("custom schedule is preserved; stale prompt gets a prompt-only edit", () =>
     { id: "s1", name: SEND.name, prompt: "SEND_BODY", schedule: { expr: "15 9 * * *" } },
     currentJob(NEGOTIATION, "n1"),
     currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });
@@ -205,6 +229,7 @@ test("stale prompt + old default schedule produce two independent edit calls", (
     { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },
     currentJob(NEGOTIATION, "n1"),
     currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });
@@ -223,6 +248,7 @@ test("up-to-date jobs (staggered schedule + current prompt) trigger no cron call
     currentJob(SEND, "s1"),
     currentJob(NEGOTIATION, "n1"),
     currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });
@@ -234,12 +260,59 @@ test("retired Edge-prefixed crons are removed; foreign crons are untouched", () 
   writeJobs([
     { id: "old1", name: "Edge — old heartbeat", prompt: "X", schedule: { expr: "0 6 * * *" } },
     { id: "user1", name: "my own job", prompt: "Y", schedule: { expr: "0 7 * * *" } },
+    currentJob(SIGNALS, "g1"),
+    currentJob(PREPARE, "p1"),
+    currentJob(SEND, "s1"),
+    currentJob(NEGOTIATION, "n1"),
+    currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });
 
   const removes = cronCalls().filter((argv) => argv[1] === "remove");
   expect(removes).toEqual([["cron", "remove", "old1"]]);
+});
+
+test("token usage audit cron is removed when opted out", () => {
+  const env = { ...process.env, TOKEN_USAGE_AUDIT_CRON: "off" };
+  writeJobs([
+    currentJob(SIGNALS, "g1"),
+    currentJob(PREPARE, "p1"),
+    currentJob(SEND, "s1"),
+    currentJob(NEGOTIATION, "n1"),
+    currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
+  ]);
+
+  reconcileDigestCronJobs(env);
+
+  expect(cronCalls()).toEqual([["cron", "remove", "a1"]]);
+});
+
+test("token usage audit cron is recreated when its script path is stale", () => {
+  writeJobs([
+    currentJob(SIGNALS, "g1"),
+    currentJob(PREPARE, "p1"),
+    currentJob(SEND, "s1"),
+    currentJob(NEGOTIATION, "n1"),
+    currentJob(EVENING, "e1"),
+    {
+      ...currentJob(TOKEN_AUDIT, "a1"),
+      script: join(home, "skills", "token-usage-audit/scripts/old_audit.py"),
+    },
+  ]);
+
+  reconcileDigestCronJobs({ ...process.env });
+
+  const calls = cronCalls();
+  expect(calls[0]).toEqual(["cron", "remove", "a1"]);
+  const create = calls[1];
+  expect(create[0]).toBe("cron");
+  expect(create[1]).toBe("create");
+  expect(create).toContain(TOKEN_AUDIT.name);
+  expect(create).toContain("--script");
+  expect(create).toContain(installedTokenAuditScript());
 });
 
 test("a Hermes that rejects --schedule still gets the prompt update (degraded migration)", () => {
@@ -250,6 +323,7 @@ test("a Hermes that rejects --schedule still gets the prompt update (degraded mi
     { id: "s1", name: SEND.name, prompt: "OLD_BODY", schedule: { expr: SEND.schedule } },
     currentJob(NEGOTIATION, "n1"),
     currentJob(EVENING, "e1"),
+    currentJob(TOKEN_AUDIT, "a1"),
   ]);
 
   reconcileDigestCronJobs({ ...process.env });

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,14 +4,15 @@ Agent skills for **Edge Esmeralda 2026** (May 30 – Jun 27, Healdsburg, CA). Sh
 
 ## What you get
 
-Four skill bundles that give your agent Edge Esmeralda knowledge and live API access:
+Five skill bundles give your agent Edge Esmeralda knowledge, live API access, and local operational guardrails:
 
 - **edge-esmeralda** — popup constants (popup id, week dates, themes), attendee directory field semantics, curated wiki/website/newsletter knowledge base, and the onboarding pointer for obtaining EdgeOS tokens.
 - **edgeos** — backend-generic EdgeOS API recipes: events, RSVPs, venues, attendee directory, and your own profile lookup.
 - **geo-esmeralda** — Geo knowledge graph access through the Geo CLI package: ontology, fixed graph tools, guarded native read-only queries, and attendee-authored content/photo creation.
 - **index-network** — Index Network discovery: onboarding ritual, opportunity surfacing, voice exemplars, cron prompts for welcome/digest flows, and heartbeat tasks.
+- **token-usage-audit** — deterministic local token usage audit script and Hermes script-cron contract. It wakes the agent only when meaningful usage has an actionable driver and emits no raw transcripts, prompts, session ids, env values, private hosts, or secrets.
 
-The skills cross-reference each other. `edge-esmeralda` supplies the popup id that `edgeos` recipes need. `geo-esmeralda` handles Geo knowledge graph-backed knowledge and attendee-authored writes, and `index-network` handles discovery and intent-based matching. Install all four together.
+The skills cross-reference each other. `edge-esmeralda` supplies the popup id that `edgeos` recipes need. `geo-esmeralda` handles Geo knowledge graph-backed knowledge and attendee-authored writes, `index-network` handles discovery and intent-based matching, and `token-usage-audit` provides the local script-cron guardrail. Install all five together.
 
 ## Host-specific silence
 
@@ -73,6 +74,7 @@ hermes skills install Edge-City/agentvillage/skills/edge-esmeralda --force
 hermes skills install Edge-City/agentvillage/skills/edgeos --force
 hermes skills install Edge-City/agentvillage/skills/geo-esmeralda --force
 hermes skills install Edge-City/agentvillage/skills/index-network --force
+hermes skills install Edge-City/agentvillage/skills/token-usage-audit --force
 ```
 
 Add to `~/.hermes/.env`:

--- a/skills/token-usage-audit/SKILL.md
+++ b/skills/token-usage-audit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: token-usage-audit
+description: Deterministic tenant-local token usage audit for AgentVillage Hermes installs. Runs as a script cron and wakes the agent only when a clear actionable token-spend driver is found.
+---
+
+# Token Usage Audit
+
+This skill owns the local token usage audit cron. It is operational plumbing for the resident's agent, not a chat skill the agent should mention by name.
+
+## What It Does
+
+The script at `scripts/audit_token_usage.py` reads only tenant-local operational metadata:
+
+- Hermes dashboard session summaries from `http://127.0.0.1:9119/api/sessions?limit=500`
+- local cron metadata from `cron/jobs.json`
+- metadata-like local JSON/JSONL files only as a fallback when dashboard usage is unavailable
+
+It does not call an LLM. It does not emit raw message content, prompts, raw session ids, private hosts, secrets, env values, or profile/memory prose. Session ids are used only for in-process grouping and become ordinal refs like `session_001`.
+
+## Cron Contract
+
+The AgentVillage installer creates one Hermes cron:
+
+- name: `Edge — token usage audit`
+- default schedule: `0 9 * * *` with deterministic per-tenant staggering
+- delivery: Telegram only after the script wake gate returns `wakeAgent:true`
+- skill: `token-usage-audit`
+- script: `skills/token-usage-audit/scripts/audit_token_usage.py`
+
+The script prints a final JSON line. When no action is needed, the line is:
+
+```json
+{"wakeAgent":false}
+```
+
+When action is needed, the script prints a short sanitized agent prompt plus a final JSON line with `wakeAgent:true`. The agent should use only the facts in that prompt, keep any user-facing message brief, name a likely cron only when confidence is high or medium, and suggest pausing/reporting the driver. If attribution is unknown or ambiguous, say that plainly instead of guessing.
+
+## Alert Policy
+
+Defaults:
+
+- lookback: 24 hours
+- cooldown: 72 hours per driver
+- state file: `memory/token-usage-audit.json`
+- total usage threshold: 100,000 tokens before spend-driver alerts
+
+The script wakes only for actionable drivers, such as:
+
+- cron-source usage is at least 60% of meaningful total usage
+- one known cron is at least 40% of usage and at least 50,000 tokens
+- one session is at least 250,000 tokens
+- unknown scheduled-work bucket is very large, but emitted as unknown rather than guessed
+- low-budget metadata is present and indicates a near-exhausted token budget
+
+Operators can opt out at install/reconcile time with `TOKEN_USAGE_AUDIT_CRON=off` or `--skip-token-usage-audit-cron`.
+
+## Manual Validation
+
+From the Hermes root:
+
+```bash
+python3 skills/token-usage-audit/scripts/audit_token_usage.py --json-only
+```
+
+The output must be sanitized aggregate JSON. On quiet runs, normal cron output should end with `{"wakeAgent":false}`.

--- a/skills/token-usage-audit/scripts/audit_token_usage.py
+++ b/skills/token-usage-audit/scripts/audit_token_usage.py
@@ -1,0 +1,963 @@
+#!/usr/bin/env python3
+"""Tenant-local token usage audit for AgentVillage.
+
+The audit is intentionally deterministic: it reads local Hermes dashboard
+session summaries and cron metadata, aggregates only token/tool counts, and
+prints a final JSON line that Hermes script cron can use as a wake contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "agentvillage.token_usage_audit.v1"
+DASHBOARD_URL = "http://127.0.0.1:9119"
+SESSION_HEADER = "X-Hermes-Session-Token"
+STATE_RELATIVE_PATH = Path("memory/token-usage-audit.json")
+
+INPUT_KEYS = {
+    "input_tokens",
+    "inputTokens",
+    "prompt_tokens",
+    "promptTokens",
+    "promptTokenCount",
+    "inputTokenCount",
+}
+OUTPUT_KEYS = {
+    "output_tokens",
+    "outputTokens",
+    "completion_tokens",
+    "completionTokens",
+    "completionTokenCount",
+    "outputTokenCount",
+}
+TOTAL_KEYS = {"total_tokens", "totalTokens", "tokens", "token_count", "tokenCount"}
+TOOL_COUNT_KEYS = {"tool_calls", "toolCalls", "tool_call_count", "toolCallCount"}
+TIME_KEYS = {
+    "timestamp",
+    "created_at",
+    "createdAt",
+    "updated_at",
+    "updatedAt",
+    "started_at",
+    "startedAt",
+    "ended_at",
+    "endedAt",
+    "last_run_at",
+    "lastRunAt",
+    "time",
+    "ts",
+    "date",
+}
+SOURCE_KEYS = {"source", "platform", "channel", "surface"}
+MODEL_KEYS = {"model", "model_name", "modelName", "response_model", "responseModel"}
+SESSION_KEYS = {"session_id", "sessionId", "session", "conversation_id", "conversationId", "thread_id", "threadId", "id"}
+USAGE_CONTAINER_KEYS = {"usage", "token_usage", "tokenUsage", "token_counts", "tokenCounts"}
+CRON_NAME_KEYS = {
+    "cron_name",
+    "cronName",
+    "job_name",
+    "jobName",
+    "cronJobName",
+    "cron_job_name",
+    "scheduled_job_name",
+    "scheduledJobName",
+}
+CRON_ID_KEYS = {
+    "cron_id",
+    "cronId",
+    "job_id",
+    "jobId",
+    "cronJobId",
+    "cron_job_id",
+    "scheduled_job_id",
+    "scheduledJobId",
+}
+CRON_CONTAINER_KEYS = {
+    "cron",
+    "job",
+    "scheduled_job",
+    "scheduledJob",
+    "cron_job",
+    "cronJob",
+    "source_details",
+    "sourceDetails",
+    "details",
+    "metadata",
+    "meta",
+}
+CRON_RUN_TIME_KEYS = {
+    "last_run_at",
+    "lastRunAt",
+    "last_started_at",
+    "lastStartedAt",
+    "started_at",
+    "startedAt",
+    "last_active_at",
+    "lastActiveAt",
+    "updated_at",
+    "updatedAt",
+}
+BUDGET_REMAINING_KEYS = {
+    "remaining_tokens",
+    "remainingTokens",
+    "budget_remaining_tokens",
+    "budgetRemainingTokens",
+    "tokenBudgetRemaining",
+}
+BUDGET_LIMIT_KEYS = {"token_budget", "tokenBudget", "budget_tokens", "budgetTokens", "tokenLimit"}
+BUDGET_USED_KEYS = {"used_tokens", "usedTokens", "budget_used_tokens", "budgetUsedTokens"}
+
+CRON_MATCH_BEFORE = timedelta(minutes=5)
+CRON_MATCH_AFTER = timedelta(minutes=90)
+MAX_TOP = 10
+MAX_FILE_BYTES = 10 * 1024 * 1024
+MAX_PARSE_ERRORS = 10
+SECRETISH_PATH_PARTS = {
+    ".env",
+    "config.yaml",
+    "config.yml",
+    "USER.md",
+    "MEMORY.md",
+    "IDENTITY.md",
+    "SOUL.md",
+    "profile",
+    "profiles",
+    "pairing",
+    "auth",
+    "token",
+    "tokens",
+    "secret",
+    "secrets",
+    "key",
+    "keys",
+    "credentials",
+    "cache",
+    "node_modules",
+    "skills",
+    ".git",
+}
+METADATA_NAME_HINTS = ("session", "sessions", "usage", "trace", "response", "cron", "jobs", "jsonl", "log")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_time(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+        if seconds > 10_000_000_000:
+            seconds /= 1000.0
+        try:
+            return datetime.fromtimestamp(seconds, timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if re.fullmatch(r"\d+(?:\.\d+)?", text):
+        return parse_time(float(text))
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def safe_number(value: Any) -> int:
+    if value is None or isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value) if value >= 0 else 0
+    if isinstance(value, str) and re.fullmatch(r"\d+(?:\.\d+)?", value.strip()):
+        return int(float(value.strip()))
+    return 0
+
+
+def sanitize_label(value: Any, default: str = "unknown", limit: int = 80) -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    if not text:
+        return default
+    text = re.sub(r"https?://\S+", "[url]", text)
+    text = re.sub(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+", "[email]", text)
+    text = re.sub(r"[^A-Za-z0-9._:/+ -]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return default
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def value_for_keys(obj: dict[str, Any], keys: set[str]) -> Any:
+    for key in keys:
+        if key in obj:
+            return obj.get(key)
+    return None
+
+
+def counts_from_obj(obj: dict[str, Any]) -> dict[str, int] | None:
+    input_tokens = sum(safe_number(obj.get(key)) for key in INPUT_KEYS)
+    output_tokens = sum(safe_number(obj.get(key)) for key in OUTPUT_KEYS)
+    total_tokens = sum(safe_number(obj.get(key)) for key in TOTAL_KEYS)
+    for key in USAGE_CONTAINER_KEYS:
+        usage = obj.get(key)
+        if isinstance(usage, dict):
+            input_tokens += sum(safe_number(usage.get(k)) for k in INPUT_KEYS)
+            output_tokens += sum(safe_number(usage.get(k)) for k in OUTPUT_KEYS)
+            total_tokens += sum(safe_number(usage.get(k)) for k in TOTAL_KEYS)
+    if not (input_tokens or output_tokens or total_tokens):
+        return None
+    total_tokens = max(total_tokens, input_tokens + output_tokens)
+    tool_calls = sum(safe_number(obj.get(key)) for key in TOOL_COUNT_KEYS)
+    if isinstance(obj.get("tool_calls"), list):
+        tool_calls = max(tool_calls, len(obj["tool_calls"]))
+    if isinstance(obj.get("toolCalls"), list):
+        tool_calls = max(tool_calls, len(obj["toolCalls"]))
+    return {
+        "records": 1,
+        "inputTokens": input_tokens,
+        "outputTokens": output_tokens,
+        "totalTokens": total_tokens,
+        "toolCalls": tool_calls,
+    }
+
+
+def empty_counts() -> dict[str, int]:
+    return {"records": 0, "inputTokens": 0, "outputTokens": 0, "totalTokens": 0, "toolCalls": 0}
+
+
+def merge_counts(target: dict[str, int], counts: dict[str, int]) -> None:
+    for key in ("records", "inputTokens", "outputTokens", "totalTokens", "toolCalls"):
+        target[key] += counts.get(key, 0)
+
+
+def first_time(obj: dict[str, Any]) -> datetime | None:
+    for key in TIME_KEYS:
+        parsed = parse_time(obj.get(key))
+        if parsed:
+            return parsed
+    return None
+
+
+def detect_source(obj: dict[str, Any], default: str = "unknown") -> str:
+    value = value_for_keys(obj, SOURCE_KEYS)
+    origin = obj.get("origin")
+    if value is None and isinstance(origin, dict):
+        value = value_for_keys(origin, SOURCE_KEYS)
+    return sanitize_label(value, default)
+
+
+def detect_model(obj: dict[str, Any], default: str = "unknown") -> str:
+    return sanitize_label(value_for_keys(obj, MODEL_KEYS), default)
+
+
+def detect_session_key(obj: dict[str, Any], fallback: str) -> str:
+    value = value_for_keys(obj, SESSION_KEYS)
+    text = str(value).strip() if value is not None else ""
+    return text or fallback
+
+
+def parse_sessions_list(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("data", "sessions", "items", "results"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def cron_public_name(job: dict[str, Any]) -> str:
+    for key in ("name", "title", "display_name", "displayName"):
+        if job.get(key):
+            return sanitize_label(job.get(key), "unnamed")
+    return "unnamed"
+
+
+def cron_id_values(job: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in CRON_ID_KEYS | {"id", "uuid", "key"}:
+        value = job.get(key)
+        if value is not None and str(value).strip():
+            values.append(str(value).strip())
+    return values
+
+
+def cron_run_time(job: dict[str, Any]) -> datetime | None:
+    for key in CRON_RUN_TIME_KEYS:
+        parsed = parse_time(job.get(key))
+        if parsed:
+            return parsed
+    return None
+
+
+def cron_schedule(job: dict[str, Any]) -> str:
+    schedule = job.get("schedule_display") or job.get("schedule") or ""
+    if isinstance(schedule, dict):
+        schedule = schedule.get("display") or schedule.get("expr") or schedule.get("kind") or ""
+    return sanitize_label(schedule, "unknown")
+
+
+@dataclass
+class CronRun:
+    name: str
+    ids: list[str]
+    last_run: datetime | None
+
+
+def load_crons(root: Path, since: datetime, now: datetime) -> tuple[dict[str, Any], dict[str, Any]]:
+    public: dict[str, Any] = {"available": False, "totalJobs": 0, "recentRuns": 0, "jobs": []}
+    index: dict[str, Any] = {"byId": {}, "byName": {}, "runs": []}
+    jobs_file = root / "cron" / "jobs.json"
+    if not jobs_file.exists():
+        return public, index
+    public["available"] = True
+    try:
+        data = json.loads(jobs_file.read_text(encoding="utf-8", errors="replace"))
+    except Exception as exc:  # noqa: BLE001 - error type only is emitted.
+        public["error"] = f"cron_jobs_parse_error:{type(exc).__name__}"
+        return public, index
+    jobs = data.get("jobs") if isinstance(data, dict) else data if isinstance(data, list) else []
+    if not isinstance(jobs, list):
+        public["error"] = "cron_jobs_shape_error"
+        return public, index
+    public["totalJobs"] = len(jobs)
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        name = cron_public_name(job)
+        last_run = cron_run_time(job)
+        recent = bool(last_run and since <= last_run <= now)
+        if recent:
+            public["recentRuns"] += 1
+        run = CronRun(name=name, ids=cron_id_values(job), last_run=last_run)
+        for cron_id in run.ids:
+            index["byId"][cron_id] = run
+        index["byName"][name.lower()] = run
+        if run.last_run:
+            index["runs"].append(run)
+        public["jobs"].append(
+            {
+                "name": name,
+                "enabled": bool(job.get("enabled", True)),
+                "state": sanitize_label(job.get("state"), "unknown"),
+                "deliver": sanitize_label(job.get("deliver"), "none"),
+                "schedule": cron_schedule(job),
+                "lastRunInWindow": recent,
+                "lastStatus": sanitize_label(job.get("last_status"), "unknown"),
+                "scriptPresent": bool(job.get("script")),
+                "promptExcluded": True,
+            }
+        )
+    public["jobs"].sort(key=lambda row: (not row["lastRunInWindow"], row["name"]))
+    return public, index
+
+
+def find_cron_metadata(obj: dict[str, Any], depth: int = 0) -> dict[str, Any]:
+    if depth > 3:
+        return {}
+    name = value_for_keys(obj, CRON_NAME_KEYS)
+    cron_id = value_for_keys(obj, CRON_ID_KEYS)
+    if name or cron_id:
+        return {"name": name, "id": cron_id}
+    for key in CRON_CONTAINER_KEYS:
+        value = obj.get(key)
+        if not isinstance(value, dict):
+            continue
+        result = find_cron_metadata(value, depth + 1)
+        generic_name = value_for_keys(value, {"name", "title", "display_name", "displayName"})
+        if result or generic_name:
+            result = dict(result)
+            if generic_name and not result.get("name"):
+                result["name"] = generic_name
+            return result
+    return {}
+
+
+def default_attribution(method: str) -> dict[str, Any]:
+    return {"cronName": "unknown", "method": method, "confidence": "none", "ambiguityCount": 0}
+
+
+def attribution_from_run(run: CronRun, method: str, confidence: str, candidate_count: int = 1) -> dict[str, Any]:
+    return {
+        "cronName": sanitize_label(run.name, "unknown"),
+        "method": method,
+        "confidence": confidence,
+        "ambiguityCount": max(0, candidate_count - 1),
+    }
+
+
+def attribute_cron(session: dict[str, Any], session_time: datetime | None, cron_index: dict[str, Any]) -> dict[str, Any]:
+    metadata = find_cron_metadata(session)
+    raw_id = metadata.get("id")
+    if raw_id is not None:
+        run = cron_index["byId"].get(str(raw_id).strip())
+        if run:
+            return attribution_from_run(run, "metadata_id", "high")
+    raw_name = metadata.get("name")
+    if raw_name is not None:
+        name = sanitize_label(raw_name, "unknown")
+        run = cron_index["byName"].get(name.lower())
+        if run:
+            return attribution_from_run(run, "metadata_name", "high")
+        if name != "unknown":
+            return {"cronName": name, "method": "metadata_name_unverified", "confidence": "medium", "ambiguityCount": 0}
+    if not session_time:
+        return default_attribution("missing_session_timestamp")
+    candidates: list[tuple[float, CronRun]] = []
+    for run in cron_index["runs"]:
+        if not run.last_run:
+            continue
+        if run.last_run - CRON_MATCH_BEFORE <= session_time <= run.last_run + CRON_MATCH_AFTER:
+            delta = abs((session_time - run.last_run).total_seconds())
+            candidates.append((delta, run))
+    if not candidates:
+        return default_attribution("time_window_no_match")
+    candidates.sort(key=lambda item: (item[0], item[1].name))
+    best_delta, best_run = candidates[0]
+    confidence = "medium" if len(candidates) == 1 else "low"
+    method = "time_window_nearest" if len(candidates) == 1 else "time_window_nearest_ambiguous"
+    attribution = attribution_from_run(best_run, method, confidence, len(candidates))
+    if best_delta > 45 * 60:
+        attribution["confidence"] = "low"
+    return attribution
+
+
+class AuditState:
+    def __init__(self) -> None:
+        self.totals = empty_counts()
+        self.by_source: dict[str, dict[str, int]] = defaultdict(empty_counts)
+        self.by_model: dict[str, dict[str, int]] = defaultdict(empty_counts)
+        self.by_cron: dict[str, dict[str, int]] = defaultdict(empty_counts)
+        self.by_cron_attribution: dict[tuple[str, str], dict[str, int]] = defaultdict(empty_counts)
+        self.by_session: dict[str, dict[str, int]] = defaultdict(empty_counts)
+        self.session_cron: dict[str, dict[str, Any]] = {}
+        self.budget_signals: list[dict[str, Any]] = []
+
+    def add_record(
+        self,
+        counts: dict[str, int],
+        source: str,
+        model: str,
+        session_key: str,
+        attribution: dict[str, Any] | None,
+        budget: dict[str, Any] | None = None,
+    ) -> None:
+        merge_counts(self.totals, counts)
+        merge_counts(self.by_source[source], counts)
+        merge_counts(self.by_model[model], counts)
+        merge_counts(self.by_session[session_key], counts)
+        if attribution:
+            merge_counts(self.by_cron[attribution["cronName"]], counts)
+            merge_counts(self.by_cron_attribution[(attribution["method"], attribution["confidence"])], counts)
+            self.session_cron[session_key] = attribution
+        if budget:
+            self.budget_signals.append(budget)
+
+
+def extract_budget_signal(obj: dict[str, Any]) -> dict[str, Any] | None:
+    remaining = safe_number(value_for_keys(obj, BUDGET_REMAINING_KEYS))
+    limit = safe_number(value_for_keys(obj, BUDGET_LIMIT_KEYS))
+    used = safe_number(value_for_keys(obj, BUDGET_USED_KEYS))
+    if not (remaining or limit or used):
+        usage = obj.get("usage")
+        if isinstance(usage, dict):
+            remaining = safe_number(value_for_keys(usage, BUDGET_REMAINING_KEYS))
+            limit = safe_number(value_for_keys(usage, BUDGET_LIMIT_KEYS))
+            used = safe_number(value_for_keys(usage, BUDGET_USED_KEYS))
+    if not (remaining or limit or used):
+        return None
+    return {"remainingTokens": remaining, "budgetTokens": limit, "usedTokens": used}
+
+
+def dashboard_get(url: str, path: str, token: str | None = None, timeout: float = 10.0) -> str:
+    request = urllib.request.Request(url.rstrip("/") + path)
+    if token:
+        request.add_header(SESSION_HEADER, token)
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def dashboard_token(url: str) -> str | None:
+    html = dashboard_get(url, "/")
+    match = re.search(r'window\.__HERMES_SESSION_TOKEN__="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+def collect_dashboard_sessions(
+    audit: AuditState,
+    cron_index: dict[str, Any],
+    since: datetime,
+    now: datetime,
+    url: str,
+    sessions_file: Path | None = None,
+) -> dict[str, Any]:
+    details: dict[str, Any] = {
+        "available": False,
+        "sessionsSeen": 0,
+        "sessionsInWindow": 0,
+        "usageRecords": 0,
+        "error": None,
+    }
+    try:
+        if sessions_file:
+            data = json.loads(sessions_file.read_text(encoding="utf-8"))
+        else:
+            token = dashboard_token(url)
+            if not token:
+                details["error"] = "dashboard_session_token_missing"
+                return details
+            data = json.loads(dashboard_get(url, "/api/sessions?limit=500", token=token))
+        sessions = parse_sessions_list(data)
+        details["available"] = True
+        details["sessionsSeen"] = len(sessions)
+        for idx, session in enumerate(sessions, 1):
+            if not isinstance(session, dict):
+                continue
+            ts = first_time(session)
+            if not ts or not (since <= ts <= now):
+                continue
+            details["sessionsInWindow"] += 1
+            counts = counts_from_obj(session)
+            if not counts:
+                continue
+            attribution = attribute_cron(session, ts, cron_index)
+            audit.add_record(
+                counts,
+                detect_source(session),
+                detect_model(session),
+                detect_session_key(session, f"dashboard:{idx}"),
+                attribution,
+                extract_budget_signal(session),
+            )
+            details["usageRecords"] += 1
+    except Exception as exc:  # noqa: BLE001 - sanitized error only.
+        details["error"] = f"dashboard_fetch_error:{type(exc).__name__}"
+    return details
+
+
+def should_scan(path: Path, root: Path) -> bool:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    parts = {part.lower() for part in rel.parts}
+    if any(part in SECRETISH_PATH_PARTS for part in parts):
+        return False
+    if path.suffix.lower() not in {".json", ".jsonl"}:
+        return False
+    joined = "/".join(rel.parts).lower()
+    return any(hint in joined for hint in METADATA_NAME_HINTS)
+
+
+def iter_json_records(path: Path) -> Any:
+    if path.suffix.lower() == ".jsonl":
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                text = line.strip()
+                if text:
+                    yield json.loads(text)
+        return
+    yield json.loads(path.read_text(encoding="utf-8", errors="replace"))
+
+
+def collect_file_fallback(audit: AuditState, root: Path, since: datetime, now: datetime) -> dict[str, Any]:
+    details = {"enabled": True, "filesScanned": 0, "recordsParsed": 0, "usageRecords": 0, "parseErrorCount": 0}
+    errors = 0
+    for path in root.rglob("*"):
+        if not path.is_file() or not should_scan(path, root):
+            continue
+        details["filesScanned"] += 1
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        if stat.st_size > MAX_FILE_BYTES:
+            continue
+        file_time = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        if file_time < since - timedelta(hours=12):
+            continue
+        try:
+            for record in iter_json_records(path):
+                details["recordsParsed"] += 1
+                if isinstance(record, dict):
+                    ts = first_time(record) or file_time
+                    counts = counts_from_obj(record)
+                    if counts and since <= ts <= now:
+                        audit.add_record(
+                            counts,
+                            detect_source(record),
+                            detect_model(record),
+                            f"file:{details['usageRecords'] + 1}",
+                            None,
+                            extract_budget_signal(record),
+                        )
+                        details["usageRecords"] += 1
+        except Exception:
+            errors += 1
+            details["parseErrorCount"] = min(errors, MAX_PARSE_ERRORS)
+    return details
+
+
+def sorted_rollup(mapping: dict[str, dict[str, int]]) -> list[dict[str, Any]]:
+    rows = [{"label": sanitize_label(label), **counts} for label, counts in mapping.items()]
+    rows.sort(key=lambda row: (row["totalTokens"], row["records"]), reverse=True)
+    return rows[:MAX_TOP]
+
+
+def sorted_attribution_rollup(mapping: dict[tuple[str, str], dict[str, int]]) -> list[dict[str, Any]]:
+    rows = [
+        {"method": sanitize_label(method), "confidence": sanitize_label(confidence), **counts}
+        for (method, confidence), counts in mapping.items()
+    ]
+    rows.sort(key=lambda row: (row["totalTokens"], row["records"]), reverse=True)
+    return rows[:MAX_TOP]
+
+
+def session_rollup(audit: AuditState) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    items = sorted(audit.by_session.items(), key=lambda item: (item[1]["totalTokens"], item[1]["records"]), reverse=True)
+    for idx, (raw_session, counts) in enumerate(items[:MAX_TOP], 1):
+        row: dict[str, Any] = {"sessionRef": f"session_{idx:03d}", **counts}
+        attribution = audit.session_cron.get(raw_session)
+        if attribution:
+            row["cronName"] = attribution["cronName"]
+            row["cronAttribution"] = {
+                "method": attribution["method"],
+                "confidence": attribution["confidence"],
+                "ambiguityCount": attribution["ambiguityCount"],
+            }
+        rows.append(row)
+    return rows
+
+
+def pct(part: int, total: int) -> float:
+    return round((part / total) * 100, 1) if total else 0.0
+
+
+def driver_key(driver: dict[str, Any]) -> str:
+    return sanitize_label(f"{driver.get('type')}:{driver.get('name')}", "unknown", limit=120)
+
+
+def driver_priority(driver: dict[str, Any]) -> int:
+    priorities = {
+        "low_budget": 5,
+        "single_cron": 4,
+        "single_session": 3,
+        "unknown_cron_bucket": 2,
+        "cron_share": 1,
+    }
+    return priorities.get(str(driver.get("type")), 0)
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def decide_alert(
+    result: dict[str, Any],
+    state: dict[str, Any],
+    now: datetime,
+    cooldown_hours: float,
+    total_threshold: int,
+) -> tuple[bool, dict[str, Any] | None]:
+    total = result["totals"]["totalTokens"]
+    by_cron = result["byCron"]
+    by_source = result["bySource"]
+    top_sessions = result["topSessions"]
+    budget_signals = result.get("budgetSignals", [])
+    candidates: list[dict[str, Any]] = []
+
+    if total >= total_threshold:
+        cron_tokens = sum(row["totalTokens"] for row in by_source if row["label"].lower() == "cron")
+        if cron_tokens >= total * 0.60:
+            candidates.append(
+                {
+                    "type": "cron_share",
+                    "name": "scheduled background work",
+                    "reason": "cron_source_share",
+                    "totalTokens": cron_tokens,
+                    "sharePct": pct(cron_tokens, total),
+                    "confidence": "medium",
+                    "action": "Review scheduled jobs and pause or narrow the background driver if this spend was unexpected.",
+                }
+            )
+        for row in by_cron:
+            name = row["label"]
+            share = row["totalTokens"] / total if total else 0
+            if name != "unknown" and row["totalTokens"] >= 50_000 and share >= 0.40:
+                attr = next((s for s in top_sessions if s.get("cronName") == name), {})
+                cron_attr = attr.get("cronAttribution", {})
+                if cron_attr.get("confidence") in {"high", "medium"}:
+                    candidates.append(
+                        {
+                            "type": "single_cron",
+                            "name": name,
+                            "reason": "single_cron_driver",
+                            "totalTokens": row["totalTokens"],
+                            "sharePct": pct(row["totalTokens"], total),
+                            "confidence": cron_attr.get("confidence", "medium"),
+                            "attribution": cron_attr,
+                            "action": "Consider pausing this cron or narrowing its prompt/script before the next run.",
+                        }
+                    )
+            if name == "unknown" and (row["totalTokens"] >= 500_000 or share >= 0.50):
+                candidates.append(
+                    {
+                        "type": "unknown_cron_bucket",
+                        "name": "unknown scheduled work",
+                        "reason": "unknown_cron_bucket",
+                        "totalTokens": row["totalTokens"],
+                        "sharePct": pct(row["totalTokens"], total),
+                        "confidence": "none",
+                        "action": "Check recently-run cron jobs; attribution was intentionally left unknown rather than guessed.",
+                    }
+                )
+        for row in top_sessions:
+            if row["totalTokens"] >= 250_000:
+                name = row.get("cronName") or row["sessionRef"]
+                candidates.append(
+                    {
+                        "type": "single_session",
+                        "name": name,
+                        "reason": "single_session_spike",
+                        "totalTokens": row["totalTokens"],
+                        "sharePct": pct(row["totalTokens"], total),
+                        "confidence": row.get("cronAttribution", {}).get("confidence", "medium"),
+                        "attribution": row.get("cronAttribution"),
+                        "action": "Inspect the named cron if present; otherwise look for one unusually large recent session.",
+                    }
+                )
+    for budget in budget_signals:
+        remaining = safe_number(budget.get("remainingTokens"))
+        limit = safe_number(budget.get("budgetTokens"))
+        used = safe_number(budget.get("usedTokens"))
+        if remaining and remaining <= 50_000:
+            candidates.append(
+                {
+                    "type": "low_budget",
+                    "name": "token budget",
+                    "reason": "low_budget_remaining",
+                    "remainingTokens": remaining,
+                    "budgetTokens": limit,
+                    "usedTokens": used,
+                    "confidence": "high",
+                    "action": "Reduce or pause scheduled background work until budget is refreshed.",
+                }
+            )
+        elif limit and used and used >= limit * 0.80:
+            candidates.append(
+                {
+                    "type": "low_budget",
+                    "name": "token budget",
+                    "reason": "budget_usage_high",
+                    "remainingTokens": remaining,
+                    "budgetTokens": limit,
+                    "usedTokens": used,
+                    "confidence": "high",
+                    "action": "Reduce or pause scheduled background work until budget is refreshed.",
+                }
+            )
+
+    if not candidates:
+        return False, None
+
+    if any(candidate.get("type") in {"single_cron", "single_session", "unknown_cron_bucket"} for candidate in candidates):
+        candidates = [candidate for candidate in candidates if candidate.get("type") != "cron_share"]
+
+    candidates.sort(
+        key=lambda candidate: (
+            driver_priority(candidate),
+            safe_number(candidate.get("totalTokens")),
+            safe_number(candidate.get("usedTokens")),
+            safe_number(candidate.get("remainingTokens")) * -1,
+        ),
+        reverse=True,
+    )
+    last_alerts = state.get("lastAlerts", {}) if isinstance(state.get("lastAlerts"), dict) else {}
+    for candidate in candidates:
+        key = driver_key(candidate)
+        last = parse_time(last_alerts.get(key))
+        if last and now - last < timedelta(hours=cooldown_hours):
+            candidate["cooldownActive"] = True
+            candidate["lastAlertAt"] = last.isoformat()
+            continue
+        candidate["driverKey"] = key
+        return True, candidate
+    return False, {"suppressedByCooldown": True, "candidateCount": len(candidates)}
+
+
+def run_audit(
+    root: Path,
+    lookback_hours: float,
+    dashboard_url: str = DASHBOARD_URL,
+    dashboard_sessions_file: Path | None = None,
+    file_fallback: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    now = now or now_utc()
+    since = now - timedelta(hours=lookback_hours)
+    cron_public, cron_index = load_crons(root, since, now)
+    audit = AuditState()
+    dashboard = collect_dashboard_sessions(audit, cron_index, since, now, dashboard_url, dashboard_sessions_file)
+    file_details = {"enabled": False, "reason": "dashboard_usage_available"}
+    if file_fallback and dashboard["usageRecords"] == 0:
+        file_details = collect_file_fallback(audit, root, since, now)
+    return {
+        "schema": SCHEMA,
+        "generatedAt": now.isoformat(),
+        "lookbackHours": lookback_hours,
+        "privacy": {
+            "redacted": True,
+            "rawContentIncluded": False,
+            "rawSessionIdsIncluded": False,
+            "privateHostsIncluded": False,
+            "secretsIncluded": False,
+            "notes": [
+                "Dashboard session ids are used only for in-process grouping and emitted as ordinal session refs.",
+                "Cron prompts, message text, env files, config files, profiles, secrets, and memory prose are excluded.",
+            ],
+        },
+        "coverage": {
+            "root": "HERMES_HOME",
+            "dashboardLocalApi": dashboard,
+            "fileFallback": file_details,
+            "countingMethod": "local dashboard session token summaries; metadata JSON fallback only when dashboard usage is unavailable",
+        },
+        "totals": audit.totals,
+        "bySource": sorted_rollup(audit.by_source),
+        "byModel": sorted_rollup(audit.by_model),
+        "byCron": sorted_rollup(audit.by_cron),
+        "byCronAttribution": sorted_attribution_rollup(audit.by_cron_attribution),
+        "topSessions": session_rollup(audit),
+        "budgetSignals": audit.budget_signals[:MAX_TOP],
+        "cron": cron_public,
+    }
+
+
+def alert_prompt(result: dict[str, Any], driver: dict[str, Any]) -> str:
+    safe_payload = {
+        "schema": result["schema"],
+        "wakeAgent": True,
+        "generatedAt": result["generatedAt"],
+        "lookbackHours": result["lookbackHours"],
+        "driver": driver,
+        "totals": result["totals"],
+        "bySource": result["bySource"][:5],
+        "byModel": result["byModel"][:5],
+        "byCron": result["byCron"][:5],
+        "byCronAttribution": result["byCronAttribution"][:5],
+        "topSessions": result["topSessions"][:5],
+        "privacy": result["privacy"],
+    }
+    return "\n".join(
+        [
+            "# AgentVillage Token Usage Audit",
+            "",
+            "A deterministic local audit found an actionable token usage driver.",
+            "Use only these sanitized facts. Do not mention raw session ids, private hosts, prompts, transcripts, or secrets.",
+            "If messaging the resident, keep it brief: name the likely scheduled driver when confidence is high/medium, explain that background work drove spend, and suggest pausing or reporting the driver.",
+            "",
+            "```json",
+            json.dumps(safe_payload, indent=2, sort_keys=True),
+            "```",
+            json.dumps({"wakeAgent": True, "driver": driver}, sort_keys=True, separators=(",", ":")),
+        ]
+    )
+
+
+def update_run_state(
+    state: dict[str, Any],
+    result: dict[str, Any],
+    now: datetime,
+    wake: bool,
+    driver: dict[str, Any] | None,
+) -> dict[str, Any]:
+    next_state = dict(state)
+    next_state["schema"] = SCHEMA
+    next_state["lastRunAt"] = now.isoformat()
+    next_state["lastTotals"] = result["totals"]
+    if wake and driver and driver.get("driverKey"):
+        alerts = next_state.get("lastAlerts") if isinstance(next_state.get("lastAlerts"), dict) else {}
+        alerts[driver["driverKey"]] = now.isoformat()
+        next_state["lastAlerts"] = alerts
+        next_state["lastAlert"] = {"at": now.isoformat(), "driver": driver}
+    return next_state
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=os.environ.get("HERMES_HOME") or os.environ.get("HOME") or ".")
+    parser.add_argument("--lookback-hours", type=float, default=float(os.environ.get("TOKEN_USAGE_AUDIT_LOOKBACK_HOURS", "24")))
+    parser.add_argument("--cooldown-hours", type=float, default=float(os.environ.get("TOKEN_USAGE_AUDIT_COOLDOWN_HOURS", "72")))
+    parser.add_argument("--total-threshold", type=int, default=int(os.environ.get("TOKEN_USAGE_AUDIT_TOTAL_THRESHOLD", "100000")))
+    parser.add_argument("--dashboard-url", default=os.environ.get("TOKEN_USAGE_AUDIT_DASHBOARD_URL", DASHBOARD_URL))
+    parser.add_argument("--dashboard-sessions-file", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--no-file-fallback", action="store_true")
+    parser.add_argument("--json-only", action="store_true", help="Print the full audit JSON and skip prompt text.")
+    args = parser.parse_args()
+
+    root = Path(args.root).expanduser().resolve()
+    state_path = root / STATE_RELATIVE_PATH
+    now = now_utc()
+    state = load_state(state_path)
+    result = run_audit(
+        root=root,
+        lookback_hours=args.lookback_hours,
+        dashboard_url=args.dashboard_url,
+        dashboard_sessions_file=args.dashboard_sessions_file,
+        file_fallback=not args.no_file_fallback,
+        now=now,
+    )
+    wake, driver = decide_alert(result, state, now, args.cooldown_hours, args.total_threshold)
+    save_state(state_path, update_run_state(state, result, now, wake, driver if wake else None))
+
+    if args.json_only:
+        print(json.dumps({**result, "wakeAgent": wake, "driver": driver}, sort_keys=True, separators=(",", ":")))
+    elif wake and driver:
+        print(alert_prompt(result, driver))
+    else:
+        print(json.dumps({"wakeAgent": False}, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001 - sanitize failure for cron.
+        safe = {
+            "schema": SCHEMA,
+            "generatedAt": now_utc().isoformat(),
+            "error": "audit_script_failed",
+            "errorType": type(exc).__name__,
+            "wakeAgent": False,
+        }
+        print(json.dumps(safe, sort_keys=True, separators=(",", ":")))
+        raise SystemExit(1)

--- a/skills/token-usage-audit/scripts/tests/test_audit_token_usage.py
+++ b/skills/token-usage-audit/scripts/tests/test_audit_token_usage.py
@@ -1,0 +1,186 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "audit_token_usage.py"
+SPEC = importlib.util.spec_from_file_location("audit_token_usage", SCRIPT)
+audit = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules["audit_token_usage"] = audit
+SPEC.loader.exec_module(audit)
+
+
+NOW = datetime(2026, 6, 22, 12, 0, tzinfo=timezone.utc)
+
+
+class TokenUsageAuditTests(unittest.TestCase):
+    def write_json(self, path: Path, data: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_cron_attribution_prefers_safe_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_json(
+                root / "cron/jobs.json",
+                {
+                    "jobs": [
+                        {"id": "job-safe-id", "name": "Edge - digest prepare", "lastRunAt": "2026-06-22T11:00:00Z"},
+                        {"id": "other", "name": "Other cron", "lastRunAt": "2026-06-22T11:00:00Z"},
+                    ]
+                },
+            )
+            cron_public, cron_index = audit.load_crons(root, NOW.replace(hour=0), NOW)
+
+            attribution = audit.attribute_cron(
+                {"createdAt": "2026-06-22T11:05:00Z", "metadata": {"jobId": "job-safe-id"}},
+                audit.parse_time("2026-06-22T11:05:00Z"),
+                cron_index,
+            )
+
+        self.assertEqual(cron_public["totalJobs"], 2)
+        self.assertEqual(attribution["cronName"], "Edge - digest prepare")
+        self.assertEqual(attribution["method"], "metadata_id")
+        self.assertEqual(attribution["confidence"], "high")
+        self.assertEqual(attribution["ambiguityCount"], 0)
+
+    def test_cron_attribution_marks_ambiguous_timestamp_matches_low_confidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_json(
+                root / "cron/jobs.json",
+                {
+                    "jobs": [
+                        {"id": "a", "name": "Edge - digest prepare", "lastRunAt": "2026-06-22T11:00:00Z"},
+                        {"id": "b", "name": "Edge - daily digest", "lastRunAt": "2026-06-22T11:03:00Z"},
+                    ]
+                },
+            )
+            _, cron_index = audit.load_crons(root, NOW.replace(hour=0), NOW)
+
+            attribution = audit.attribute_cron(
+                {"createdAt": "2026-06-22T11:04:00Z"},
+                audit.parse_time("2026-06-22T11:04:00Z"),
+                cron_index,
+            )
+
+        self.assertEqual(attribution["method"], "time_window_nearest_ambiguous")
+        self.assertEqual(attribution["confidence"], "low")
+        self.assertEqual(attribution["ambiguityCount"], 1)
+
+    def test_decision_wakes_for_actionable_known_cron_and_cools_down(self) -> None:
+        result = {
+            "totals": {"totalTokens": 160_000},
+            "bySource": [{"label": "cron", "totalTokens": 160_000}],
+            "byCron": [{"label": "Edge - digest prepare", "totalTokens": 120_000}],
+            "topSessions": [
+                {
+                    "sessionRef": "session_001",
+                    "totalTokens": 120_000,
+                    "cronName": "Edge - digest prepare",
+                    "cronAttribution": {"method": "metadata_name", "confidence": "high", "ambiguityCount": 0},
+                }
+            ],
+            "budgetSignals": [],
+        }
+
+        wake, driver = audit.decide_alert(result, {}, NOW, cooldown_hours=72, total_threshold=100_000)
+
+        self.assertTrue(wake)
+        self.assertIsNotNone(driver)
+        self.assertEqual(driver["type"], "single_cron")
+        state = {"lastAlerts": {driver["driverKey"]: NOW.isoformat()}}
+        wake_again, cooled = audit.decide_alert(result, state, NOW, cooldown_hours=72, total_threshold=100_000)
+        self.assertFalse(wake_again)
+        self.assertEqual(cooled["suppressedByCooldown"], True)
+
+    def test_cli_no_alert_prints_quiet_contract_and_sanitizes_session_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sessions = root / "sessions.json"
+            current = datetime.now(timezone.utc).isoformat()
+            self.write_json(
+                sessions,
+                {
+                    "sessions": [
+                        {
+                            "id": "raw-secret-session-id",
+                            "createdAt": current,
+                            "source": "chat",
+                            "model": "gpt-test",
+                            "usage": {"totalTokens": 1_000},
+                        }
+                    ]
+                },
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--root",
+                    str(root),
+                    "--dashboard-sessions-file",
+                    str(sessions),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+        self.assertEqual(json.loads(completed.stdout.strip().splitlines()[-1]), {"wakeAgent": False})
+        self.assertNotIn("raw-secret-session-id", completed.stdout)
+
+    def test_cli_alert_shape_uses_sanitized_facts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            current = datetime.now(timezone.utc).isoformat()
+            self.write_json(
+                root / "cron/jobs.json",
+                {"jobs": [{"id": "job1", "name": "Edge - digest prepare", "lastRunAt": current}]},
+            )
+            sessions = root / "sessions.json"
+            self.write_json(
+                sessions,
+                {
+                    "sessions": [
+                        {
+                            "id": "raw-secret-session-id",
+                            "createdAt": current,
+                            "source": "cron",
+                            "model": "gpt-test",
+                            "metadata": {"jobId": "job1"},
+                            "usage": {"totalTokens": 180_000},
+                            "toolCalls": 7,
+                        }
+                    ]
+                },
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--root",
+                    str(root),
+                    "--dashboard-sessions-file",
+                    str(sessions),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+        last = json.loads(completed.stdout.strip().splitlines()[-1])
+        self.assertTrue(last["wakeAgent"])
+        self.assertEqual(last["driver"]["type"], "single_cron")
+        self.assertIn("Edge - digest prepare", completed.stdout)
+        self.assertNotIn("raw-secret-session-id", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Story

Residents should be able to understand when their agent's token budget is being spent by background work rather than direct chat. This adds a tenant-local token usage audit that is deterministic by default: Hermes runs a Python script first, and the agent only wakes when the script finds a meaningful, actionable driver in the last day.

The intended user-facing behavior is narrow: if scheduled background work dominates usage, the agent can tell the resident the likely background job when attribution is safe, or say attribution is unknown when it is not. Quiet runs end with `{"wakeAgent":false}` and skip the agent entirely.

## What changed

- Add `skills/token-usage-audit/` with a deterministic audit script and skill docs.
- Read local dashboard session summaries plus `cron/jobs.json`, with metadata fallback only when dashboard usage has no usable token records.
- Attribute cron usage from explicit safe metadata first, then conservative timestamp proximity, emitting method/confidence/ambiguity.
- Gate alerts by thresholds and 72-hour per-driver cooldown state in `memory/token-usage-audit.json`.
- Install a script-backed Hermes cron, copied into `$HERMES_HOME/scripts/agentvillage_token_usage_audit.py`, with Telegram delivery gated by the script wake line.
- Add installer opt-out via `--skip-token-usage-audit-cron` or `TOKEN_USAGE_AUDIT_CRON=off`.
- Extend installer and script tests for create/reconcile, opt-out, stale script path repair, attribution, cooldown, quiet output, and sanitized alert output.

## Validation

- `bun test install/tests`
- `python3 -m unittest discover -s skills/token-usage-audit/scripts/tests -p 'test_*.py'`
- `git diff --check`

## Review notes

I spawned two bb review threads against this worktree. Both stalled before producing completed findings: the first blocked on read-only test approval, and the second stalled during file exploration. I stopped both rather than leave active agents running. I then performed a manual final review of the changed installer/script paths and reran the validation above.
