### PR TITLE
Suppress all cron failure notices

### DIFF
--- a/install/hermes_runtime_patches.ts
+++ b/install/hermes_runtime_patches.ts
@@ -5,17 +5,13 @@ import { execFileSync } from "node:child_process";
 import { hermesBin, hermesExecEnv } from "./hermes_cli";
 
 const QUIET_HELPER = `def _is_quiet_cron_failure(error: Optional[str]) -> bool:
-    """Return True for expected provider-budget failures that should stay internal."""
-    if not error:
-        return False
-    message = str(error).lower()
-    budget_exhausted = "key limit exceeded" in message or "spending limit" in message
-    if not budget_exhausted:
-        return False
-    return "403" in message or "openrouter" in message or "billing" in message
+    """Return True when a failed cron job should stay internal."""
+    return bool(error)
 
 
 `;
+
+const QUIET_HELPER_PATTERN = /def _is_quiet_cron_failure\(error: Optional\[str\]\) -> bool:\n(?:    .*\n)+\n\n/;
 
 const HELPER_ANCHOR = `SILENT_MARKER = "[SILENT]"
 
@@ -32,7 +28,7 @@ const PATCHED_DELIVERY_BLOCK = `                deliver_content = final_response
                 should_deliver = bool(deliver_content)
                 if should_deliver and not success and _is_quiet_cron_failure(error):
                     logger.info(
-                        "Job '%s': suppressing delivery for quiet provider-budget failure: %s",
+                        "Job '%s': suppressing delivery for cron failure: %s",
                         job["id"],
                         error,
                     )
@@ -45,7 +41,13 @@ const PATCHED_DELIVERY_BLOCK = `                deliver_content = final_response
 export function patchHermesSchedulerSource(source: string): { source: string; changed: boolean } {
   let next = source;
 
-  if (!next.includes("def _is_quiet_cron_failure(")) {
+  if (next.includes("def _is_quiet_cron_failure(")) {
+    const updated = next.replace(QUIET_HELPER_PATTERN, QUIET_HELPER);
+    if (updated === next && !next.includes('"""Return True when a failed cron job should stay internal."""')) {
+      throw new Error("Hermes scheduler quiet-failure helper block not found");
+    }
+    next = updated;
+  } else {
     if (!next.includes(HELPER_ANCHOR)) {
       throw new Error("Hermes scheduler helper anchor not found");
     }
@@ -93,7 +95,7 @@ export function patchHermesCronFailureDelivery(): void {
   try {
     const schedulerPath = locateHermesScheduler();
     if (!schedulerPath) {
-      console.warn("  warning: Hermes cron scheduler source not found; provider-budget cron failures may still notify users");
+      console.warn("  warning: Hermes cron scheduler source not found; cron failures may still notify users");
       return;
     }
 

--- a/install/tests/hermes_runtime_patches.test.ts
+++ b/install/tests/hermes_runtime_patches.test.ts
@@ -15,7 +15,7 @@ def tick():
     def _process_job(job: dict) -> bool:
         success = False
         final_response = ""
-        error = "RuntimeError: Error code: 403 - key limit exceeded"
+        error = "TimeoutError: cron job idle for 600s"
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\\n{error}"
                 should_deliver = bool(deliver_content)
                 if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
@@ -24,12 +24,13 @@ def tick():
         return should_deliver
 `;
 
-test("patchHermesSchedulerSource suppresses quiet OpenRouter budget failures", () => {
+test("patchHermesSchedulerSource suppresses all cron failure notices", () => {
   const { source, changed } = patchHermesSchedulerSource(schedulerFixture);
 
   expect(changed).toBe(true);
   expect(source).toContain("def _is_quiet_cron_failure(error: Optional[str]) -> bool:");
-  expect(source).toContain("key limit exceeded");
+  expect(source).toContain('"""Return True when a failed cron job should stay internal."""');
+  expect(source).toContain("return bool(error)");
   expect(source).toContain("if should_deliver and not success and _is_quiet_cron_failure(error):");
 });
 
@@ -41,4 +42,49 @@ test("patchHermesSchedulerSource is idempotent", () => {
   expect(twice.changed).toBe(false);
   expect(twice.source.match(/def _is_quiet_cron_failure/g)?.length).toBe(1);
   expect(twice.source.match(/_is_quiet_cron_failure\(error\)/g)?.length).toBe(1);
+});
+
+test("patchHermesSchedulerSource migrates the OpenRouter-only helper", () => {
+  const oldPatched = `from typing import Optional
+
+logger = None
+
+SILENT_MARKER = "[SILENT]"
+
+def _is_quiet_cron_failure(error: Optional[str]) -> bool:
+    """Return True for expected provider-budget failures that should stay internal."""
+    if not error:
+        return False
+    message = str(error).lower()
+    budget_exhausted = "key limit exceeded" in message or "spending limit" in message
+    if not budget_exhausted:
+        return False
+    return "403" in message or "openrouter" in message or "billing" in message
+
+
+def tick():
+    def _process_job(job: dict) -> bool:
+        success = False
+        final_response = ""
+        error = "RuntimeError: arbitrary cron failure"
+                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\\n{error}"
+                should_deliver = bool(deliver_content)
+                if should_deliver and not success and _is_quiet_cron_failure(error):
+                    logger.info(
+                        "Job '%s': suppressing delivery for quiet provider-budget failure: %s",
+                        job["id"],
+                        error,
+                    )
+                    should_deliver = False
+                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    should_deliver = False
+        return should_deliver
+`;
+
+  const { source, changed } = patchHermesSchedulerSource(oldPatched);
+
+  expect(changed).toBe(true);
+  expect(source).toContain("return bool(error)");
+  expect(source).not.toContain("key limit exceeded");
 });


### PR DESCRIPTION
## Summary
- broaden the Hermes cron runtime patch so any failed cron job stays internal instead of notifying the user
- keep successful cron output delivery unchanged
- migrate existing OpenRouter-only patched scheduler sources to the broader helper

## Verification
- bun test install/tests