### PR TITLE
Suppress OpenRouter budget cron failure notices

### DIFF
--- a/install/hermes_runtime_patches.ts
+++ b/install/hermes_runtime_patches.ts
@@ -1,0 +1,114 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { hermesBin, hermesExecEnv } from "./hermes_cli";
+
+const QUIET_HELPER = `def _is_quiet_cron_failure(error: Optional[str]) -> bool:
+    """Return True for expected provider-budget failures that should stay internal."""
+    if not error:
+        return False
+    message = str(error).lower()
+    budget_exhausted = "key limit exceeded" in message or "spending limit" in message
+    if not budget_exhausted:
+        return False
+    return "403" in message or "openrouter" in message or "billing" in message
+
+
+`;
+
+const HELPER_ANCHOR = `SILENT_MARKER = "[SILENT]"
+
+`;
+
+const DELIVERY_BLOCK = `                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\\n{error}"
+                should_deliver = bool(deliver_content)
+                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    should_deliver = False
+`;
+
+const PATCHED_DELIVERY_BLOCK = `                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\\n{error}"
+                should_deliver = bool(deliver_content)
+                if should_deliver and not success and _is_quiet_cron_failure(error):
+                    logger.info(
+                        "Job '%s': suppressing delivery for quiet provider-budget failure: %s",
+                        job["id"],
+                        error,
+                    )
+                    should_deliver = False
+                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    should_deliver = False
+`;
+
+export function patchHermesSchedulerSource(source: string): { source: string; changed: boolean } {
+  let next = source;
+
+  if (!next.includes("def _is_quiet_cron_failure(")) {
+    if (!next.includes(HELPER_ANCHOR)) {
+      throw new Error("Hermes scheduler helper anchor not found");
+    }
+    next = next.replace(HELPER_ANCHOR, HELPER_ANCHOR + QUIET_HELPER);
+  }
+
+  if (!next.includes("_is_quiet_cron_failure(error)")) {
+    if (!next.includes(DELIVERY_BLOCK)) {
+      throw new Error("Hermes scheduler delivery block not found");
+    }
+    next = next.replace(DELIVERY_BLOCK, PATCHED_DELIVERY_BLOCK);
+  }
+
+  return { source: next, changed: next !== source };
+}
+
+function candidatePythonBins(): string[] {
+  const bin = hermesBin();
+  return [
+    process.env.HERMES_PYTHON?.trim() || "",
+    join(dirname(bin), "python"),
+    "python3",
+    "python",
+  ].filter(Boolean);
+}
+
+function locateHermesScheduler(): string | null {
+  const script = "import cron.scheduler; print(cron.scheduler.__file__)";
+  for (const python of candidatePythonBins()) {
+    try {
+      const out = execFileSync(python, ["-c", script], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        env: hermesExecEnv(),
+      }).trim();
+      if (out && existsSync(out)) return out;
+    } catch {
+      // Try the next interpreter.
+    }
+  }
+  return null;
+}
+
+export function patchHermesCronFailureDelivery(): void {
+  try {
+    const schedulerPath = locateHermesScheduler();
+    if (!schedulerPath) {
+      console.warn("  warning: Hermes cron scheduler source not found; provider-budget cron failures may still notify users");
+      return;
+    }
+
+    const current = readFileSync(schedulerPath, "utf8");
+    const patched = patchHermesSchedulerSource(current);
+    if (!patched.changed) {
+      console.log("→ Hermes cron quiet-failure patch already present");
+      return;
+    }
+
+    writeFileSync(schedulerPath, patched.source, "utf8");
+    console.log(`→ patched Hermes cron quiet-failure delivery at ${schedulerPath}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`  warning: could not patch Hermes cron quiet-failure delivery: ${message}`);
+    return;
+  }
+}

--- a/install/install.ts
+++ b/install/install.ts
@@ -37,6 +37,7 @@ import { installEdgeos } from "./install_edgeos";
 import { installGeo } from "./install_geo";
 import { capModelMaxTokens, configureStt, disableGatewayStreaming, setTerminalCwd } from "./config";
 import { hermesBin, hermesExecEnv } from "./hermes_cli";
+import { patchHermesCronFailureDelivery } from "./hermes_runtime_patches";
 import {
   EDGE_SKILL_NAMES,
   hermesHome,
@@ -202,6 +203,7 @@ function main(): void {
   capModelMaxTokens();
   disableGatewayStreaming();
   configureStt();
+  patchHermesCronFailureDelivery();
 
   installIndex();
   installEdgeos();

--- a/install/tests/hermes_runtime_patches.test.ts
+++ b/install/tests/hermes_runtime_patches.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+
+import { patchHermesSchedulerSource } from "../hermes_runtime_patches";
+
+const schedulerFixture = `from typing import Optional
+
+logger = None
+
+# Sentinel: when a cron agent has nothing new to report, it can start its
+# response with this marker to suppress delivery.  Output is still saved
+# locally for audit.
+SILENT_MARKER = "[SILENT]"
+
+def tick():
+    def _process_job(job: dict) -> bool:
+        success = False
+        final_response = ""
+        error = "RuntimeError: Error code: 403 - key limit exceeded"
+                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\\n{error}"
+                should_deliver = bool(deliver_content)
+                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    should_deliver = False
+        return should_deliver
+`;
+
+test("patchHermesSchedulerSource suppresses quiet OpenRouter budget failures", () => {
+  const { source, changed } = patchHermesSchedulerSource(schedulerFixture);
+
+  expect(changed).toBe(true);
+  expect(source).toContain("def _is_quiet_cron_failure(error: Optional[str]) -> bool:");
+  expect(source).toContain("key limit exceeded");
+  expect(source).toContain("if should_deliver and not success and _is_quiet_cron_failure(error):");
+});
+
+test("patchHermesSchedulerSource is idempotent", () => {
+  const once = patchHermesSchedulerSource(schedulerFixture);
+  const twice = patchHermesSchedulerSource(once.source);
+
+  expect(once.changed).toBe(true);
+  expect(twice.changed).toBe(false);
+  expect(twice.source.match(/def _is_quiet_cron_failure/g)?.length).toBe(1);
+  expect(twice.source.match(/_is_quiet_cron_failure\(error\)/g)?.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- patch Hermes cron delivery during AgentVillage install so OpenRouter budget/key-limit cron failures stay internal
- preserve cron failure logging/state while suppressing only the user-facing failure notification for key-limit/spending-limit failures
- add idempotency coverage for the runtime patch transform

## Verification
- bun test install/tests