### PR TITLE
fix(index-network): exclude non-actionable statuses from daily brief opportunities

### DIFF
--- a/skills/index-network/scripts/build-daily-brief-context.ts
+++ b/skills/index-network/scripts/build-daily-brief-context.ts
@@ -481,6 +481,31 @@ export function filterDedupedOpportunities(opportunities: BriefOpportunity[], de
   return opportunities.filter((opp) => !opp.opportunityId || !deliveredIds.has(opp.opportunityId));
 }
 
+/**
+ * Statuses a digest card may carry and still be actionable for the recipient.
+ * Mirrors the Index server's `list_opportunities` fetch filter
+ * (draft/pending/latent). Anything else — notably `stalled` (agents didn't
+ * converge; "human should take a look" is not "human should act"), plus
+ * `expired`/`rejected`/`accepted`/`negotiating` — must never be auto-included
+ * in a daily brief, because its acceptUrl resolves to a dead link.
+ */
+const ACTIONABLE_DIGEST_STATUSES = new Set(["draft", "pending", "latent"]);
+
+/**
+ * Drop cards whose status is present and not digest-actionable.
+ *
+ * Cards with a missing status are kept: the fresh MCP path is already
+ * status-filtered server-side, and legacy `--opportunities-file` transcripts
+ * may predate the `status:` field — dropping them wholesale would silently
+ * empty the brief. The guard exists chiefly for the file-replay path, where a
+ * stale snapshot can carry cards that stalled/expired after it was written.
+ */
+export function filterActionableOpportunities(opportunities: BriefOpportunity[]): BriefOpportunity[] {
+  return opportunities.filter(
+    (opp) => !opp.status || ACTIONABLE_DIGEST_STATUSES.has(opp.status.trim().toLowerCase()),
+  );
+}
+
 async function readIfExists(path: string): Promise<string> {
   try {
     return await Bun.file(path).text();
@@ -1055,7 +1080,13 @@ export async function buildDailyBriefContext(options: {
     try {
       const deliveredIds = await readDeliveredIds(options.stateFile ?? "memory/heartbeat-state.json", date);
       const fetched = await fetchOpportunitiesFromMcp({ apiKey, mcpUrl });
-      opportunities = filterDedupedOpportunities(fetched, deliveredIds);
+      const deduped = filterDedupedOpportunities(fetched, deliveredIds);
+      opportunities = filterActionableOpportunities(deduped);
+      if (opportunities.length < deduped.length) {
+        warnings.push(
+          `dropped ${deduped.length - opportunities.length} non-actionable opportunity card(s) (status outside draft/pending/latent)`,
+        );
+      }
       opportunitySource = "mcp";
     } catch (err) {
       warnings.push(`opportunities MCP unavailable: ${err instanceof Error ? err.message : String(err)}`);
@@ -1065,7 +1096,13 @@ export async function buildDailyBriefContext(options: {
     if (transcript.trim()) {
       opportunitySource = "file";
       const deliveredIds = await readDeliveredIds(options.stateFile ?? "memory/heartbeat-state.json", date);
-      opportunities = filterDedupedOpportunities(parseOpportunityTranscript(transcript), deliveredIds);
+      const deduped = filterDedupedOpportunities(parseOpportunityTranscript(transcript), deliveredIds);
+      opportunities = filterActionableOpportunities(deduped);
+      if (opportunities.length < deduped.length) {
+        warnings.push(
+          `dropped ${deduped.length - opportunities.length} non-actionable opportunity card(s) (status outside draft/pending/latent)`,
+        );
+      }
     }
   }
 

--- a/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
+++ b/skills/index-network/scripts/tests/build-daily-brief-context.test.ts
@@ -11,6 +11,7 @@ import {
   fetchOpportunitiesFromMcp,
   fetchPendingQuestionsFromMcp,
   filterCooldownQuestions,
+  filterActionableOpportunities,
   filterDedupedOpportunities,
   formatPacificTime,
   pacificDayBounds,
@@ -214,6 +215,23 @@ describe("build-daily-brief-context helpers", () => {
         new Set(["opp-1"]),
       ).map((opp) => opp.name),
     ).toEqual(["B", "C"]);
+  });
+
+  test("filterActionableOpportunities drops stalled/expired/rejected cards, keeps actionable and status-less ones", () => {
+    expect(
+      filterActionableOpportunities([
+        { name: "A", status: "pending" },
+        { name: "B", status: "stalled" },
+        { name: "C", status: "expired" },
+        { name: "D", status: "rejected" },
+        { name: "E", status: "draft" },
+        { name: "F", status: "latent" },
+        { name: "G" },
+        { name: "H", status: " Pending " },
+        { name: "I", status: "accepted" },
+        { name: "J", status: "negotiating" },
+      ]).map((opp) => opp.name),
+    ).toEqual(["A", "E", "F", "G", "H"]);
   });
 
   test("formatPacificTime renders Pacific time without a timezone suffix", () => {


### PR DESCRIPTION
## Problem

Users received daily brief cards for opportunities that were no longer actionable — clicking the `acceptUrl` connect link dead-ends in a 404 ("This link is unavailable"). We saw 3 real examples at Edge Village: one `expired`, two `stalled`.

`stalled` is a negotiation outcome (turn cap / timeout / no consensus) — the product semantics are *"human should take a look"*, not *"human should act"*. Auto-including these in the digest with an accept CTA is wrong on both counts.

## Root cause

The fresh MCP fetch (`list_opportunities`) is already status-filtered server-side to `draft/pending/latent`, but the `--opportunities-file` replay path applied only delivered-id dedup: a stale `memory/digest-opportunities.txt` snapshot could carry cards whose opportunities stalled or expired after the snapshot was written, and nothing re-checked the parsed `status:` field.

## Fix

- New `ACTIONABLE_DIGEST_STATUSES = {draft, pending, latent}` (mirrors the Index server filter) and exported `filterActionableOpportunities()` in `build-daily-brief-context.ts`.
- Applied to **both** opportunity sources: the file-replay path (the actual hole) and the MCP path (belt-and-braces).
- Cards with a missing `status:` are kept, so legacy transcripts don't silently empty the brief.
- Dropped cards surface a `diagnostics.warnings` entry (`dropped N non-actionable opportunity card(s)…`) for sidecar log visibility.

## Tests

New matrix test: `stalled/expired/rejected/accepted/negotiating` dropped; `draft/pending/latent`, status-less, and ` Pending ` (trim/case) kept. All 121 tests across 7 files pass.

## Related

Complements the resolution-side fix in the main Index repo (`fix/connect-link-actionability` — connect links for stalled/already-acted opportunities stop resolving). This PR closes the inclusion leak; a card that stalls *after* send is handled by that resolution-side change.